### PR TITLE
[Fixes bug #683242] Add an additional space before …,

### DIFF
--- a/po/sl.po
+++ b/po/sl.po
@@ -723,7 +723,7 @@ msgstr "O programu"
 
 #: Pinta/MainWindow.cs:371 Pinta/MainWindow.cs:387
 msgid "..."
-msgstr "..."
+msgstr " …"
 
 #: Pinta/MainWindow.cs:456
 msgid "_File"


### PR DESCRIPTION
...since Launchpad does not allow to do so.
