### PR TITLE
Add a note about translations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,8 @@ Used under [Creative Commons Attribution 3.0 License](http://creativecommons.org
 ##Getting help/contributing:
 
 - You can get technical help on the [Pinta Google Group](http://groups.google.com/group/pinta)
-- You can report bugs on [Launchpad.net](https://bugs.launchpad.net/pinta/+filebug)
+- You can report bugs on [Launchpad bug tracker](https://bugs.launchpad.net/pinta/+filebug)
+- You can help translate Pinta to your native language on [Launchpad translations](https://translations.launchpad.net/pinta)
 - You can fork the project on [Github](https://github.com/PintaProject/Pinta)
 - You can get help in #pinta on irc.gnome.org.
 - For details on patching, take a look at `patch-guidelines.md` in the repo.


### PR DESCRIPTION
Add a note about how the users can help Pinta to speak their language. An obvious omission.
