### PR TITLE
Canvas usage refactorings

### DIFF
--- a/Pinta.Core/Actions/ImageActions.cs
+++ b/Pinta.Core/Actions/ImageActions.cs
@@ -280,7 +280,7 @@ namespace Pinta.Core
 				hist.StartSnapshotOfImage();
 				hist.RestoreSelection = doc.Selection.Clone();
 
-				PintaCore.Chrome.Canvas.GdkWindow.FreezeUpdates();
+				doc.Workspace.Canvas.GdkWindow.FreezeUpdates();
 
 				double original_scale = doc.Workspace.Scale;
 				doc.ImageSize = rect.Size;
@@ -289,7 +289,7 @@ namespace Pinta.Core
 
 				PintaCore.Actions.View.UpdateCanvasScale();
 
-				PintaCore.Chrome.Canvas.GdkWindow.ThawUpdates();
+				doc.Workspace.Canvas.GdkWindow.ThawUpdates();
 
 				foreach (var layer in doc.UserLayers)
 					layer.Crop(rect);

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -321,7 +321,8 @@ namespace Pinta.Core
 		
 		public void SetCursor (Gdk.Cursor cursor)
 		{
-			PintaCore.Chrome.Canvas.GdkWindow.Cursor = cursor;
+            if (PintaCore.Chrome.Canvas != null && PintaCore.Chrome.Canvas.GdkWindow != null)
+			    PintaCore.Chrome.Canvas.GdkWindow.Cursor = cursor;
 		}
 
 		/// <summary>

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -321,8 +321,8 @@ namespace Pinta.Core
 		
 		public void SetCursor (Gdk.Cursor cursor)
 		{
-            if (PintaCore.Chrome.Canvas != null && PintaCore.Chrome.Canvas.GdkWindow != null)
-			    PintaCore.Chrome.Canvas.GdkWindow.Cursor = cursor;
+            if (PintaCore.Workspace.HasOpenDocuments)
+			    PintaCore.Workspace.ActiveWorkspace.Canvas.GdkWindow.Cursor = cursor;
 		}
 
 		/// <summary>

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -48,9 +48,13 @@ namespace Pinta.Core
 		}
 
 		#region Public Properties
