### PR TITLE
Cairo Images have premultiplied alpha values

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -801,7 +801,7 @@ namespace Pinta.Core
 
 				for (int i = 0; i < len; i++) {
 					if (dstPtr->A != 0)
-						*dstPtr = (ColorBgra.FromBgra (dstPtr->R, dstPtr->G, dstPtr->B, dstPtr->A));
+						*dstPtr = (ColorBgra.FromBgra ((byte)(dstPtr->R * 255 / dstPtr->A), (byte)(dstPtr->G * 255 / dstPtr->A), (byte)(dstPtr->B * 255 / dstPtr->A), dstPtr->A));
 					dstPtr++;
 				}
 


### PR DESCRIPTION
therefore before converting to Gdk.Pixbuf R,G,B values must be converted.
See:
http://cairographics.org/manual/cairo-Image-Surfaces.html#cairo-format-t

Using Gdk.pixbuf_get_from_surface() (Gdk 3) would probably be a better and faster solution...