### PR TITLE
Tab code cleanup

### DIFF
--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -289,7 +289,9 @@ namespace Pinta.Core
 			
 			zoom = Math.Min (zoom, 3600);
 			
-			Canvas.GdkWindow.FreezeUpdates ();
+            if (Canvas.GdkWindow != null)
+			    Canvas.GdkWindow.FreezeUpdates ();
+
 			PintaCore.Actions.View.SuspendZoomUpdate ();
 			
 			Gtk.Viewport view = (Gtk.Viewport)Canvas.Parent;
@@ -355,7 +357,8 @@ namespace Pinta.Core
 			RecenterView (center_x, center_y);
 			
 			PintaCore.Actions.View.ResumeZoomUpdate ();
-			Canvas.GdkWindow.ThawUpdates ();
+            if (Canvas.GdkWindow != null)
+                Canvas.GdkWindow.ThawUpdates ();
 		}
 		#endregion
 	}

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -198,8 +198,13 @@ namespace Pinta.Core
 				PintaCore.Workspace.ActiveWorkspace.History.PushNewItem (new BaseHistoryItem (Stock.Open, Catalog.GetString ("Open Image")));
 				PintaCore.Workspace.ActiveDocument.IsDirty = false;
 				PintaCore.Workspace.ActiveDocument.HasFile = true;
-				PintaCore.Actions.View.ZoomToWindow.Activate ();
-				PintaCore.Workspace.Invalidate ();
+
+                // This ensures these are called after the window is done being created and sized.
+                // Without it, we sometimes try to zoom when the window has a size of (0, 0).
+                Gtk.Application.Invoke (delegate {
+				    PintaCore.Actions.View.ZoomToWindow.Activate ();
+				    PintaCore.Workspace.Invalidate ();
+                });
 
 				fileOpened = true;
 			} catch (UnauthorizedAccessException e) {

--- a/Pinta.Docking/DockNotebook/DockNotebookContainer.cs
+++ b/Pinta.Docking/DockNotebook/DockNotebookContainer.cs
@@ -65,6 +65,8 @@ namespace Pinta.Docking.DockNotebook
 			this.tabControl = tabControl;
 			Child = tabControl;
 			
+            DockNotebookManager.AddContainer (this);
+
 			if (!isMasterTab)
 				tabControl.PageRemoved += HandlePageRemoved;
 		}
@@ -357,6 +359,13 @@ namespace Pinta.Docking.DockNotebook
 			while (paned != null);
 			return null;
 		}
+
+        protected override void OnDestroyed ()
+        {
+            DockNotebookManager.RemoveContainer (this);
+
+            base.OnDestroyed ();
+        }
 	}
 }
 

--- a/Pinta.Docking/DockNotebook/DockNotebookManager.cs
+++ b/Pinta.Docking/DockNotebook/DockNotebookManager.cs
@@ -1,0 +1,123 @@
+﻿// 
+// DockNotebookManager.cs
+//  
+// Author:
+//       Jonathan Pobst <monkey@jpobst.com>
+// 
+// Copyright (c) 2015 Jonathan Pobst
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Gtk;
+
+namespace Pinta.Docking.DockNotebook
+{
+    public static class DockNotebookManager
+    {
+        private static List<DockNotebookContainer> all_containers = new List<DockNotebookContainer> ();
+        private static bool tab_strip_visible = true;
+
+        public static event EventHandler ActiveNotebookChanged;
+        public static event EventHandler ActiveTabChanged;
+        public static event EventHandler<DragDataReceivedArgs> NotebookDragDataReceived;
+        public static event EventHandler TabStripVisibleChanged;
+        public static event EventHandler<TabClosedEventArgs> TabClosed;
+
+        public static IEnumerable<DockNotebookContainer> AllContainers {
+            get { return new ReadOnlyCollection<DockNotebookContainer> (all_containers); }
+        }
+
+		public static IEnumerable<DockNotebook> AllNotebooks {
+			get { return DockNotebook.AllNotebooks; }
+		}
+
+        public static IEnumerable<DockNotebookTab> AllTabs {
+            get { return AllNotebooks.SelectMany (p => p.Tabs); }
+        }
+
+        public static DockNotebook ActiveNotebook {
+            get { return DockNotebook.ActiveNotebook; }
+            set { DockNotebook.ActiveNotebook = value; }
+        }
+
+        public static DockNotebookContainer ActiveNotebookContainer {
+            get {
+                return DockNotebook.ActiveNotebook == null ? null : DockNotebook.ActiveNotebook.Parent as DockNotebookContainer;
+            }
+        }
+
+        public static DockNotebookTab ActiveTab {
+            get {
+                return ActiveNotebook == null ? null : ActiveNotebook.CurrentTab;
+            }
+        }
+
+        public static bool TabStripVisible {
+            get { return tab_strip_visible; }
+            set {
+                if (tab_strip_visible != value) {
+                    tab_strip_visible = value;
+
+                    if (TabStripVisibleChanged != null)
+                        TabStripVisibleChanged (null, EventArgs.Empty);
+                }
+            }
+        }
+
+        #region Internal Methods
+        internal static void AddContainer (DockNotebookContainer container)
+        {
+            all_containers.Add (container);
+        }
+
+        internal static void RemoveContainer (DockNotebookContainer container)
+        {
+            all_containers.Remove (container);
+        }
+
+        internal static void OnActiveNotebookChanged ()
+        {
+            if (ActiveNotebookChanged != null)
+                ActiveNotebookChanged (null, EventArgs.Empty);
+        }
+
+        internal static void OnActiveTabChanged ()
+        {
+            if (ActiveTabChanged != null)
+                ActiveTabChanged (null, EventArgs.Empty);
+        }
+
+        internal static void OnDragDataReceived (object sender, Gtk.DragDataReceivedArgs e)
+        {
+            if (NotebookDragDataReceived != null)
+                NotebookDragDataReceived (sender, e);
+        }
+
+        internal static void OnTabClosed (object sender, TabClosedEventArgs e)
+        {
+            if (TabClosed != null)
+                TabClosed (sender, e);
+        }
+        #endregion
+    }
+}