+        public Gtk.DrawingArea Canvas {
+            get { return PintaCore.Chrome.Canvas; }
+        }
+
 		public bool CanvasFitsInWindow {
 			get {
-				Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
+				Gtk.Viewport view = (Gtk.Viewport)Canvas.Parent;
 				
 				int window_x = view.Allocation.Width;
 				int window_y = view.Children[0].Allocation.Height;
@@ -76,7 +80,7 @@ namespace Pinta.Core
 
 		public bool ImageFitsInWindow {
 			get {
-				Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
+				Gtk.Viewport view = (Gtk.Viewport)Canvas.Parent;
 				
 				int window_x = view.Allocation.Width;
 				int window_y = view.Children[0].Allocation.Height;
@@ -89,7 +93,7 @@ namespace Pinta.Core
 		}
 
 		public Cairo.PointD Offset {
-			get { return new Cairo.PointD ((PintaCore.Chrome.Canvas.Allocation.Width - canvas_size.Width) / 2, (PintaCore.Chrome.Canvas.Allocation.Height - canvas_size.Height) / 2); }
+			get { return new Cairo.PointD ((Canvas.Allocation.Width - canvas_size.Width) / 2, (Canvas.Allocation.Height - canvas_size.Height) / 2); }
 		}
 
 		public double Scale {
@@ -169,7 +173,7 @@ namespace Pinta.Core
 
 		public void RecenterView (double x, double y)
 		{
-			Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
+			Gtk.Viewport view = (Gtk.Viewport)Canvas.Parent;
 			
 			view.Hadjustment.Value = Utility.Clamp (x * Scale - view.Hadjustment.PageSize / 2, view.Hadjustment.Lower, view.Hadjustment.Upper);
 			view.Vadjustment.Value = Utility.Clamp (y * Scale - view.Vadjustment.PageSize / 2, view.Vadjustment.Lower, view.Vadjustment.Upper);
@@ -177,7 +181,7 @@ namespace Pinta.Core
 
 		public void ScrollCanvas (int dx, int dy)
 		{
-			Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
+			Gtk.Viewport view = (Gtk.Viewport)Canvas.Parent;
 			
 			view.Hadjustment.Value = Utility.Clamp (dx + view.Hadjustment.Value, view.Hadjustment.Lower, view.Hadjustment.Upper - view.Hadjustment.PageSize);
 			view.Vadjustment.Value = Utility.Clamp (dy + view.Vadjustment.Value, view.Vadjustment.Lower, view.Vadjustment.Upper - view.Vadjustment.PageSize);
@@ -270,10 +274,10 @@ namespace Pinta.Core
 			
 			zoom = Math.Min (zoom, 3600);
 			
-			PintaCore.Chrome.Canvas.GdkWindow.FreezeUpdates ();
+			Canvas.GdkWindow.FreezeUpdates ();
 			PintaCore.Actions.View.SuspendZoomUpdate ();
 			
-			Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
+			Gtk.Viewport view = (Gtk.Viewport)Canvas.Parent;
 			
 			bool adjustOnMousePosition = point.X >= 0.0 && point.Y >= 0.0;
 			
@@ -336,7 +340,7 @@ namespace Pinta.Core
 			RecenterView (center_x, center_y);
 			
 			PintaCore.Actions.View.ResumeZoomUpdate ();
-			PintaCore.Chrome.Canvas.GdkWindow.ThawUpdates ();
+			Canvas.GdkWindow.ThawUpdates ();
 		}
 		#endregion
 	}

--- a/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
@@ -53,7 +53,7 @@ namespace Pinta.Core
 
         public TextLayout ()
         {
-            Layout = new Pango.Layout (PintaCore.Chrome.Canvas.PangoContext);
+            Layout = new Pango.Layout (PintaCore.Chrome.MainWindow.PangoContext);
         }
 
 		public Rectangle[] SelectionRectangles

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -43,7 +43,7 @@ namespace Pinta.Core
 
 		public Toolbar ToolToolBar { get { return tool_toolbar; } }
 		public Toolbar MainToolBar { get { return main_toolbar; } }
-		public DrawingArea Canvas { get { return drawing_area; } }
+		internal DrawingArea Canvas { get { return drawing_area; } }
 		public Window MainWindow { get { return main_window; } }
 		public IProgressDialog ProgressDialog { get { return progress_dialog; } }
 		public MenuBar MainMenu { get { return main_menu; } }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -383,7 +383,7 @@ namespace Pinta.Core
 			int height = (int)Math.Ceiling (y2) - y;
 
 			// Tell GTK to expose the drawing area.			
-			PintaCore.Chrome.Canvas.QueueDrawArea (x, y, width, height);
+            PintaCore.Workspace.ActiveWorkspace.Canvas.QueueDrawArea (x, y, width, height);
 		}	
 	}
 }

--- a/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
+++ b/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="gtk-gui\Pinta.Gui.Widgets.ColorPanelWidget.cs" />
     <Compile Include="Widgets\Canvas\CanvasRenderer.cs" />
+    <Compile Include="Widgets\Canvas\CanvasWindow.cs" />
     <Compile Include="Widgets\ColorPaletteWidget.cs" />
     <Compile Include="Widgets\ColorPanelWidget.cs" />
     <Compile Include="WrappingPaletteContainer.cs" />

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasWindow.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasWindow.cs
@@ -1,0 +1,153 @@
+﻿// 
+// CanvasWindow.cs
+//  
+// Author:
+//       Jonathan Pobst <monkey@jpobst.com>
+// 
+// Copyright (c) 2015 Jonathan Pobst
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Gtk;
+using Pinta.Core;
+using Pinta.Gui.Widgets;
+
+namespace Pinta
+{
+    public class CanvasWindow : Table
+    {
+        private HRuler horizontal_ruler;
+        private VRuler vertical_ruler;
+        
+        public ScrolledWindow ScrolledWindow { get; set; }
+        public PintaCanvas Canvas { get; set; }
+        public CanvasWindow () : base (2, 2, false)
+        {
+            ScrolledWindow = new ScrolledWindow ();
+
+            var vp = new Viewport () {
+                ShadowType = ShadowType.None
+            };
+
+            Canvas = new PintaCanvas () {
+                Name = "canvas",
+                CanDefault = true,
+                CanFocus = true,
+                Events = (Gdk.EventMask)16134
+            };
+
+            // Rulers
+            horizontal_ruler = new HRuler ();
+            horizontal_ruler.Metric = MetricType.Pixels;
+            Attach (horizontal_ruler, 1, 2, 0, 1, AttachOptions.Shrink | AttachOptions.Fill, AttachOptions.Shrink | AttachOptions.Fill, 0, 0);
+
+            vertical_ruler = new VRuler ();
+            vertical_ruler.Metric = MetricType.Pixels;
+            Attach (vertical_ruler, 0, 1, 1, 2, AttachOptions.Shrink | AttachOptions.Fill, AttachOptions.Shrink | AttachOptions.Fill, 0, 0);
+
+            ScrolledWindow.Hadjustment.ValueChanged += delegate {
+                UpdateRulerRange ();
+            };
+
+            ScrolledWindow.Vadjustment.ValueChanged += delegate {
+                UpdateRulerRange ();
+            };
+
+            PintaCore.Workspace.CanvasSizeChanged += delegate {
+                UpdateRulerRange ();
+            };
+
+            Canvas.MotionNotifyEvent += delegate (object o, MotionNotifyEventArgs args) {
+                if (!PintaCore.Workspace.HasOpenDocuments)
+                    return;
+
+                var point = PintaCore.Workspace.WindowPointToCanvas (args.Event.X, args.Event.Y);
+
+                horizontal_ruler.Position = point.X;
+                vertical_ruler.Position = point.Y;
+            };
+
+            Attach (ScrolledWindow, 1, 2, 1, 2, AttachOptions.Expand | AttachOptions.Fill, AttachOptions.Expand | AttachOptions.Fill, 0, 0);
+
+            ScrolledWindow.Add (vp);
+            vp.Add (Canvas);
+
+            ShowAll ();
+            Canvas.Show ();
+            vp.Show ();
+
+            horizontal_ruler.Visible = false;
+            vertical_ruler.Visible = false;
+
+            Canvas.SizeAllocated += delegate { UpdateRulerRange (); };
+        }
+
+        public bool RulersVisible {
+            get { return horizontal_ruler.Visible; }
+            set {
+                if (horizontal_ruler.Visible != value) {
+                    horizontal_ruler.Visible = value;
+                    vertical_ruler.Visible = value;
+                }
+            }
+        }
+
+        public MetricType RulerMetric {
+            get { return horizontal_ruler.Metric; }
+            set {
+                if (horizontal_ruler.Metric != value) {
+                    horizontal_ruler.Metric = value;
+                    vertical_ruler.Metric = value;
+                }
+            }
+        }
+
+        public void UpdateRulerRange ()
+        {
+            Gtk.Main.Iteration (); //Force update of scrollbar upper before recenter
+
+            var lower = new Cairo.PointD (0, 0);
+            var upper = new Cairo.PointD (0, 0);
+
+            if (ScrolledWindow.Hadjustment == null || ScrolledWindow.Vadjustment == null)
+                return;
+
+            if (PintaCore.Workspace.HasOpenDocuments) {
+                if (PintaCore.Workspace.Offset.X > 0) {
+                    lower.X = -PintaCore.Workspace.Offset.X / PintaCore.Workspace.Scale;
+                    upper.X = PintaCore.Workspace.ImageSize.Width - lower.X;
+                } else {
+                    lower.X = ScrolledWindow.Hadjustment.Value / PintaCore.Workspace.Scale;
+                    upper.X = (ScrolledWindow.Hadjustment.Value + ScrolledWindow.Hadjustment.PageSize) / PintaCore.Workspace.Scale;
+                }
+                if (PintaCore.Workspace.Offset.Y > 0) {
+                    lower.Y = -PintaCore.Workspace.Offset.Y / PintaCore.Workspace.Scale;
+                    upper.Y = PintaCore.Workspace.ImageSize.Height - lower.Y;
+                } else {
+                    lower.Y = ScrolledWindow.Vadjustment.Value / PintaCore.Workspace.Scale;
+                    upper.Y = (ScrolledWindow.Vadjustment.Value + ScrolledWindow.Vadjustment.PageSize) / PintaCore.Workspace.Scale;
+                }
+            }
+
+            horizontal_ruler.SetRange (lower.X, upper.X, 0, upper.X);
+            vertical_ruler.SetRange (lower.Y, upper.Y, 0, upper.Y);
+        }
+    }
+}

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -52,7 +52,7 @@ namespace Pinta.Tools
 				var icon = CreateIconWithShape ("Cursor.CloneStamp.png",
 				                                CursorShape.Ellipse, BrushWidth, 16, 26,
 				                                out iconOffsetX, out iconOffsetY);
-				return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, icon, iconOffsetX, iconOffsetY);
+                return new Gdk.Cursor (Gdk.Display.Default, icon, iconOffsetX, iconOffsetY);
 			}
 		}
 		public override bool CursorChangesOnZoom { get { return true; } }
