### PR TITLE
Fix for #999571, changes clone method

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -799,14 +799,7 @@ namespace Pinta.Core
 
 		public static ImageSurface Clone (this ImageSurface surf)
 		{
-			ImageSurface newsurf = new ImageSurface (surf.Format, surf.Width, surf.Height);
-
-			using (Context g = new Context (newsurf)) {
-				g.SetSource (surf);
-				g.Paint ();
-			}
-
-			return newsurf;
+			return new ImageSurface (surf.Data, surf.Format, surf.Width, surf.Height, surf.Stride);
 		}
 
 		public static unsafe bool ContainsTranslucent (this ImageSurface surf)


### PR DESCRIPTION
Instead of repainting, it just copies over the data array. Any reason
why this hasn't been used before? (Performance or otherwise?)
