### PR TITLE
Fix #1422710, 1422715 - Fix use of Recolor tool after use of Editable sh...

### DIFF
--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -246,8 +246,6 @@ namespace Pinta.Tools
         //Stores the editable shape data.
 		public static ShapeEngineCollection SEngines = new ShapeEngineCollection();
 
-		protected static bool usedToolLayer = false;
-
 
         #region ToolbarEventHandlers
 
@@ -1213,12 +1211,7 @@ namespace Pinta.Tools
 		private void beforeDraw()
 		{
 			//Clear the ToolLayer if it was used previously (e.g. for hover points when there was no active shape).
-			if (usedToolLayer)
-			{
-				PintaCore.Workspace.ActiveDocument.ToolLayer.Clear();
-
-				usedToolLayer = false;
-			}
+			PintaCore.Workspace.ActiveDocument.ToolLayer.Clear();
 
 			//Invalidate the old hover point bounds, if any.
 			if (lastHover != null)
@@ -1256,8 +1249,6 @@ namespace Pinta.Tools
 
 				//Draw the hover point. Note: the hover point has its own invalidation.
 				drawHoverPoint(g);
-
-				usedToolLayer = true;
 			}
 
 			doc.ToolLayer.Hidden = false;

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -1711,6 +1711,9 @@ namespace Pinta.Tools
 				invalidateAfterDraw(dirty.Value);
 			}
 
+            // Ensure the ToolLayer gets hidden now that we're done with it
+            doc.ToolLayer.Hidden = true;
+
 			//Clear out all of the data.
 			resetShapes();
 		}


### PR DESCRIPTION
...ape.

The issue is that Recolor temporarily draws on the ToolLayer, which it expects to be invisible.  Editable shapes make the ToolLayer visible when activated but never hides it, so the Recolor tool's temporary work is visible.  Fix by hiding the tool layer when an editable tool finalized all its shapes.  Doing it on tool deactivation misses a case where you switch to a new image and then change the tool.