### PR TITLE
Strange behaviour when width or height of a drawn rounded rectangle is 0

### DIFF
--- a/Pinta.Tools/Editable/Shapes/RoundedLineEngine.cs
+++ b/Pinta.Tools/Editable/Shapes/RoundedLineEngine.cs
@@ -206,7 +206,7 @@ namespace Pinta.Tools
 			double currentOffsetRatio;
 
 			//Prevent a divide by 0 error.
-			if (currentDistance < 0d)
+			if (currentDistance <= 0d)
 			{
 				currentOffsetRatio = 0d;
 			}
@@ -225,7 +225,7 @@ namespace Pinta.Tools
 			double nextOffsetRatio;
 
 			//Prevent a divide by 0 error.
-			if (nextDistance < 0d)
+			if (nextDistance <= 0d)
 			{
 				nextOffsetRatio = 0d;
 			}


### PR DESCRIPTION
Instead of the rectangle, a triangle with one point at (0,0) is drawn.
Reason is that divide by 0 error is not prevented correctly, resulting in NaN.