### PR TITLE
RFC: Use Cairo blend operations instead of PDN's managed blend modes.

### DIFF
--- a/Pinta.Core/Actions/ImageActions.cs
+++ b/Pinta.Core/Actions/ImageActions.cs
@@ -194,78 +194,80 @@ namespace Pinta.Core
 
 			PintaCore.Tools.Commit ();
 
-			Cairo.ImageSurface image = doc.CurrentUserLayer.Surface;
-			Gdk.Rectangle rect = image.GetBounds ();
+            using (var image = doc.GetFlattenedImage ())
+            {
+                Gdk.Rectangle rect = image.GetBounds ();
 
-			Cairo.Color borderColor = image.GetPixel (0, 0);
-			bool cropSide = true;
-			int depth = -1;
+                Cairo.Color borderColor = image.GetPixel (0, 0);
+                bool cropSide = true;
+                int depth = -1;
 
-			//From the top down
-			while (cropSide) {
-				depth++;
-				for (int i = 0; i < image.Width; i++) {
-					if (!borderColor.Equals(image.GetPixel (i, depth))) {
-						cropSide = false;
-						break;
-					}
-				}
-				//Check if the image is blank/mono-coloured, only need to do it on this scan
-				if (depth == image.Height)
-					return;
-			}
+                //From the top down
+                while (cropSide) {
+                    depth++;
+                    for (int i = 0; i < image.Width; i++) {
+                        if (!borderColor.Equals(image.GetPixel (i, depth))) {
+                            cropSide = false;
+                            break;
+                        }
+                    }
+                    //Check if the image is blank/mono-coloured, only need to do it on this scan
+                    if (depth == image.Height)
+                        return;
+                }
 
-			rect = new Gdk.Rectangle (rect.X, rect.Y + depth, rect.Width, rect.Height - depth);
+                rect = new Gdk.Rectangle (rect.X, rect.Y + depth, rect.Width, rect.Height - depth);
 
-			depth = image.Height;
-			cropSide = true;
-			//From the bottom up
-			while (cropSide) {
-				depth--;
-				for (int i = 0; i < image.Width; i++) {
-					if (!borderColor.Equals(image.GetPixel (i, depth))) {
-						cropSide = false;
-						break;
-					}
-				}
+                depth = image.Height;
+                cropSide = true;
+                //From the bottom up
+                while (cropSide) {
+                    depth--;
+                    for (int i = 0; i < image.Width; i++) {
+                        if (!borderColor.Equals(image.GetPixel (i, depth))) {
+                            cropSide = false;
+                            break;
+                        }
+                    }
 
-			}
+                }
 
-			rect = new Gdk.Rectangle (rect.X, rect.Y, rect.Width, depth - rect.Y);
+                rect = new Gdk.Rectangle (rect.X, rect.Y, rect.Width, depth - rect.Y);
 
-			depth = 0;
-			cropSide = true;
-			//From left to right
-			while (cropSide) {
-				depth++;
-				for (int i = 0; i < image.Height; i++) {
-					if (!borderColor.Equals(image.GetPixel (depth, i))) {
-						cropSide = false;
-						break;
-					}
-				}
+                depth = 0;
+                cropSide = true;
+                //From left to right
+                while (cropSide) {
+                    depth++;
+                    for (int i = 0; i < image.Height; i++) {
+                        if (!borderColor.Equals(image.GetPixel (depth, i))) {
+                            cropSide = false;
+                            break;
+                        }
+                    }
 
-			}
+                }
 
-			rect = new Gdk.Rectangle (rect.X + depth, rect.Y, rect.Width - depth, rect.Height);
+                rect = new Gdk.Rectangle (rect.X + depth, rect.Y, rect.Width - depth, rect.Height);
 
-			depth = image.Width;
-			cropSide = true;
-			//From right to left
-			while (cropSide) {
-				depth--;
-				for (int i = 0; i < image.Height; i++) {
-					if (!borderColor.Equals(image.GetPixel (depth, i))) {
-						cropSide = false;
-						break;
-					}
-				}
+                depth = image.Width;
+                cropSide = true;
+                //From right to left
+                while (cropSide) {
+                    depth--;
+                    for (int i = 0; i < image.Height; i++) {
+                        if (!borderColor.Equals(image.GetPixel (depth, i))) {
+                            cropSide = false;
+                            break;
+                        }
+                    }
 
-			}
+                }
 
-			rect = new Gdk.Rectangle (rect.X, rect.Y, depth - rect.X, rect.Height);
+                rect = new Gdk.Rectangle (rect.X, rect.Y, depth - rect.X, rect.Height);
 
-			CropImageToRectangle (doc, rect);
+                CropImageToRectangle (doc, rect);
+            }
 		}
 		#endregion
 

--- a/Pinta.Core/Actions/ImageActions.cs
+++ b/Pinta.Core/Actions/ImageActions.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using Cairo;
 using Mono.Unix;
 
 namespace Pinta.Core
@@ -185,7 +186,7 @@ namespace Pinta.Core
 
 			Gdk.Rectangle rect = doc.GetSelectedBounds (true);
 
-			CropImageToRectangle (doc, rect);
+			CropImageToRectangle (doc, rect, doc.Selection.SelectionPath);
 		}
 
 		private void HandlePintaCoreActionsImageAutoCropActivated (object sender, EventArgs e)
@@ -266,12 +267,13 @@ namespace Pinta.Core
 
                 rect = new Gdk.Rectangle (rect.X, rect.Y, depth - rect.X, rect.Height);
 
-                CropImageToRectangle (doc, rect);
+                // Ignore the current selection when auto-cropping.
+                CropImageToRectangle (doc, rect, /*selection*/ null);
             }
 		}
 		#endregion
 