--- a/Pinta.Docking/DockNotebook/DockNotebookManager.cs
+++ b/Pinta.Docking/DockNotebook/DockNotebookManager.cs
@@ -62,7 +62,7 @@ namespace Pinta.Docking.DockNotebook
 
         public static DockNotebookContainer ActiveNotebookContainer {
             get {
-                return DockNotebook.ActiveNotebook == null ? null : DockNotebook.ActiveNotebook.Parent as DockNotebookContainer;
+                return ActiveNotebook == null ? null : ActiveNotebook.Parent as DockNotebookContainer;
             }
         }
 

--- a/Pinta.Docking/Pinta.Docking.csproj
+++ b/Pinta.Docking/Pinta.Docking.csproj
@@ -71,6 +71,7 @@
     <Compile Include="DockLibrary\TabStrip.cs" />
     <Compile Include="DockNotebook\DockNotebook.cs" />
     <Compile Include="DockNotebook\DockNotebookContainer.cs" />
+    <Compile Include="DockNotebook\DockNotebookManager.cs" />
     <Compile Include="DockNotebook\DockNotebookTab.cs" />
     <Compile Include="DockNotebook\DockWindow.cs" />
     <Compile Include="DockNotebook\PlaceholderWindow.cs" />

--- a/Pinta/Actions/View/ImageTabsToggledAction.cs
+++ b/Pinta/Actions/View/ImageTabsToggledAction.cs
@@ -46,7 +46,7 @@ namespace Pinta.Actions
 
 		private void Activated (object sender, EventArgs e)
 		{
-			Pinta.Docking.DockNotebook.DockNotebook.TabStripVisible = ((ToggleAction)sender).Active;
+			Pinta.Docking.DockNotebook.DockNotebookManager.TabStripVisible = ((ToggleAction)sender).Active;
 		}
 	}
 }

--- a/Pinta/DocumentViewContent.cs
+++ b/Pinta/DocumentViewContent.cs
@@ -42,6 +42,7 @@ namespace Pinta
             this.canvas_window = canvasWindow;
 
             document.IsDirtyChanged += (o, e) => IsDirty = document.IsDirty;
+            document.Renamed += (o, e) => { if (ContentNameChanged != null) ContentNameChanged (this, EventArgs.Empty); };
         }
 
         #region IViewContent Members

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -189,7 +189,7 @@ namespace Pinta
 
             var my_content = new DocumentViewContent (doc, canvas);
 
-            // Insert our tab to the left of the currently selected tab
+            // Insert our tab to the right of the currently selected tab
             var tab = container.TabControl.InsertTab (my_content, selected_index + 1);
 
             doc.Workspace.Canvas = canvas.Canvas;


### PR DESCRIPTION
Refactor all public static DockNotebook functions into a static class called DockNotebookManager, and add some convenience methods for work we had in MainWindow.

Also update behavior:
- New tabs will be added to the active container rather than the first container.
- New tabs will be added to the right of the active tab rather than the end.