### PR TITLE
[Fixes Bug #1084213] Fix screen repaint of zoomed image after undoing any SimpleHistoryItem

### DIFF
--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -122,6 +122,15 @@ namespace Pinta.Core
 		public void Invalidate (Gdk.Rectangle rect)
 		{
 			rect = new Gdk.Rectangle ((int)((rect.X) * Scale + Offset.X), (int)((rect.Y) * Scale + Offset.Y), (int)(rect.Width * Scale), (int)(rect.Height * Scale));
+
+			// Adjust dirty rectangle to allow for rounding errors
+			// when rendering a zoomed image
+			if (Scale != 1)
+			{
+				rect.Offset (1, 1);
+				rect.Inflate (2, 2);
+			}
+
 			PintaCore.Workspace.OnCanvasInvalidated (new CanvasInvalidatedEventArgs (rect));
 		}
 


### PR DESCRIPTION
Adjusted the rectangle in DocumentWorkspace::Invalidate(Rectangle) when the zoom is not 100%.  This was done to account for rounding errors when rendering a zoomed (in or out) image.
