### PR TITLE
reenabled setting of cursor icon when changing the selected tool.

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -237,7 +237,7 @@ namespace Pinta.Core
 		
 		protected void SetCursor (Gdk.Cursor cursor)
 		{
-			//PintaCore.Chrome.DrawingArea.GdkWindow.Cursor = cursor;
+			PintaCore.Chrome.Canvas.GdkWindow.Cursor = cursor;
 		}
 		#endregion
 


### PR DESCRIPTION
(see also "cursor of mouse" on pinta.uservoice.com)

hi. i was using an older version of pinta and noticed there were no cursor icons for the tools like there are in paint.NET.

i decided that this was a good place to start to see if i can contribute to the pinta effort.

when downloading the 1.0 sources i then discovered there are already SOME icons for some tools.

when downloading the current git-master i was surprised that this feature is gone again.
i now reenabled it so now as the first step to get in cursors for all the tools!

first note:
i could only test this on ubuntu 10.04, are there any requirements on testing before something is accepted into the master branch?

second note:
i am new to git and github, i was not able to reconstruct through the history as to why the code was removed again, so i just examined how to enable it again and then tested if its working. 

additionally, i hope i did everything right with the branching and the pull request :)

third note:
i did not find a bug report for this, so i just added the name of the feature request of pinta.uservoice.com instead.