@@ -159,7 +159,7 @@ namespace Pinta.Tools
 			//note that this WONT work if user presses control key and THEN selects the tool!
 			if (args.Event.Key == Key.Control_L || args.Event.Key == Key.Control_R) {
 				Gdk.Pixbuf icon = PintaCore.Resources.GetIcon ("Cursor.CloneStampSetSource.png");
-				Gdk.Cursor setSourceCursor = new Gdk.Cursor(PintaCore.Chrome.Canvas.Display, icon, 16, 26);
+				Gdk.Cursor setSourceCursor = new Gdk.Cursor (Gdk.Display.Default, icon, 16, 26);
 				SetCursor(setSourceCursor);
 			}
 		}

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -75,7 +75,7 @@ namespace Pinta.Tools
 				var icon = CreateIconWithShape ("Cursor.ColorPicker.png",
 				                                CursorShape.Rectangle, SampleSize, 7, 27,
 				                                out iconOffsetX, out iconOffsetY);
-				return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, icon, iconOffsetX, iconOffsetY);
+                return new Gdk.Cursor (Gdk.Display.Default, icon, iconOffsetX, iconOffsetY);
 			}
 		}
 		public override bool CursorChangesOnZoom { get { return true; } }

--- a/Pinta.Tools/Tools/EllipseSelectTool.cs
+++ b/Pinta.Tools/Tools/EllipseSelectTool.cs
@@ -42,7 +42,7 @@ namespace Pinta.Tools
 		public override string StatusBarText {
 			get { return Catalog.GetString ("Click and drag to draw an elliptical selection. Hold Shift to constrain to a circle."); }
 		}
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.EllipseSelect.png"), 9, 18); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.EllipseSelect.png"), 9, 18); } }
 		public override int Priority { get { return 13; } }
 
 		protected override Rectangle DrawShape (Rectangle r, Layer l)

