### PR TITLE
 [Fix for Bug #1081030]

### DIFF
--- a/Pinta/Dialogs/ResizeCanvasDialog.cs
+++ b/Pinta/Dialogs/ResizeCanvasDialog.cs
@@ -71,6 +71,7 @@ namespace Pinta
 			widthSpinner.ActivatesDefault = true;
 			heightSpinner.ActivatesDefault = true;
 			percentageSpinner.ActivatesDefault = true;
+			percentageSpinner.GrabFocus();
 		}
 
 		#region Public Methods

--- a/Pinta/Dialogs/ResizeImageDialog.cs
+++ b/Pinta/Dialogs/ResizeImageDialog.cs
@@ -59,6 +59,7 @@ namespace Pinta
 			widthSpinner.ActivatesDefault = true;
 			heightSpinner.ActivatesDefault = true;
 			percentageSpinner.ActivatesDefault = true;
+			percentageSpinner.GrabFocus();
 		}
 
 		#region Public Methods


### PR DESCRIPTION
Percentage field on Resize canvas/image dialogs gets focus and selection immediately when dialog is opened
