### PR TITLE
Performance fix for 73b856af

### DIFF
--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -130,8 +130,7 @@ namespace Pinta.Core
 		/// </summary>
 		public bool IsPartiallyOffscreen (Gdk.Rectangle rect)
 		{
-			return (rect.IsEmpty || rect.Left < 0 || rect.Top < 0 ||
-			        rect.Bottom > CanvasSize.Height || rect.Right > CanvasSize.Width);
+			return (rect.IsEmpty || rect.Left < 0 || rect.Top < 0);
 		}
 
 		public bool PointInCanvas (Cairo.PointD point)

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -119,7 +119,7 @@ namespace Pinta.Tools
 			if (doc.Workspace.IsPartiallyOffscreen (r)) {
 				doc.Workspace.Invalidate ();
 			} else {
-				doc.Workspace.Invalidate (r);
+				doc.Workspace.Invalidate (doc.ClampToImageSize (r));
 			}
 			
 			last_point = new Point (x, y);

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -170,7 +170,7 @@ namespace Pinta.Tools
 			if (doc.Workspace.IsPartiallyOffscreen (invalidate_rect)) {
 				doc.Workspace.Invalidate ();
 			} else {
-				doc.Workspace.Invalidate (invalidate_rect);
+				doc.Workspace.Invalidate (doc.ClampToImageSize (invalidate_rect));
 			}
 
 			LastPoint = new Point (x, y);

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -144,7 +144,7 @@ namespace Pinta.Tools
 			if (doc.Workspace.IsPartiallyOffscreen (r)) {
 				doc.Workspace.Invalidate ();
 			} else {
-				doc.Workspace.Invalidate (r);
+				doc.Workspace.Invalidate (doc.ClampToImageSize (r));
 			}
 			
 			last_point = new Point (x, y);


### PR DESCRIPTION
The previous fix caused severe performance regression when drawing in the right or bottom half of the canvas because it was always triggering a full invalidate. (http://i.imgur.com/GWLNK.png)

I think this fixes the disappearing canvas issue (bug #1015345) without the performance loss by clamping the invalidate rectangle to the canvas.