--- a/Pinta.Tools/Tools/EllipseTool.cs
+++ b/Pinta.Tools/Tools/EllipseTool.cs
@@ -56,7 +56,7 @@ namespace Pinta.Tools
 			}
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Ellipse.png"), 9, 18); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Ellipse.png"), 9, 18); }
 		}
 		public override int Priority {
 			get { return 45; }

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -59,7 +59,7 @@ namespace Pinta.Tools
 				var icon = CreateIconWithShape ("Cursor.Eraser.png",
 				                                CursorShape.Ellipse, BrushWidth, 8, 22,
 				                                out iconOffsetX, out iconOffsetY);
-				return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, icon, iconOffsetX, iconOffsetY);
+                return new Gdk.Cursor (Gdk.Display.Default, icon, iconOffsetX, iconOffsetY);
 			}
 		}
 		public override bool CursorChangesOnZoom { get { return true; } }

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -56,7 +56,7 @@ namespace Pinta.Tools
 		public override string Name { get { return Catalog.GetString ("Freeform Shape"); } }
 		public override string Icon { get { return "Tools.FreeformShape.png"; } }
 		public override string StatusBarText { get { return Catalog.GetString ("Left click to draw with primary color, right click to draw with secondary color."); } }
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.FreeformShape.png"), 9, 18); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.FreeformShape.png"), 9, 18); } }
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.O; } }
 		public override int Priority { get { return 47; } }
 		#endregion

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -63,7 +63,7 @@ namespace Pinta.Tools
 			get { return Catalog.GetString ("Click and drag to draw gradient from primary to secondary color.  Right click to reverse."); }
 		}
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.G; } }
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Gradient.png"), 9, 18); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Gradient.png"), 9, 18); } }
 		public override int Priority { get { return 23; } }
 
 		#region Mouse Handlers

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -52,7 +52,7 @@ namespace Pinta.Tools
 		public override string Name { get { return Catalog.GetString ("Lasso Select"); } }
 		public override string Icon { get { return "Tools.LassoSelect.png"; } }
 		public override string StatusBarText { get { return Catalog.GetString ("Click and drag to draw the outline for a selection area."); } }
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.LassoSelect.png"), 9, 18); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.LassoSelect.png"), 9, 18); } }
 		public override int Priority { get { return 9; } }
 		#endregion
 

