### PR TITLE
Fix problem with selection tool handles still being enabled while invisible after deselecting

### DIFF
--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -222,7 +222,9 @@ namespace Pinta.Core
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-            PintaCore.Tools.CurrentTool.OnDeselected ();
+            foreach (BaseTool tool in PintaCore.Tools) {
+                tool.OnDeselected ();
+            }
 			PintaCore.Tools.Commit ();
 
 			SelectionHistoryItem hist = new SelectionHistoryItem ("Menu.Edit.Deselect.png", Catalog.GetString ("Deselect"));

--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -222,6 +222,7 @@ namespace Pinta.Core
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
+            PintaCore.Tools.CurrentTool.OnDeselected ();
 			PintaCore.Tools.Commit ();
 
 			SelectionHistoryItem hist = new SelectionHistoryItem ("Menu.Edit.Deselect.png", Catalog.GetString ("Deselect"));

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -277,6 +277,14 @@ namespace Pinta.Core
 		protected virtual void OnKeyUp (DrawingArea canvas, Gtk.KeyReleaseEventArgs args)
 		{
 		}
+
+        /// <summary>
+        /// This is called when the "Deselect all" menu option is called,
+        /// so that tools such as the SelectTool can reset its tool handles.
+        /// </summary>
+        public virtual void OnDeselected()
+        {
+        }
 		
 		/// <summary>
 		/// This is called whenever a menu option is called, for

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -104,6 +104,11 @@ namespace Pinta.Tools
                     hist.Dispose();
                     hist = null;
                 }
+                // reset tool controls to its original values
+                foreach (ToolControl tc in controls)
+                {
+                    tc.Reset ();
+                }
 				doc.ToolLayer.Clear ();
 			} else {
                 ClearHandles (doc.ToolLayer);

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -104,11 +104,6 @@ namespace Pinta.Tools
                     hist.Dispose();
                     hist = null;
                 }
-                // reset tool controls to its original values
-                foreach (ToolControl tc in controls)
-                {
-                    tc.Reset ();
-                }
 				doc.ToolLayer.Clear ();
 			} else {
                 ClearHandles (doc.ToolLayer);
@@ -364,6 +359,17 @@ namespace Pinta.Tools
 			shape_end = doc.Selection.End;
 			UpdateHandler();
 		}
+
+        public override void OnDeselected ()
+        {
+            base.OnDeselected ();
+
+            // reset tool controls to its original values
+            foreach (var tc in controls)
+            {
+                tc.Reset ();
+            }
+        }
 
 		/// <summary>
 		/// Update the selection handles' positions, and redraw them.

--- a/Pinta.Tools/Tools/ToolControl/ToolControl.cs
+++ b/Pinta.Tools/Tools/ToolControl/ToolControl.cs
@@ -57,6 +57,11 @@ namespace Pinta.Tools
             action (x, y, state);
         }
 
+        public void Reset()
+        {
+            Position = new PointD (-5, -5);
+        }
+
         public void Render (Context g)
         {
             var rect = GetHandleRect ();


### PR DESCRIPTION
This one bothered me, so I decided to make a (quick) fix for it. The second commit is kind of an ugly workaround, but it works, and is the fastest way to get the job done properly.
