### PR TITLE
Throw OutOfMemory exception no memory for layers ImageSurface

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -329,6 +329,11 @@ namespace Pinta.Core
 		public UserLayer CreateLayer(string name, int width, int height)
 		{
 			Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
+            if (surface.Status == Cairo.Status.NoMemory)
+            {
+                throw new OutOfMemoryException();
+            }
+
 			UserLayer layer = new UserLayer(surface) { Name = name };
 
 			return layer;

--- a/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
@@ -54,7 +54,20 @@ namespace Pinta.Actions
 					if (image != null) {
 						Gdk.Size size = new Gdk.Size (image.Width, image.Height);
 
-						PintaCore.Workspace.NewDocument (size, true);
+                        try
+                        {
+                            PintaCore.Workspace.NewDocument(size, true);
+                        }
+                        catch (OutOfMemoryException)
+                        {
+                            MessageDialog md = new MessageDialog(PintaCore.Chrome.MainWindow, DialogFlags.Modal, MessageType.Error, ButtonsType.Ok, "<b>" + Catalog.GetString("Failed to create document.") + "</b>\n\n" + Catalog.GetString("Insufficient memory available."));
+                            md.Title = Catalog.GetString("Error");
+
+                            md.Run();
+                            md.Destroy();
+                            return;
+                        }
+                        
 						PintaCore.Actions.Edit.Paste.Activate ();
 						PintaCore.Actions.Edit.Deselect.Activate ();
 						return;

--- a/Pinta/Actions/File/NewDocumentAction.cs
+++ b/Pinta/Actions/File/NewDocumentAction.cs
@@ -25,6 +25,8 @@
 // THE SOFTWARE.
 
 using System;
+using Gtk;
+using Mono.Unix;
 using Pinta.Core;
 
 namespace Pinta.Actions
@@ -65,7 +67,21 @@ namespace Pinta.Actions
 			int response = dialog.Run ();
 
 			if (response == (int)Gtk.ResponseType.Ok) {
-				PintaCore.Workspace.NewDocument (new Gdk.Size (dialog.NewImageWidth, dialog.NewImageHeight), false);
+                try
+                {
+				    PintaCore.Workspace.NewDocument (new Gdk.Size (dialog.NewImageWidth, dialog.NewImageHeight), false);
+                }
+                catch (OutOfMemoryException)
+                {
+                    dialog.Destroy();
+
+                    MessageDialog md = new MessageDialog(PintaCore.Chrome.MainWindow, DialogFlags.Modal, MessageType.Error, ButtonsType.Ok, "<b>" + Catalog.GetString("Failed to create document.") + "</b>\n\n" + Catalog.GetString("Insufficient memory available."));
+                    md.Title = Catalog.GetString("Error");
+
+                    md.Run();
+                    md.Destroy();
+                    return;
+                }
 
 				PintaCore.Settings.PutSetting ("new-image-width", dialog.NewImageWidth);
 				PintaCore.Settings.PutSetting ("new-image-height", dialog.NewImageHeight);

--- a/Pinta/Actions/File/NewScreenshotAction.cs
+++ b/Pinta/Actions/File/NewScreenshotAction.cs
@@ -28,6 +28,7 @@ using System;
 using Pinta.Core;
 using Mono.Unix;
 using Gdk;
+using Gtk;
 
 namespace Pinta.Actions
 {
@@ -60,7 +61,23 @@ namespace Pinta.Actions
 
 				GLib.Timeout.Add ((uint)delay * 1000, () => {
 					Screen screen = Screen.Default;
-					Document doc = PintaCore.Workspace.NewDocument (new Size (screen.Width, screen.Height), false);
+
+                    Document doc;
+					try
+                    {
+                        doc = PintaCore.Workspace.NewDocument (new Size (screen.Width, screen.Height), false);
+                    }
+                    catch (OutOfMemoryException)
+                    {
+                        dialog.Destroy();
+
+                        MessageDialog md = new MessageDialog(PintaCore.Chrome.MainWindow, DialogFlags.Modal, MessageType.Error, ButtonsType.Ok, "<b>" + Catalog.GetString("Failed to create document.") + "</b>\n\n" + Catalog.GetString("Insufficient memory available."));
+                        md.Title = Catalog.GetString("Error");
+
+                        md.Run();
+                        md.Destroy();
+                        return false;
+                    }
 
 					using (Pixbuf pb = Pixbuf.FromDrawable (screen.RootWindow, screen.RootWindow.Colormap, 0, 0, 0, 0, screen.Width, screen.Height)) {
 						using (Cairo.Context g = new Cairo.Context (doc.UserLayers[0].Surface)) {

--- a/Pinta/Main.cs
+++ b/Pinta/Main.cs
@@ -145,7 +145,19 @@ namespace Pinta
 			else
 			{
 				// Create a blank document
-				PintaCore.Workspace.NewDocument (new Gdk.Size (800, 600), false);
+                try
+                {
+    				PintaCore.Workspace.NewDocument (new Gdk.Size (800, 600), false);
+                }
+                catch (OutOfMemoryException)
+                {
+                    MessageDialog md = new MessageDialog(PintaCore.Chrome.MainWindow, DialogFlags.Modal, MessageType.Error, ButtonsType.Ok, Catalog.GetString("Failed to create document.\n\nInsufficient memory available."));
+                    md.Title = Catalog.GetString("Error");
+
+                    md.Run();
+                    md.Destroy();
+                    return;
+                }
 			}
 		}
 


### PR DESCRIPTION
Change for Bug #776346 comment 3: grey zombie canvas due to no memory for the layer's ImageSurface.  This change causes Pinta to check the status of the ImageSurface and throw an OutOfMemory exception if there is insufficient memory available for the ImageSurface.  I am handling this exception in all areas a document could be created and displaying an error message.  There are other areas in the code where layers are created and an OutOfMemory exception could be thrown and (currently) unhandled.
