### PR TITLE
Reduce main toolbars’ height to a saner 32px

### DIFF
--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -182,7 +182,7 @@ namespace Pinta
 			if (PintaCore.System.OperatingSystem == OS.Windows)
 				tool_toolbar.HeightRequest = 28;
 			else
-				tool_toolbar.HeightRequest = 42;
+				tool_toolbar.HeightRequest = 32;
 
 			PintaCore.Chrome.InitializeToolToolBar (tool_toolbar);
 		}


### PR DESCRIPTION
This change is made to avoid wasting space in netbooks and other devices.
