### PR TITLE
Fix #1422710, 1422715 - Fix use of Recolor tool after use of Editable sh...

### DIFF
--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -473,6 +473,9 @@ namespace Pinta.Tools
 				finalizeAllShapes();
 			}
 
+            if (PintaCore.Workspace.HasOpenDocuments)
+                PintaCore.Workspace.ActiveDocument.ToolLayer.Hidden = true;
+
             PintaCore.Palette.PrimaryColorChanged -= Palette_PrimaryColorChanged;
             PintaCore.Palette.SecondaryColorChanged -= Palette_SecondaryColorChanged;
         }


### PR DESCRIPTION
...ape.

The issue is that Recolor temporarily draws on the ToolLayer, which it expects to be invisible.  Editable shapes make the ToolLayer visible when activated but do not hide it when deactivated, so the Recolor tool's temporary works is visible.  Fix by hiding the tool layer when an editable tool is deselected.