### PR TITLE
Added FixedStrokeExtents() to correct Rectangle returned by StrokeExtents

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -63,7 +63,7 @@ namespace Pinta.Core
 			g.LineWidth = lineWidth;
 			g.LineCap = LineCap.Square;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 			g.Stroke ();
 
 			g.Restore ();
@@ -99,7 +99,7 @@ namespace Pinta.Core
 
 			g.Color = color;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Fill ();
 			g.Restore ();
@@ -119,7 +119,7 @@ namespace Pinta.Core
 
 			g.Pattern = pattern;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 			g.Fill ();
 
 			g.Restore ();
@@ -140,7 +140,7 @@ namespace Pinta.Core
 
 			g.Color = color;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 			g.Stroke ();
 
 			g.Restore ();
@@ -158,7 +158,7 @@ namespace Pinta.Core
 
 			g.Color = color;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 			g.Fill ();
 
 			g.Restore ();
@@ -192,7 +192,7 @@ namespace Pinta.Core
 			g.LineWidth = lineWidth;
 			g.LineCap = LineCap.Square;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Stroke ();
 			g.Restore ();
@@ -222,7 +222,7 @@ namespace Pinta.Core
 			g.Color = color;
 			g.LineWidth = lineWidth;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Stroke ();
 			g.Restore ();
@@ -251,7 +251,7 @@ namespace Pinta.Core
 
 			g.Color = color;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Fill ();
 			g.Restore ();
@@ -310,7 +310,7 @@ namespace Pinta.Core
 			g.Color = stroke;
 			g.LineWidth = lineWidth;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Stroke ();
 			g.Restore ();
@@ -341,7 +341,7 @@ namespace Pinta.Core
 			g.Color = stroke;
 			g.LineWidth = lineWidth;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Stroke ();
 			g.Restore ();
@@ -368,7 +368,7 @@ namespace Pinta.Core
 
 			g.Color = fill;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Fill ();
 			g.Restore ();
@@ -391,7 +391,7 @@ namespace Pinta.Core
 
 				g.Color = color;
 
-				g.StrokeExtents ();
+				g.FixedStrokeExtents ();
 				g.Fill ();
 			}
 
@@ -409,7 +409,7 @@ namespace Pinta.Core
 			g.Color = stroke;
 			g.LineWidth = lineWidth;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 
 			g.Stroke ();
 			g.Restore ();
@@ -470,12 +470,33 @@ namespace Pinta.Core
 			g.LineWidth = lineWidth;
 			g.LineCap = LineCap.Square;
 
-			Rectangle dirty = g.StrokeExtents ();
+			Rectangle dirty = g.FixedStrokeExtents ();
 			g.Stroke ();
 
 			g.Restore ();
 
 			return dirty;
+		}
+
+		/// <summary>
+		/// Computes a bounding box in user coordinates covering the
+		/// area that would be affected by a call to Context.Stroke()
+		/// using the current stroke parameters.
+		/// 
+		/// The rectangle returned by Cairo.Context.StrokeExtents()
+		/// incorrectly specifies the X & Y coordinates of the
+		/// bottom-right corner of the Rectangle in the width and
+		/// height members. This method corrects the rectangle to
+		/// contain the width and height in the width and height members.
+		/// </summary>
+		/// <returns>
+		/// The rectangle describing the area that would be
+		/// affected.
+		/// </returns>
+		public static Rectangle FixedStrokeExtents (this Context g)
+		{
+			Rectangle r = g.StrokeExtents();
+			return new Rectangle (r.X, r.Y, r.Width - r.X, r.Height - r.Y);
 		}
 
 		private static Pango.Style CairoToPangoSlant (FontSlant slant)
@@ -865,7 +886,7 @@ namespace Pinta.Core
 				// of 1, but setting it to 0 returns an empty rectangle.  Set
 				// it to a sufficiently small width and rounding takes care of it
 				g.LineWidth = .01;
-				rect = g.StrokeExtents ();
+				rect = g.FixedStrokeExtents ();
 			}
 
 			int x = (int)Math.Round (rect.X);
@@ -873,7 +894,7 @@ namespace Pinta.Core
 			int w = (int)Math.Round (rect.Width);
 			int h = (int)Math.Round (rect.Height);
 
-			return new Gdk.Rectangle (x, y, w - x, h - y);
+			return new Gdk.Rectangle (x, y, w, h);
 		}
 
 		public static Gdk.Color ToGdkColor (this Cairo.Color color)

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -58,8 +58,14 @@ namespace Pinta.Tools.Brushes
 			G.MoveTo (lastX + 0.5, lastY + 0.5);
 			G.LineTo (x + 0.5, y + 0.5);
 			G.StrokePreserve ();
-			
-			return G.StrokeExtents ().ToGdkRectangle ();
+
+			Gdk.Rectangle dirty = G.FixedStrokeExtents ().ToGdkRectangle ();
+
+			// For some reason (?!) we need to inflate the dirty
+			// rectangle for small brush widths in zoomed images
+			dirty.Inflate (1, 1);
+
+			return dirty;
 		}
 	}
 }

--- a/Pinta.Tools/Brushes/SplatterBrush.cs
+++ b/Pinta.Tools/Brushes/SplatterBrush.cs
@@ -75,7 +75,7 @@ namespace Pinta.Tools.Brushes
 
 			G.ClosePath ();
 
-			Rectangle dirty = G.StrokeExtents ();
+			Rectangle dirty = G.FixedStrokeExtents ();
 
 			G.Fill ();
 			G.Restore ();

--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -54,7 +54,7 @@ namespace Pinta.Tools.Brushes
 
 			G.StrokePreserve ();
 
-			return G.StrokeExtents ().ToGdkRectangle ();
+			return G.FixedStrokeExtents ().ToGdkRectangle ();
 		}
 	}
 }


### PR DESCRIPTION
The Cairo.Context.StrokeExtents() method returns a rectangle in which the X & Y coordinates of the bottom-right corner are incorrectly specified in the width and height members.  In the previous code only CairoExtensions.GetBounds(Path) was correcting for this.  As a result of this Cairo bug, when you drew a very small line in the middle of the image with the PaintBrush tool, Pinta would invalidate the entire bottom-right corner of the image.  In most cases this would not be a big deal, but I thought it worth fixing none-the-less.
If some time in the future the bug is fixed in Cairo, would there be consequences for a version of Pinta with this fix?  Should we perform a test during program startup to check if the fix is required?
After fixing the issue, it was found that when drawing with a small brush width, the corners of the invalidation rectangle were being clipped to short, so I added an Inflate(1, 1) to PlainBrush.  This is a bit of a hack and I'd prefer not to have it, but oh well...