-		static void CropImageToRectangle (Document doc, Gdk.Rectangle rect)
+		static void CropImageToRectangle (Document doc, Gdk.Rectangle rect, Path selection)
 		{
 			if (rect.Width > 0 && rect.Height > 0)
 			{
@@ -294,7 +296,7 @@ namespace Pinta.Core
 				doc.Workspace.Canvas.GdkWindow.ThawUpdates();
 
 				foreach (var layer in doc.UserLayers)
-					layer.Crop(rect);
+                    layer.Crop (rect, selection);
 
 				hist.FinishSnapshotOfImage();
 

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -698,12 +698,12 @@ namespace Pinta.Core
 
 		public void RotateImageCW ()
 		{
-			RotateImage (-90);
+			RotateImage (90);
 		}
 
 		public void RotateImageCCW ()
 		{
-			RotateImage (90);
+			RotateImage (-90);
 		}
 
 		/// <summary>
@@ -711,11 +711,12 @@ namespace Pinta.Core
 		/// </summary>
 		private void RotateImage (double angle)
 		{
+		    var new_size = Layer.RotateDimensions (ImageSize, angle);
 			foreach (var layer in UserLayers)
-				layer.Rotate (angle, false);
+				layer.Rotate (angle, new_size);
 
-			ImageSize = Layer.RotateDimensions (ImageSize, angle);
-			Workspace.CanvasSize = Layer.RotateDimensions (Workspace.CanvasSize, angle);
+		    ImageSize = new_size;
+			Workspace.CanvasSize = new_size;
 
 			PintaCore.Actions.View.UpdateCanvasScale ();
 			Workspace.Invalidate ();

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -698,12 +698,12 @@ namespace Pinta.Core
 
 		public void RotateImageCW ()
 		{
-			RotateImage (90);
+			RotateImage (-90);
 		}
 
 		public void RotateImageCCW ()
 		{
-			RotateImage (-90);
+			RotateImage (90);
 		}
 
 		/// <summary>
@@ -712,9 +712,7 @@ namespace Pinta.Core
 		private void RotateImage (double angle)
 		{
 			foreach (var layer in UserLayers)
-			{
-				layer.Rotate (angle);
-			}
+				layer.Rotate (angle, false);
 
 			ImageSize = Layer.RotateDimensions (ImageSize, angle);
 			Workspace.CanvasSize = Layer.RotateDimensions (Workspace.CanvasSize, angle);

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -129,13 +129,17 @@ namespace Pinta.Core
 			Draw(ctx, Surface, Opacity);
 		}
 
-		public void Draw(Context ctx, ImageSurface surface, double opacity)
+		public void Draw (Context ctx, ImageSurface surface, double opacity, bool transform = true)
 		{
-			ctx.Save();
-			ctx.Transform(Transform);
-			ctx.SetSourceSurface(surface, 0, 0);
-			ctx.PaintWithAlpha(opacity);
-			ctx.Restore();
+			ctx.Save ();
+
+            if (transform)
+			    ctx.Transform (Transform);
+
+            ctx.SetBlendMode (BlendMode);
+			ctx.SetSourceSurface (surface, 0, 0);
+			ctx.PaintWithAlpha (opacity);
+			ctx.Restore ();
 		}
 		
 		/// <summary>

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -279,7 +279,7 @@ namespace Pinta.Core
 			Surface = dest;
 		}
 
-		public virtual void Crop (Gdk.Rectangle rect)
+		public virtual void Crop (Gdk.Rectangle rect, Path selection)
 		{
 			ImageSurface dest = new ImageSurface (Format.Argb32, rect.Width, rect.Height);
 
@@ -287,6 +287,14 @@ namespace Pinta.Core
 				// Move the selected content to the upper left
 				g.Translate (-rect.X, -rect.Y);
 				g.Antialias = Antialias.None;
+
+                // Optionally, respect the given path.
+                if (selection != null)
+                {
+                    g.AppendPath (selection);
+                    g.FillRule = Cairo.FillRule.EvenOdd;
+                    g.Clip ();
+                }
 
 				g.SetSource (Surface);
 				g.Paint ();

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -143,19 +143,15 @@ namespace Pinta.Core
 		}
 		
 		/// <summary>
-		/// Rotates layer counter-clockwise by the specified angle (in degrees).
+		/// Rotates layer clockwise by the specified angle (in degrees).
 		/// </summary>
 		/// <param name='angle'>Angle (in degrees)</param>
-		/// <param name='in_place'>Specifies whether or not to also adjust the layer's dimensions.</param>
-		public virtual void Rotate (double angle, bool in_place)
+		/// <param name='new_size'>Specifies the desired new size of the layer.</param>
+		public virtual void Rotate (double angle, Size new_size)
 		{
 			double radians = (angle / 180d) * Math.PI;
 
 		    var old_size = PintaCore.Workspace.ImageSize;
-		    var new_size = PintaCore.Workspace.ImageSize;
-		    if (!in_place)
-		        new_size = RotateDimensions (new_size, angle);
-
 		    var dest = new ImageSurface (Format.ARGB32, new_size.Width, new_size.Height);
 			using (var g = new Context (dest))
 			{

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -142,25 +142,13 @@ namespace Pinta.Core
 			ctx.Restore ();
 		}
 		
-		/// <summary>
-		/// Rotates layer clockwise by the specified angle (in degrees).
-		/// </summary>
-		/// <param name='angle'>Angle (in degrees)</param>
-		/// <param name='new_size'>Specifies the desired new size of the layer.</param>
-		public virtual void Rotate (double angle, Size new_size)
+		public virtual void ApplyTransform (Matrix xform, Size new_size)
 		{
-			double radians = (angle / 180d) * Math.PI;
-
 		    var old_size = PintaCore.Workspace.ImageSize;
 		    var dest = new ImageSurface (Format.ARGB32, new_size.Width, new_size.Height);
 			using (var g = new Context (dest))
 			{
-			    var xform = new Matrix ();
-                xform.Translate (new_size.Width / 2.0, new_size.Height / 2.0);
-                xform.Rotate (radians);
-                xform.Translate (-old_size.Width / 2.0, -old_size.Height / 2.0);
                 g.Transform (xform);
-
 			    g.SetSource (Surface);
 				g.Paint ();
 			}

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -143,35 +143,35 @@ namespace Pinta.Core
 		}
 		
 		/// <summary>
-		/// Rotates layer by the specified angle (in degrees).
+		/// Rotates layer counter-clockwise by the specified angle (in degrees).
 		/// </summary>
-		/// <param name='angle'>
-		/// Angle (in degrees).
-		/// </param>
-		public virtual void Rotate (double angle)
+		/// <param name='angle'>Angle (in degrees)</param>
+		/// <param name='in_place'>Specifies whether or not to also adjust the layer's dimensions.</param>
+		public virtual void Rotate (double angle, bool in_place)
 		{
-			int w = PintaCore.Workspace.ImageSize.Width;
-			int h = PintaCore.Workspace.ImageSize.Height;
-
 			double radians = (angle / 180d) * Math.PI;
-			double cos = Math.Cos (radians);
-			double sin = Math.Sin (radians);
 
-			var newSize = RotateDimensions (PintaCore.Workspace.ImageSize, angle);
+		    var old_size = PintaCore.Workspace.ImageSize;
+		    var new_size = PintaCore.Workspace.ImageSize;
+		    if (!in_place)
+		        new_size = RotateDimensions (new_size, angle);
 
-			Layer dest = PintaCore.Layers.CreateLayer (string.Empty, newSize.Width, newSize.Height);
+		    var dest = new ImageSurface (Format.ARGB32, new_size.Width, new_size.Height);
+			using (var g = new Context (dest))
+			{
+			    var xform = new Matrix ();
+                xform.Translate (new_size.Width / 2.0, new_size.Height / 2.0);
+                xform.Rotate (radians);
+                xform.Translate (-old_size.Width / 2.0, -old_size.Height / 2.0);
+                g.Transform (xform);
 
-			using (Cairo.Context g = new Cairo.Context (dest.Surface)) {
-				g.Matrix = new Matrix (cos, sin, -sin, cos, newSize.Width / 2.0, newSize.Height / 2.0);
-				g.Translate (-w / 2.0, -h / 2.0);
-				g.SetSource (Surface);
-
+			    g.SetSource (Surface);
 				g.Paint ();
 			}
 			
 			Surface old = Surface;
-			Surface = dest.Surface;
-			(old as IDisposable).Dispose ();
+		    Surface = dest;
+			old.Dispose ();
 		}
 
 		public static Gdk.Size RotateDimensions (Gdk.Size originalSize, double angle)

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -82,16 +82,14 @@ namespace Pinta.Core
 			}
 		}
 
-		public override void Crop(Gdk.Rectangle rect)
+        public override void Crop (Gdk.Rectangle rect, Path selection)
 		{
-			base.Crop (rect);
+			base.Crop (rect, selection);
 
 			foreach (ReEditableLayer rel in ReEditableLayers)
 			{
 				if (rel.IsLayerSetup)
-				{
-					rel.Layer.Crop(rect);
-				}
+                    rel.Layer.Crop (rect, selection);
 			}
 		}
 

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -69,16 +69,29 @@ namespace Pinta.Core
 		public Gdk.Rectangle textBounds = Gdk.Rectangle.Zero;
 		public Gdk.Rectangle previousTextBounds = Gdk.Rectangle.Zero;
 
-        public override void Rotate (double angle, Size new_size)
+        public override void ApplyTransform (Matrix xform, Size new_size)
 		{
-			base.Rotate (angle, new_size);
+			base.ApplyTransform (xform, new_size);
 
 			foreach (ReEditableLayer rel in ReEditableLayers)
 			{
 				if (rel.IsLayerSetup)
-                    rel.Layer.Rotate (angle, new_size);
+                    rel.Layer.ApplyTransform (xform, new_size);
 			}
 		}
+
+        public void Rotate (double angle, Size new_size)
+        {
+			double radians = (angle / 180d) * Math.PI;
+		    var old_size = PintaCore.Workspace.ImageSize;
+
+            var xform = new Matrix ();
+            xform.Translate (new_size.Width / 2.0, new_size.Height / 2.0);
+            xform.Rotate (radians);
+            xform.Translate (-old_size.Width / 2.0, -old_size.Height / 2.0);
+
+            ApplyTransform (xform, new_size);
+        }
 
         public override void Crop (Gdk.Rectangle rect, Path selection)
 		{

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -69,16 +69,14 @@ namespace Pinta.Core
 		public Gdk.Rectangle textBounds = Gdk.Rectangle.Zero;
 		public Gdk.Rectangle previousTextBounds = Gdk.Rectangle.Zero;
 
-        public override void Rotate (double angle, bool in_place)
+        public override void Rotate (double angle, Size new_size)
 		{
-			base.Rotate (angle, in_place);
+			base.Rotate (angle, new_size);
 
 			foreach (ReEditableLayer rel in ReEditableLayers)
 			{
 				if (rel.IsLayerSetup)
-				{
-					rel.Layer.Rotate(angle, in_place);
-				}
+                    rel.Layer.Rotate (angle, new_size);
 			}
 		}
 

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -69,15 +69,15 @@ namespace Pinta.Core
 		public Gdk.Rectangle textBounds = Gdk.Rectangle.Zero;
 		public Gdk.Rectangle previousTextBounds = Gdk.Rectangle.Zero;
 
-		public override void Rotate(double angle)
+        public override void Rotate (double angle, bool in_place)
 		{
-			base.Rotate (angle);
+			base.Rotate (angle, in_place);
 
 			foreach (ReEditableLayer rel in ReEditableLayers)
 			{
 				if (rel.IsLayerSetup)
 				{
-					rel.Layer.Rotate(angle);
+					rel.Layer.Rotate(angle, in_place);
 				}
 			}
 		}

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -153,6 +153,27 @@ namespace Pinta.Core
 			return dirty;
 		}
 
+        public static Rectangle FillRectangle (this Context g, Rectangle r, Pattern pattern, PointD patternOffset)
+        {
+            g.Save ();
+
+            g.MoveTo (r.X, r.Y);
+            g.LineTo (r.X + r.Width, r.Y);
+            g.LineTo (r.X + r.Width, r.Y + r.Height);
+            g.LineTo (r.X, r.Y + r.Height);
+            g.LineTo (r.X, r.Y);
+
+            pattern.Matrix.Translate (-patternOffset.X, -patternOffset.Y);
+            g.SetSource (pattern);
+
+            Rectangle dirty = g.FixedStrokeExtents ();
+            g.Fill ();
+
+            g.Restore ();
+
+            return dirty;
+        }
+
 		public static Rectangle DrawPolygonal (this Context g, PointD[] points, Color color)
 		{
 			g.Save ();
@@ -1645,6 +1666,91 @@ namespace Pinta.Core
             pattern.Extend = Extend.Repeat;
 
             return pattern;
+        }
+
+        public static void SetBlendMode (this Context g, BlendMode mode)
+        {
+            switch (mode) {
+                case BlendMode.Normal:
+                    g.Operator = Operator.Over;
+                    break;
+                case BlendMode.Multiply:
+                    g.Operator = (Operator)ExtendedOperators.Multiply;
+                    break;
+                case BlendMode.Additive:
+                    g.Operator = Operator.Add;
+                    break;
+                case BlendMode.ColorBurn:
+                    g.Operator = (Operator)ExtendedOperators.ColorBurn;
+                    break;
+                case BlendMode.ColorDodge:
+                    g.Operator = (Operator)ExtendedOperators.ColorDodge;
+                    break;
+                //case BlendMode.Reflect:
+                //    g.Operator = (Operator)ExtendedOperators.HardLight;
+                //    break;
+                //case BlendMode.Glow:
+                //    g.Operator = (Operator)ExtendedOperators.SoftLight;
+                //    break;
+                case BlendMode.Overlay:
+                    g.Operator = (Operator)ExtendedOperators.Overlay;
+                    break;
+                case BlendMode.Difference:
+                    g.Operator = (Operator)ExtendedOperators.Difference;
+                    break;
+                //case BlendMode.Negation:
+                //    g.Operator = (Operator)21;
+                //    break;
+                case BlendMode.Lighten:
+                    g.Operator = (Operator)ExtendedOperators.Lighten;
+                    break;
+                case BlendMode.Darken:
+                    g.Operator = (Operator)ExtendedOperators.Darken;
+                    break;
+                case BlendMode.Screen:
+                    g.Operator = (Operator)ExtendedOperators.Screen;
+                    break;
+                case BlendMode.Xor:
+                    g.Operator = Operator.Xor;
+                    break;
+            }
+        }
+
+        public enum ExtendedOperators
+        {
+            Clear = 0,
+
+            Source = 1,
+            SourceOver = 2,
+            SourceIn = 3,
+            SourceOut = 4,
+            SourceAtop = 5,
+
+            Destination = 6,
+            DestinationOver = 7,
+            DestinationIn = 8,
+            DestinationOut = 9,
+            DestinationAtop = 10,
+
+            Xor = 11,
+            Add = 12,
+            Saturate = 13,
+
+            Multiply = 14,
+            Screen = 15,
+            Overlay = 16,
+            Darken = 17,
+            Lighten = 18,
+            ColorDodge = 19,
+            ColorBurn = 20,
+            HardLight = 21,
+            SoftLight = 22,
+            Difference = 23,
+            Exclusion = 24,
+            HslHue = 25,
+            HslSaturation = 26,
+            HslColor = 27,
+            HslLuminosity = 28
         }
 	}
 }

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -63,15 +63,11 @@ namespace Pinta.Effects
 			VBox.Remove (hboxBottom);
 			foreach (Widget widget in hboxBottom)
 			{
-				hboxBottom.Remove (widget);
+                hboxBottom.Remove (widget);
 				if (widget == buttonOk)
-				{
 					AddActionWidget (widget, ResponseType.Ok);
-				}
 				else
-				{
-					AddActionWidget (widget, ResponseType.None);
-				}
+                    ActionArea.PackEnd (widget);
 			}
 
 			UpdateInputHistogram ();

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -16,6 +16,8 @@ namespace Pinta.Gui.Widgets
 {
 	class CanvasRenderer
 	{
+        private static Cairo.Pattern tranparent_pattern;
+
 		private Size source_size;
 		private Size destination_size;
 		private Layer offset_layer;
@@ -33,6 +35,13 @@ namespace Pinta.Gui.Widgets
 			this.enable_pixel_grid = enable_pixel_grid;
 		}
 
+        static CanvasRenderer ()
+        {
+            using (var grid = GdkExtensions.CreateTransparentColorSwatch (false))
+            using (var surf = grid.ToSurface ())
+                tranparent_pattern = surf.ToTiledPattern ();
+        }
+
 		public void Initialize (Size sourceSize, Size destinationSize)
 		{
 			if (sourceSize == source_size && destinationSize == destination_size)
@@ -48,13 +57,45 @@ namespace Pinta.Gui.Widgets
 		public void Render (List<Layer> layers, Cairo.ImageSurface dst, Gdk.Point offset)
 		{
 			dst.Flush ();
-		
-			if (scale_factor.Ratio == 1)
-				RenderOneToOne (layers, dst, offset);
-			else if (scale_factor.Ratio < 1)
-				RenderZoomIn (layers, dst, offset);
-			else
-				RenderZoomOut (layers, dst, offset, destination_size);
+
+            // Our rectangle of interest
+            var r = new Gdk.Rectangle (offset, dst.GetBounds ().Size).ToCairoRectangle ();
+
+            using (var g = new Cairo.Context (dst)) {
+                // Create the transparent checkerboard background
+                g.Translate (-offset.X, -offset.Y);
+                g.FillRectangle (r, tranparent_pattern, new Cairo.PointD (offset.X, offset.Y));
+
+                for (var i = 0; i < layers.Count; i++) {
+                    var layer = layers[i];
+
+                    // If we're in LivePreview, substitute current layer with the preview layer
+                    if (layer == PintaCore.Layers.CurrentLayer && PintaCore.LivePreview.IsEnabled)
+                        layer = CreateLivePreviewLayer (layer);
+
+                    // If the layer is offset, handle it here
+                    if (!layer.Transform.IsIdentity ())
+                        layer = CreateOffsetLayer (layer);
+
+                    // No need to resize the surface if we're at 100% zoom
+                    if (scale_factor.Ratio == 1)
+                        layer.Draw (g, layer.Surface, layer.Opacity, false);
+                    else {
+                        using (var scaled = new Cairo.ImageSurface (Cairo.Format.Argb32, dst.Width, dst.Height)) {
+                            g.Save ();
+                            // Have to undo the translate set above
+                            g.Translate (offset.X, offset.Y);
+                            CopyScaled (layer.Surface, scaled, r.ToGdkRectangle ());
+                            layer.Draw (g, scaled, layer.Opacity, false);
+                            g.Restore ();
+                        }
+                    }
+                }
+            }
+
+            // If we are at least 200% and grid is requested, draw it
+            if (enable_pixel_grid && PintaCore.Actions.View.PixelGrid.Active && scale_factor.Ratio <= 0.5d)
+                RenderPixelGrid (dst, offset);
 			
 			dst.MarkDirty ();
 		}
@@ -80,7 +121,7 @@ namespace Pinta.Gui.Widgets
 			var preview_layer = new Layer (PintaCore.LivePreview.LivePreviewSurface);
 
 			preview_layer.BlendMode = original.BlendMode;
-			preview_layer.Transform.InitMatrix(original.Transform);
+			preview_layer.Transform.InitMatrix (original.Transform);
 			preview_layer.Opacity = original.Opacity;
 			preview_layer.Hidden = original.Hidden;
 
@@ -92,245 +133,135 @@ namespace Pinta.Gui.Widgets
 			var offset = OffsetLayer;
 			offset.Surface.Clear ();
 
-			using (var g = new Cairo.Context (offset.Surface)) {
-				original.Draw(g, original.Surface, 1);
-			}
+			using (var g = new Cairo.Context (offset.Surface))
+				original.Draw (g, original.Surface, 1);
 
 			offset.BlendMode = original.BlendMode;
-			offset.Transform.InitMatrix(original.Transform);
+			offset.Transform.InitMatrix (original.Transform);
 			offset.Opacity = original.Opacity;
 
 			return offset;
 		}
 
 		#region Algorithms ported from PDN
-		private unsafe void RenderOneToOne (List<Layer> layers, Cairo.ImageSurface dst, Gdk.Point offset)
-		{
-			// The first layer should be blended with the transparent checkerboard
-			var checker = true;
-			CheckerBoardOperation checker_op = null;
+        private void CopyScaled (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
+        {
+            if (scale_factor.Ratio < 1)
+                CopyScaledZoomIn (src, dst, roi);
+            else
+                CopyScaledZoomOut (src, dst, roi);
+        }
 
-			for (int i = 0; i < layers.Count; i++) {
-				var layer = layers[i];
+        private unsafe void CopyScaledZoomIn (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
+        {
+            // Tell Cairo we need the latest raw data
+            dst.Flush ();
 
-				// If we're in LivePreview, substitute current layer with the preview layer
-				if (layer == PintaCore.Layers.CurrentLayer && PintaCore.LivePreview.IsEnabled)
-					layer = CreateLivePreviewLayer (layer);
+            EnsureLookupTablesCreated ();
 
-				// If the layer is offset, handle it here
-				if (!layer.Transform.IsIdentity ())
-					layer = CreateOffsetLayer (layer);
+            // Cache pointers to surface raw data
+            var src_ptr = (ColorBgra*)src.DataPtr;
+            var dst_ptr = (ColorBgra*)dst.DataPtr;
 
-				var src = layer.Surface;
+            // Cache surface sizes
+            var src_width = src.Width;
+            var dst_width = dst.Width;
+            var dst_height = dst.Height;
 
-				// Get the blend mode for this layer and opacity
-				var blend_op = UserBlendOps.GetBlendOp (layer.BlendMode, layer.Opacity);
-				
-				if (checker)
-					checker_op = new CheckerBoardOperation (layer.Opacity);
+            for (var dst_row = 0; dst_row < dst_height; ++dst_row) {
+                // For each dest row, look up the src row to copy from
+                var nnY = dst_row + roi.Y;
+                var srcY = d2sLookupY[nnY];
 
-				// Figure out where our source and destination intersect
-				var srcRect = new Gdk.Rectangle (offset, dst.GetBounds ().Size);
-				srcRect.Intersect (src.GetBounds ());
+                // Get pointers to src and dest rows
+                var dst_row_ptr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dst_row);
+                var src_row_ptr = src.GetRowAddressUnchecked (src_ptr, src_width, srcY);
 
-				// Get pointers to our surfaces
-				var src_ptr = (ColorBgra*)src.DataPtr;
-				var dst_ptr = (ColorBgra*)dst.DataPtr;
+                for (var dstCol = 0; dstCol < dst_width; ++dstCol) {
+                    // Look up the src column to copy from
+                    var nnX = dstCol + roi.X;
+                    var srcX = d2sLookupX[nnX];
 
-				// Cache widths
-				int src_width = src.Width;
-				int dst_width = dst.Width;
+                    // Copy source to destination
+                    *dst_row_ptr++ = *(src_row_ptr + srcX);
+                }
+            }
 
-				for (int dstRow = 0; dstRow < srcRect.Height; ++dstRow) {
-					ColorBgra* dstRowPtr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dstRow);
-					ColorBgra* srcRowPtr = src.GetPointAddressUnchecked (src_ptr, src_width, offset.X, dstRow + offset.Y);
+            // Tell Cairo we changed the raw data
+            dst.MarkDirty ();
+        }
 
-					int dstCol = offset.X;
-					int dstColEnd = offset.X + srcRect.Width;
-					int checkerY = dstRow + offset.Y;
+        private unsafe void CopyScaledZoomOut (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
+        {
+            // Tell Cairo we need the latest raw data
+            dst.Flush ();
 
-					while (dstCol < dstColEnd) {
-						// Blend it over the checkerboard background
-						if (checker)
-							*dstRowPtr = checker_op.Apply (*srcRowPtr, dstCol, checkerY);
-						else
-							*dstRowPtr = blend_op.Apply (*dstRowPtr, *srcRowPtr);
-					
-						++dstRowPtr;
-						++srcRowPtr;
-						++dstCol;
-					}
-				}
+            const int fpShift = 12;
+            const int fpFactor = (1 << fpShift);
 
-				// Only checker the first layer
-				checker = false;
-			}
-		}
+            var source_size = src.GetBounds ().Size;
 
-		private unsafe void RenderZoomIn (List<Layer> layers, Cairo.ImageSurface dst, Gdk.Point offset)
-		{
-			if (!generated) {
-				d2sLookupX = CreateLookupX (source_size.Width, destination_size.Width, scale_factor);
-				d2sLookupY = CreateLookupY (source_size.Height, destination_size.Height, scale_factor);
-				s2dLookupX = CreateS2DLookupX (source_size.Width, destination_size.Width, scale_factor);
-				s2dLookupY = CreateS2DLookupY (source_size.Height, destination_size.Height, scale_factor);
+            // Find destination bounds
+            var dst_left = (int)(((long)roi.X * fpFactor * (long)source_size.Width) / (long)destination_size.Width);
+            var dst_top = (int)(((long)roi.Y * fpFactor * (long)source_size.Height) / (long)destination_size.Height);
+            var dst_right = (int)(((long)(roi.X + dst.Width) * fpFactor * (long)source_size.Width) / (long)destination_size.Width);
+            var dst_bottom = (int)(((long)(roi.Y + dst.Height) * fpFactor * (long)source_size.Height) / (long)destination_size.Height);
+            var dx = (dst_right - dst_left) / dst.Width;
+            var dy = (dst_bottom - dst_top) / dst.Height;
 
-				generated = true;
-			}
+            // Cache pointers to surface raw data and sizes
+            var src_ptr = (ColorBgra*)src.DataPtr;
+            var dst_ptr = (ColorBgra*)dst.DataPtr;
+            var src_width = src.Width;
+            var dst_width = dst.Width;
+            var dst_height = dst.Height;
 
-			// The first layer should be blended with the transparent checkerboard
-			var checker = true;
-			CheckerBoardOperation checker_op = null;
+            for (int dstRow = 0, fDstY = dst_top; dstRow < dst_height && fDstY < dst_bottom; ++dstRow, fDstY += dy) {
+                var srcY1 = fDstY >> fpShift;                            // y
+                var srcY2 = (fDstY + (dy >> 2)) >> fpShift;              // y + 0.25
+                var srcY3 = (fDstY + (dy >> 1)) >> fpShift;              // y + 0.50
+                var srcY4 = (fDstY + (dy >> 1) + (dy >> 2)) >> fpShift;  // y + 0.75
 
-			for (int i = 0; i < layers.Count; i++) {
-				var layer = layers[i];
+                var src1 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY1);
+                var src2 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY2);
+                var src3 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY3);
+                var src4 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY4);
+                var dstPtr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dstRow);
 
-				// If we're in LivePreview, substitute current layer with the preview layer
-				if (layer == PintaCore.Layers.CurrentLayer && PintaCore.LivePreview.IsEnabled)
-					layer = CreateLivePreviewLayer (layer);
+                var checkerY = dstRow + roi.Y;
+                var checkerX = roi.X;
+                var maxCheckerX = checkerX + dst.Width;
 
-				// If the layer is offset, handle it here
-				if (!layer.Transform.IsIdentity ())
-					layer = CreateOffsetLayer (layer);
+                for (var fDstX = dst_left; checkerX < maxCheckerX && fDstX < dst_right; ++checkerX, fDstX += dx) {
+                    var srcX1 = (fDstX + (dx >> 2)) >> fpShift;             // x + 0.25
+                    var srcX2 = (fDstX + (dx >> 1) + (dx >> 2)) >> fpShift; // x + 0.75
+                    var srcX3 = fDstX >> fpShift;                           // x
+                    var srcX4 = (fDstX + (dx >> 1)) >> fpShift;             // x + 0.50
 
-				var src = layer.Surface;
+                    var p1 = src1 + srcX1;
+                    var p2 = src2 + srcX2;
+                    var p3 = src3 + srcX3;
+                    var p4 = src4 + srcX4;
 
-				// Get the blend mode for this layer and opacity
-				var blend_op = UserBlendOps.GetBlendOp (layer.BlendMode, layer.Opacity);
+                    var r = (2 + p1->R + p2->R + p3->R + p4->R) >> 2;
+                    var g = (2 + p1->G + p2->G + p3->G + p4->G) >> 2;
+                    var b = (2 + p1->B + p2->B + p3->B + p4->B) >> 2;
+                    var a = (2 + p1->A + p2->A + p3->A + p4->A) >> 2;
 
-				if (checker)
-					checker_op = new CheckerBoardOperation (layer.Opacity);
-				
-				ColorBgra* src_ptr = (ColorBgra*)src.DataPtr;
-				ColorBgra* dst_ptr = (ColorBgra*)dst.DataPtr;
+                    // Copy color to destination
+                    *dstPtr++ = ColorBgra.FromUInt32 ((uint)b + ((uint)g << 8) + ((uint)r << 16) + ((uint)a << 24));
+                }
+            }
 
