### PR TITLE
Added checks for null in SelectTool mouse-up event

### DIFF
--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -109,26 +109,27 @@ namespace Pinta.Tools
 			int tolerance = 0;
 			if (Math.Abs (reset_origin.X - args.Event.X) <= tolerance && Math.Abs (reset_origin.Y - args.Event.Y) <= tolerance) {
 				PintaCore.Actions.Edit.Deselect.Activate ();
-				hist.Dispose ();
-				hist = null;
-				handler_active = false;
-
+                if (hist != null)
+                {
+                    hist.Dispose();
+                    hist = null;
+                }
+                handler_active = false;
 				doc.ToolLayer.Clear ();
 			} else {
 				ReDraw(args.Event.State);
-
 				if (doc.Selection != null)
 				{
 					doc.selHandler.PerformSelectionMode(DocumentSelection.ConvertToPolygonSet(doc.Selection.SelectionPolygons));
 					PintaCore.Workspace.Invalidate();
 				}
-
-				if (hist != null)
-					doc.History.PushNewItem (hist);
-
+                if (hist != null)
+                {
+                    doc.History.PushNewItem(hist);
+                    hist.Dispose();
+                    hist = null;
+                }
 				handler_active = true;
-				hist.Dispose();
-				hist = null;
 			}
 
 			is_drawing = false;


### PR DESCRIPTION
I caused a crash by dragging and dropping an image into Pinta.  I wasn't able to reproduce the problem, but I believe this pull request will prevent it in future.
