### PR TITLE
Prevented overflow when zooming in very far on large images

### DIFF
--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -107,7 +107,7 @@ namespace Pinta.Core
 					}
 
 					int new_x = Math.Max ((int)(document.ImageSize.Width * value), 1);
-					int new_y = Math.Max ((int)((new_x * document.ImageSize.Height) / document.ImageSize.Width), 1);
+					int new_y = Math.Max ((int)(((long)new_x * document.ImageSize.Height) / document.ImageSize.Width), 1);
 
 					CanvasSize = new Gdk.Size (new_x, new_y);
 					Invalidate ();


### PR DESCRIPTION
Problem description: If you created a large image (e.g. 8000 x 8000) and then zoomed in very far (e.g., 3600%) an overflow would occur within the code.  This resulted in the image being displayed in a 1 pixel high canvas and you could no longer change the zoom.
