### PR TITLE
Source Operator not correctly set in LivePreviewManager.cs

### DIFF
--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -140,6 +140,21 @@ namespace Pinta.Core
 
 			ctx.Restore ();
 		}
+
+        public void DrawWithOperator (Context ctx, ImageSurface surface, Operator op, double opacity = 1.0, bool transform = true)
+        {
+            ctx.Save ();
+
+            if (transform)
+                ctx.Transform (Transform);
+            ctx.Operator = op;
+            ctx.SetSourceSurface (surface, 0, 0);
+            if (opacity >= 1.0)
+                ctx.Paint ();
+            else 
+                ctx.PaintWithAlpha (opacity);
+            ctx.Restore ();
+        }
 		
 		public virtual void ApplyTransform (Matrix xform, Size new_size)
 		{

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -241,14 +241,7 @@ namespace Pinta.Core
 				ctx.Save ();
 				PintaCore.Workspace.ActiveDocument.Selection.Clip (ctx);
 			
-				ctx.Operator = Cairo.Operator.Source;
-		                //Set layer.BlendMode to an invalid value, because otherwise ctx.Operator is overwritten and BlendMode.Source is not supported.
-		                //This prevents BlendSurface(), which is called by layer.Draw() to change ctx.Operator.
-		                //TODO: replace this dirity fix (use of invalid BlendMode) by something better
-		                BlendMode oldBlendMode = layer.BlendMode;
-		                layer.BlendMode = (BlendMode)9999;
-				layer.Draw(ctx, live_preview_surface, 1);
-		                layer.BlendMode = oldBlendMode;
+                layer.DrawWithOperator(ctx, live_preview_surface, Cairo.Operator.Source);
 				ctx.Restore ();
 			}
 			

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -242,8 +242,13 @@ namespace Pinta.Core
 				PintaCore.Workspace.ActiveDocument.Selection.Clip (ctx);
 			
 				ctx.Operator = Cairo.Operator.Source;
-				
+		                //Set layer.BlendMode to an invalid value, because otherwise ctx.Operator is overwritten and BlendMode.Source is not supported.
+		                //This prevents BlendSurface(), which is called by layer.Draw() to change ctx.Operator.
+		                //TODO: replace this dirity fix (use of invalid BlendMode) by something better
+		                BlendMode oldBlendMode = layer.BlendMode;
+		                layer.BlendMode = (BlendMode)9999;
 				layer.Draw(ctx, live_preview_surface, 1);
+		                layer.BlendMode = oldBlendMode;
 				ctx.Restore ();
 			}
 			


### PR DESCRIPTION
changing ctx.Operator before a call to layer.Draw(...) has no effect because the BlendMode is overwritten by layer.Draw(...).
The error can be seen e.g. when having a colored semi-transparent image and apply a black and white filter. In the regions of the image where alpha is != 255 there remain colored parts.