--- a/Pinta.Tools/Tools/LineCurveTool.cs
+++ b/Pinta.Tools/Tools/LineCurveTool.cs
@@ -59,7 +59,7 @@ namespace Pinta.Tools
 			}
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Line.png"), 9, 18); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Line.png"), 9, 18); }
 		}
 		public override int Priority {
 			get { return 39; }

--- a/Pinta.Tools/Tools/MagicWandTool.cs
+++ b/Pinta.Tools/Tools/MagicWandTool.cs
@@ -74,7 +74,7 @@ namespace Pinta.Tools
 
 		public override Gdk.Cursor DefaultCursor
 		{
-			get { return new Gdk.Cursor(PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon("Cursor.MagicWand.png"), 21, 10); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.MagicWand.png"), 21, 10); }
 		}
 		public override int Priority { get { return 17; } }
 

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -49,7 +49,7 @@ namespace Pinta.Tools
 			get { return Catalog.GetString ("Left click and drag the selection to move selected content. Right click and drag the selection to rotate selected content."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Tools.Move.png"), 0, 0); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Move.png"), 0, 0); }
 		}
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.M; } }
 		public override int Priority { get { return 7; } }

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -48,7 +48,7 @@ namespace Pinta.Tools
 			get { return Catalog.GetString ("Left click and drag the selection to move selection outline. Right click and drag the selection to rotate selection outline."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Tools.MoveSelection.png"), 0, 0); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.MoveSelection.png"), 0, 0); }
 		}
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.M; } }
 		public override int Priority { get { return 11; } }

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -47,7 +47,7 @@ namespace Pinta.Tools
 				var icon = CreateIconWithShape ("Cursor.Paintbrush.png",
 				                                CursorShape.Ellipse, BrushWidth, 8, 24,
 				                                out iconOffsetX, out iconOffsetY);
-				return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, icon, iconOffsetX, iconOffsetY);
+                return new Gdk.Cursor (Gdk.Display.Default, icon, iconOffsetX, iconOffsetY);
 			}
 		}
 		public override bool CursorChangesOnZoom { get { return true; } }

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 			get { return Catalog.GetString ("Left click to fill a region with the primary color, right click to fill with the secondary color."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.PaintBucket.png"), 21, 21); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.PaintBucket.png"), 21, 21); }
 		}
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.F; } }
 		public override int Priority { get { return 21; } }

--- a/Pinta.Tools/Tools/PanTool.cs
+++ b/Pinta.Tools/Tools/PanTool.cs
@@ -43,7 +43,7 @@ namespace Pinta.Tools
 			get { return Catalog.GetString ("Click and drag to navigate image."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Pan.png"), 8, 8); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Pan.png"), 8, 8); }
 		}
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.H; } }
 		public override int Priority { get { return 19; } }

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -48,7 +48,7 @@ namespace Pinta.Tools
 		public override string Name { get { return Catalog.GetString ("Pencil"); } }
 		public override string Icon { get { return "Tools.Pencil.png"; } }
 		public override string StatusBarText { get { return Catalog.GetString ("Left click to draw freeform one-pixel wide lines with the primary color. Right click to use the secondary color."); } }
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Pencil.png"), 7, 24); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Pencil.png"), 7, 24); } }
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.P; } }
 		public override int Priority { get { return 29; } }
 		#endregion

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -63,7 +63,7 @@ namespace Pinta.Tools
 				                          "Right click to reverse.");
 			}
 		}
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Recolor.png"), 9, 18); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Recolor.png"), 9, 18); } }
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.R; } }
 		protected float Tolerance { get { return (float)(tolerance_slider.Slider.Value / 100); } }
 		public override int Priority { get { return 35; } }