-				int src_width = src.Width;
-				int dst_width = dst.Width;
-				int dst_height = dst.Height;
-
-				for (int dstRow = 0; dstRow < dst_height; ++dstRow) {
-					int nnY = dstRow + offset.Y;
-					int srcY = d2sLookupY[nnY];
-
-					ColorBgra* dstPtr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dstRow);
-					ColorBgra* srcRow = src.GetRowAddressUnchecked (src_ptr, src_width, srcY);
-
-					for (int dstCol = 0; dstCol < dst_width; ++dstCol) {
-						int nnX = dstCol + offset.X;
-						int srcX = d2sLookupX[nnX];
-
-						// Blend it over the checkerboard background
-						if (checker)
-							*dstPtr = checker_op.Apply (*(srcRow + srcX), dstCol + offset.X, dstRow + offset.Y);
-						else
-							*dstPtr = blend_op.Apply (*dstPtr, *(srcRow + srcX));
-
-						++dstPtr;
-					}
-				}
-
-				// Only checker the first layer
-				checker = false;
-			}
-
-			// If we are at least 200% and grid is requested, draw it
-			if (enable_pixel_grid && PintaCore.Actions.View.PixelGrid.Active && scale_factor.Ratio <= 0.5d)
-				RenderPixelGrid (dst, offset);
-		}
-
-		private unsafe void RenderZoomOut (List<Layer> layers, Cairo.ImageSurface dst, Gdk.Point offset, Gdk.Size destinationSize)
-		{
-			// The first layer should be blended with the transparent checkerboard
-			var checker = true;
-			CheckerBoardOperation checker_op = null;
-
-			for (int i = 0; i < layers.Count; i++) {
-				var layer = layers[i];
-
-				// If we're in LivePreview, substitute current layer with the preview layer
-				if (layer == PintaCore.Layers.CurrentLayer && PintaCore.LivePreview.IsEnabled)
-					layer = CreateLivePreviewLayer (layer);
-
-				// If the layer is offset, handle it here
-				if (!layer.Transform.IsIdentity ())
-					layer = CreateOffsetLayer (layer);
-
-				var src = layer.Surface;
-
-				// Get the blend mode for this layer and opacity
-				var blend_op = UserBlendOps.GetBlendOp (layer.BlendMode, layer.Opacity);
-
-				if (checker)
-					checker_op = new CheckerBoardOperation (layer.Opacity);
-
-				const int fpShift = 12;
-				const int fpFactor = (1 << fpShift);
-
-				Gdk.Size sourceSize = src.GetBounds ().Size;
-				long fDstLeftLong = ((long)offset.X * fpFactor * (long)sourceSize.Width) / (long)destinationSize.Width;
-				long fDstTopLong = ((long)offset.Y * fpFactor * (long)sourceSize.Height) / (long)destinationSize.Height;
-				long fDstRightLong = ((long)(offset.X + dst.Width) * fpFactor * (long)sourceSize.Width) / (long)destinationSize.Width;
-				long fDstBottomLong = ((long)(offset.Y + dst.Height) * fpFactor * (long)sourceSize.Height) / (long)destinationSize.Height;
-				int fDstLeft = (int)fDstLeftLong;
-				int fDstTop = (int)fDstTopLong;
-				int fDstRight = (int)fDstRightLong;
-				int fDstBottom = (int)fDstBottomLong;
-				int dx = (fDstRight - fDstLeft) / dst.Width;
-				int dy = (fDstBottom - fDstTop) / dst.Height;
-
-				ColorBgra* src_ptr = (ColorBgra*)src.DataPtr;
-				ColorBgra* dst_ptr = (ColorBgra*)dst.DataPtr;
-				int src_width = src.Width;
-				int dst_width = dst.Width;
-			
-				for (int dstRow = 0, fDstY = fDstTop; dstRow < dst.Height && fDstY < fDstBottom; ++dstRow, fDstY += dy) {
-					int srcY1 = fDstY >> fpShift;                            // y
-					int srcY2 = (fDstY + (dy >> 2)) >> fpShift;              // y + 0.25
-					int srcY3 = (fDstY + (dy >> 1)) >> fpShift;              // y + 0.50
-					int srcY4 = (fDstY + (dy >> 1) + (dy >> 2)) >> fpShift;  // y + 0.75
-
-					ColorBgra* src1 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY1);
-					ColorBgra* src2 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY2);
-					ColorBgra* src3 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY3);
-					ColorBgra* src4 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY4);
-					ColorBgra* dstPtr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dstRow);
-					int checkerY = dstRow + offset.Y;
-					int checkerX = offset.X;
-					int maxCheckerX = checkerX + dst.Width;
-
-					for (int fDstX = fDstLeft; checkerX < maxCheckerX && fDstX < fDstRight; ++checkerX, fDstX += dx) {
-						int srcX1 = (fDstX + (dx >> 2)) >> fpShift;             // x + 0.25
-						int srcX2 = (fDstX + (dx >> 1) + (dx >> 2)) >> fpShift; // x + 0.75
-						int srcX3 = fDstX >> fpShift;                           // x
-						int srcX4 = (fDstX + (dx >> 1)) >> fpShift;             // x + 0.50
-						ColorBgra* p1 = src1 + srcX1;
-						ColorBgra* p2 = src2 + srcX2;
-						ColorBgra* p3 = src3 + srcX3;
-						ColorBgra* p4 = src4 + srcX4;
-
-						int r = (2 + p1->R + p2->R + p3->R + p4->R) >> 2;
-						int g = (2 + p1->G + p2->G + p3->G + p4->G) >> 2;
-						int b = (2 + p1->B + p2->B + p3->B + p4->B) >> 2;
-						int a = (2 + p1->A + p2->A + p3->A + p4->A) >> 2;
-
-						// Blend it over the checkerboard background
-						if (checker)
-							*dstPtr = checker_op.Apply (ColorBgra.FromUInt32 ((uint)b + ((uint)g << 8) + ((uint)r << 16) + ((uint)a << 24)), checkerX, checkerY);
-						else
-							*dstPtr = blend_op.Apply (*dstPtr, ColorBgra.FromUInt32 ((uint)b + ((uint)g << 8) + ((uint)r << 16) + ((uint)a << 24)));
-					
-						++dstPtr;
-					}
-				}
-
-				// Only checker the first layer
-				checker = false;
-			}
-		}
+            // Tell Cairo we changed the raw data
+            dst.MarkDirty ();
+        }
 
 		private unsafe void RenderPixelGrid (Cairo.ImageSurface dst, Gdk.Point offset)
 		{
-			// Draw horizontal lines
+            EnsureLookupTablesCreated ();
+            
+            // Draw horizontal lines
 			var dst_ptr = (ColorBgra*)dst.DataPtr; 
 			int dstHeight = dst.Height;
 			int dstWidth = dst.Width;
@@ -376,6 +307,18 @@ namespace Pinta.Gui.Widgets
 				}
 			}
 		}
