### PR TITLE
[fix #722045] - Save as different type doesn't change the extension

### DIFF
--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using Gtk;
 using Mono.Unix;
 using Pinta.Core;
@@ -232,15 +233,9 @@ namespace Pinta.Actions
         private void OnFilterChanged(object o, GLib.NotifyArgs args)
         {
             FileChooserDialog fcd = (FileChooserDialog)o;
-            
+    
             // find the FormatDescriptor
-			FormatDescriptor format_desc = null;
-			foreach (var format in PintaCore.System.ImageFormats.Formats) {
-                if (format.Filter == fcd.Filter) {
-                    format_desc = format;
-                    break;
-                }
-            }
+            FormatDescriptor format_desc = PintaCore.System.ImageFormats.Formats.Single (f => f.Filter == fcd.Filter);
 
             // adjust the filename
             var p = fcd.Filename;


### PR DESCRIPTION
This fix was tested with Mono 2.10 on Ubuntu 10.04.

I'm an experienced developer, but I've never written a line of c#. My code is likely to be buggy, poorly styled, and generally awful. Please review carefully. :)