--- a/Pinta.Tools/Tools/RectangleSelectTool.cs
+++ b/Pinta.Tools/Tools/RectangleSelectTool.cs
@@ -42,7 +42,7 @@ namespace Pinta.Tools
 		public override string StatusBarText {
 			get { return Catalog.GetString ("Click and drag to draw a rectangular selection. Hold Shift to constrain to a square."); }
 		}
-		public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.RectangleSelect.png"), 9, 18); } }
+        public override Gdk.Cursor DefaultCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.RectangleSelect.png"), 9, 18); } }
 		public override int Priority { get { return 5; } }
 
 		protected override Rectangle DrawShape (Rectangle r, Layer l)

--- a/Pinta.Tools/Tools/RectangleTool.cs
+++ b/Pinta.Tools/Tools/RectangleTool.cs
@@ -56,7 +56,7 @@ namespace Pinta.Tools
 			}
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Rectangle.png"), 9, 18); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Rectangle.png"), 9, 18); }
 		}
 		public override int Priority{
 			get { return 41; }

--- a/Pinta.Tools/Tools/RoundedRectangleTool.cs
+++ b/Pinta.Tools/Tools/RoundedRectangleTool.cs
@@ -56,7 +56,7 @@ namespace Pinta.Tools
 			}
 		}
 		public override Gdk.Cursor DefaultCursor {
-			get { return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.RoundedRectangle.png"), 9, 18); }
+            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.RoundedRectangle.png"), 9, 18); }
 		}
 		public override int Priority {
 			get { return 43; }

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -49,7 +49,7 @@ namespace Pinta.Tools
 		public SelectTool ()
 		{
 			CreateHandler ();
-			cursor_hand = new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Tools.Pan.png"), 0, 0);
+            cursor_hand = new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Pan.png"), 0, 0);
 		}
 
         #region ToolBar

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -103,17 +103,17 @@ namespace Pinta.Tools
 
 		public override Gdk.Cursor DefaultCursor {
 			get {
-				return new Gdk.Cursor (PintaCore.Chrome.Canvas.Display,
+                return new Gdk.Cursor (Gdk.Display.Default,
 				                       PintaCore.Resources.GetIcon ("Cursor.Text.png"),
 				                       16, 16);
 			}
 		}
-		public Gdk.Cursor InvalidEditCursor { get { return new Gdk.Cursor(PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon("Menu.Edit.EraseSelection.png"), 8, 0); } }
+        public Gdk.Cursor InvalidEditCursor { get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Menu.Edit.EraseSelection.png"), 8, 0); } }
 
 		#region Constructor
 		public TextTool ()
 		{
-			cursor_hand = new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Cursor.Pan.png"), 8, 8);
+            cursor_hand = new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.Pan.png"), 8, 8);
             imContext = new Gtk.IMMulticontext ();
             imContext.Commit += OnIMCommit;
             layout = new TextLayout ();

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -298,7 +298,8 @@ namespace Pinta.Tools
 
 		private void HandleFontChanged (object sender, EventArgs e)
 		{
-			PintaCore.Chrome.Canvas.GrabFocus ();
+            if (PintaCore.Workspace.HasOpenDocuments)
+                PintaCore.Workspace.ActiveDocument.Workspace.Canvas.GrabFocus ();
 
 			UpdateFontSizes ();
 			UpdateFont ();
@@ -508,7 +509,7 @@ namespace Pinta.Tools
 			Point pt = point.ToGdkPoint();
 
 			// Grab focus so we can get keystrokes
-			PintaCore.Chrome.Canvas.GrabFocus();
+			canvas.GrabFocus ();
 
 			if (selection != null)
                 selection.Dispose ();

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -63,10 +63,10 @@ namespace Pinta.Tools
 		{
 			this.mouseDown = 0;
 
-			cursorZoomIn = new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Menu.View.ZoomIn.png"), 0, 0);
-			cursorZoomOut = new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Menu.View.ZoomOut.png"), 0, 0);
-			cursorZoom = new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Tools.Zoom.png"), 0, 0);
-			cursorZoomPan = new Gdk.Cursor (PintaCore.Chrome.Canvas.Display, PintaCore.Resources.GetIcon ("Tools.Pan.png"), 0, 0);
+            cursorZoomIn = new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Menu.View.ZoomIn.png"), 0, 0);
+            cursorZoomOut = new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Menu.View.ZoomOut.png"), 0, 0);
+            cursorZoom = new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Zoom.png"), 0, 0);
+            cursorZoomPan = new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Pan.png"), 0, 0);
 		}
 
 		protected void UpdateRectangle (PointD point)

--- a/Pinta/Actions/Edit/PasteAction.cs
+++ b/Pinta/Actions/Edit/PasteAction.cs
@@ -55,19 +55,18 @@ namespace Pinta.Actions
 				return;
 			}
 
+            var doc = PintaCore.Workspace.ActiveDocument;
+
 			// Get the scroll position in canvas co-ordinates
-			Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
-			Cairo.PointD canvasPos = PintaCore.Workspace.ActiveWorkspace.WindowPointToCanvas (
+			Gtk.Viewport view = (Gtk.Viewport)doc.Workspace.Canvas.Parent;
+			Cairo.PointD canvasPos = doc.Workspace.WindowPointToCanvas (
 				view.Hadjustment.Value,
 				view.Vadjustment.Value);
 
 			// Paste into the active document.
 			// The 'false' argument indicates that paste should be
 			// performed into the current (not a new) layer.
-			PintaCore.Workspace.ActiveDocument.Paste (
-				false,
-				(int) canvasPos.X,
-				(int) canvasPos.Y);
+			doc.Paste (false, (int) canvasPos.X, (int) canvasPos.Y);
 		}
 	}
 }

--- a/Pinta/Actions/Edit/PasteIntoNewLayerAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewLayerAction.cs
@@ -55,19 +55,18 @@ namespace Pinta.Actions
 				return;
 			}
 
+            var doc = PintaCore.Workspace.ActiveDocument;
+
 			// Get the scroll position in canvas co-ordinates
-			Gtk.Viewport view = (Gtk.Viewport)PintaCore.Chrome.Canvas.Parent;
-			Cairo.PointD canvasPos = PintaCore.Workspace.ActiveWorkspace.WindowPointToCanvas (
+			Gtk.Viewport view = (Gtk.Viewport)doc.Workspace.Canvas.Parent;
+			Cairo.PointD canvasPos = doc.Workspace.WindowPointToCanvas (
 				view.Hadjustment.Value,
 				view.Vadjustment.Value);
 
 			// Paste into the active document.
 			// The 'true' argument indicates that paste should be
 			// performed into a new layer.
-			PintaCore.Workspace.ActiveDocument.Paste (
-				true,
-				(int) canvasPos.X,
-				(int) canvasPos.Y);
+			doc.Paste (true, (int) canvasPos.X, (int) canvasPos.Y);
 		}
 	}
 }

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -84,9 +84,6 @@ namespace Pinta
 			// Load the user's previous settings
 			LoadUserSettings ();
 
-			// Give the canvas focus
-			PintaCore.Chrome.Canvas.GrabFocus ();
-
 			// We support drag and drop for URIs
 			window_shell.AddDragDropSupport (new Gtk.TargetEntry ("text/uri-list", 0, 100));
 			


### PR DESCRIPTION
- Use Gdk.Display.Default instead of canvas to create cursors.
- Move access to the Canvas to the DocumentWorkspace in preparation for a per-document canvas world.
- Encapsulate canvas + scroll window + rulers into one widget.