+
+        private void EnsureLookupTablesCreated ()
+        {
+            if (!generated) {
+                d2sLookupX = CreateLookupX (source_size.Width, destination_size.Width, scale_factor);
+                d2sLookupY = CreateLookupY (source_size.Height, destination_size.Height, scale_factor);
+                s2dLookupX = CreateS2DLookupX (source_size.Width, destination_size.Width, scale_factor);
+                s2dLookupY = CreateS2DLookupY (source_size.Height, destination_size.Height, scale_factor);
+
+                generated = true;
+            }
+        }
 
 		private int[] CreateLookupX (int srcWidth, int dstWidth, ScaleFactor scaleFactor)
 		{

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -81,13 +81,13 @@ namespace Pinta.Actions
 	    {
 	        var xform = new Matrix ();
 	        var image_size = PintaCore.Workspace.ImageSize;
-            var x = image_size.Width / 2.0;
-            var y = image_size.Height / 2.0;
+            var center_x = image_size.Width / 2.0;
+            var center_y = image_size.Height / 2.0;
 
-	        xform.Translate (x, y);
+            xform.Translate ((1 + data.Pan.X) * center_x, (1 + data.Pan.Y) * center_y);
             xform.Rotate ((-data.Angle / 180d) * Math.PI);
             xform.Scale (data.Zoom, data.Zoom);
-	        xform.Translate (-x, -y);
+	        xform.Translate (-center_x, -center_y);
 
 	        return xform;
 	    }
@@ -111,6 +111,9 @@ namespace Pinta.Actions
 		{
 			[Caption ("Angle")]
 			public double Angle = 0;
+
+            [Caption ("Pan")]
+		    public PointD Pan;
 
             [Caption ("Zoom"), MinimumValue (0), MaximumValue (16)]
             public double Zoom = 1.0;

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -69,7 +69,7 @@ namespace Pinta.Actions
 
 			var oldSurface = doc.CurrentUserLayer.Surface.Clone ();
 
-			doc.CurrentUserLayer.Rotate (rotateZoomData.Angle, true);
+			doc.CurrentUserLayer.Rotate (-rotateZoomData.Angle, PintaCore.Workspace.ImageSize);
 			doc.Workspace.Invalidate ();
 
 			var historyItem = new SimpleHistoryItem ("Menu.Layers.RotateZoom.png", Catalog.GetString ("Rotate / Zoom Layer"), oldSurface, doc.CurrentUserLayerIndex);

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -86,6 +86,7 @@ namespace Pinta.Actions
 
 	        xform.Translate (x, y);
             xform.Rotate ((-data.Angle / 180d) * Math.PI);
+            xform.Scale (data.Zoom, data.Zoom);
 	        xform.Translate (-x, -y);
 
 	        return xform;
@@ -110,6 +111,9 @@ namespace Pinta.Actions
 		{
 			[Caption ("Angle")]
 			public double Angle = 0;
+
+            [Caption ("Zoom"), MinimumValue (0), MaximumValue (16)]
+            public double Zoom = 1.0;
 
 			public override bool IsDefault {
 				get { return Angle == 0; }

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -52,7 +52,6 @@ namespace Pinta.Actions
 			var dialog = new SimpleEffectDialog (Catalog.GetString ("Rotate / Zoom Layer"),
 				PintaCore.Resources.GetIcon ("Menu.Layers.RotateZoom.png"), rotateZoomData,
 			                                     new PintaLocalizer ());
-
 			int response = dialog.Run ();
 
 			if (response == (int)Gtk.ResponseType.Ok && !rotateZoomData.IsDefault)
@@ -70,7 +69,7 @@ namespace Pinta.Actions
 
 			var oldSurface = doc.CurrentUserLayer.Surface.Clone ();
 
-			doc.CurrentUserLayer.Rotate (rotateZoomData.Angle);
+			doc.CurrentUserLayer.Rotate (rotateZoomData.Angle, true);
 			doc.Workspace.Invalidate ();
 
 			var historyItem = new SimpleHistoryItem ("Menu.Layers.RotateZoom.png", Catalog.GetString ("Rotate / Zoom Layer"), oldSurface, doc.CurrentUserLayerIndex);

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -119,7 +119,10 @@ namespace Pinta.Actions
             public double Zoom = 1.0;
 
 			public override bool IsDefault {
-				get { return Angle == 0; }
+                get
+                {
+                    return Angle == 0 && Pan.X == 0.0 && Pan.Y == 0.0 && Zoom == 1.0;
+                }
 			}
 		}
 	}


### PR DESCRIPTION
I was intrigued by bug #1091910.  Unfortunately I seem to lack the math skills to fix the problem with using PDN's blend modes, but while investigating I found out that Cairo has supported blend modes since version 1.10 (released in Sept 2010).

The attached patch is a POC using the Cairo blend modes instead of the PDN blend modes.  The results are very promising, ranging between 3x and 49x faster.  The results are also correct, so we render the image correctly unlike the current code.

For the .ora image attached to bug #1091910 (3 layers @ 615x755) doing a full invalidate at various zoom levels on my machine (Intel i7):
- 75% zoom, PDN: 75 ms, Cairo: 25 ms
- 100% zoom, PDN: 98 ms, Cairo: 2 ms
- 125% zoom, PDN: 157 ms, Cairo: 13 ms

There is one large caveat, which is why I'm posting this now before I finish it.  Cairo supports the standard blend modes from the PDF/SVG standards.  PDN adds a few extra blend modes of its own (Additive, Reflect, Glow, and Negation).

If we switch to Cairo, we will lose these blend modes.  This means we will be incompatible with .ora files created with Pinta that use these blend modes.  Note these are not part of the ora standard, so they were already incompatible with any other ora application.  (We wrote them as Pinta extensions, like "pinta-glow" into the ora files.)

I am guessing this is a trivially small amount of files (if any), so I think the tradeoff is probably worth it, but I'd like to get other opinions before writing the rest of the code.

The only other caveat is we have to make sure the system Cairo is "new" enough to be at least 1.10.  It seems fine on Windows.