### PR TITLE
Add accelerator for closing a file without saving

### DIFF
--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -1269,7 +1269,7 @@ msgstr "If you don't save, all changes will be permanently lost."
 
 #: Pinta/Actions/File/CloseDocumentAction.cs:69
 msgid "Close without saving"
-msgstr "Close without saving"
+msgstr "Close _without saving"
 
 #: Pinta/MainWindow.cs:123
 msgid "_File"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -1265,7 +1265,7 @@ msgstr "If you don't save, all changes will be permanently lost."
 
 #: Pinta/Actions/File/CloseDocumentAction.cs:69
 msgid "Close without saving"
-msgstr "Close without saving"
+msgstr "Close _without saving"
 
 #: Pinta/MainWindow.cs:123
 msgid "_File"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1275,7 +1275,7 @@ msgstr "If you don't save, all changes will be permanently lost."
 
 #: Pinta/Actions/File/CloseDocumentAction.cs:69
 msgid "Close without saving"
-msgstr "Close without saving"
+msgstr "Close _without saving"
 
 #: Pinta/MainWindow.cs:123
 msgid "_File"


### PR DESCRIPTION
I often want to close Pinta and abandon changes to a file, and I currently cannot do that with the keyboard. This PR makes it possible to do it by pressing ctrl+q, alt+w.
