### PR TITLE
corrected display problems in MoveSelectedTool and LivePreviewManager

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -55,29 +55,29 @@ namespace Pinta.Core
 
 		private bool show_selection;
 
-	    private DocumentSelection selection;
-        public DocumentSelection Selection
-        {
-            get { return selection; }
-            set
-            {
-                selection = value;
+		private DocumentSelection selection;
+		public DocumentSelection Selection
+		{
+			get { return selection; }
+			set
+			{
+				selection = value;
 
-                // Listen for any changes to this selection.
-                selection.SelectionModified += (sender, args) => {
-                    OnSelectionChanged ();
-                };
+				// Listen for any changes to this selection.
+				selection.SelectionModified += (sender, args) => {
+					OnSelectionChanged ();
+				};
 
-                // Notify listeners that our selection has been modified.
-                OnSelectionChanged();
-            }
-        }
+				// Notify listeners that our selection has been modified.
+				OnSelectionChanged();
+			}
+		}
 
-        public DocumentSelection PreviousSelection = new DocumentSelection ();
+		public DocumentSelection PreviousSelection = new DocumentSelection ();
 
 		public Document (Gdk.Size size)
 		{
-		    Selection = new DocumentSelection ();
+			Selection = new DocumentSelection ();
 
 			Guid = Guid.NewGuid ();
 			
@@ -264,8 +264,8 @@ namespace Pinta.Core
 			if (selection_layer != null)
 				(selection_layer.Surface as IDisposable).Dispose ();
 
-            Selection.Dispose ();
-            PreviousSelection.Dispose ();
+			Selection.Dispose ();
+			PreviousSelection.Dispose ();
 
 			Workspace.History.Clear ();
 		}
@@ -422,8 +422,8 @@ namespace Pinta.Core
 
 			using (Cairo.Context g = new Cairo.Context (CurrentUserLayer.Surface)) {
 				//layer.Draw(g);
-                selection.Clip (g);
-                layer.DrawWithOperator(g, layer.Surface, Operator.Source, 1.0f, true);
+				selection.Clip (g);
+				layer.DrawWithOperator(g, layer.Surface, Operator.Source, 1.0f, true);
 			}
 
 			DestroySelectionLayer ();
@@ -496,21 +496,21 @@ namespace Pinta.Core
 		/// </summary>
 		public ColorBgra GetComputedPixel (int x, int y)
 		{
-            using (var dst = new ImageSurface (Format.Argb32, 1, 1)) {
-                using (var g = new Context (dst)) {
-			        foreach (var layer in GetLayersToPaint ()) {
-                        var color = layer.Surface.GetColorBgraUnchecked (x, y).ToStraightAlpha ().ToCairoColor ();
+			using (var dst = new ImageSurface (Format.Argb32, 1, 1)) {
+				using (var g = new Context (dst)) {
+					foreach (var layer in GetLayersToPaint ()) {
+						var color = layer.Surface.GetColorBgraUnchecked (x, y).ToStraightAlpha ().ToCairoColor ();
 
-                        g.SetBlendMode (layer.BlendMode);
-                        g.SetSourceColor (color);
+						g.SetBlendMode (layer.BlendMode);
+						g.SetSourceColor (color);
 
-                        g.Rectangle (dst.GetBounds ().ToCairoRectangle ());
-                        g.PaintWithAlpha (layer.Opacity);
-                    }
-                }
+						g.Rectangle (dst.GetBounds ().ToCairoRectangle ());
+						g.PaintWithAlpha (layer.Opacity);
+					}
+				}
 
-                return dst.GetColorBgraUnchecked (0, 0);
-            }
+				return dst.GetColorBgraUnchecked (0, 0);
+			}
 		}
 
 		public ImageSurface GetFlattenedImage ()
@@ -520,8 +520,8 @@ namespace Pinta.Core
 
 			// Blend each visible layer onto our surface
 			foreach (var layer in GetLayersToPaint (include_tool_layer: false)) {
-                using (var g = new Context (surf))
-                    layer.Draw (g);
+				using (var g = new Context (surf))
+					layer.Draw (g);
 			}
 
 			surf.MarkDirty ();
@@ -600,8 +600,8 @@ namespace Pinta.Core
 			var dest = UserLayers[current_layer - 1];
 
 			// Blend the layers
-            using (var g = new Context (dest.Surface))
-                source.Draw (g);
+			using (var g = new Context (dest.Surface))
+				source.Draw (g);
 
 			DeleteCurrentLayer ();
 		}
@@ -638,9 +638,9 @@ namespace Pinta.Core
 		
 		public void ResetSelectionPaths()
 		{
-		    var rect = new Cairo.Rectangle (0, 0, ImageSize.Width, ImageSize.Height);
-            Selection.CreateRectangleSelection (rect);
-            PreviousSelection.CreateRectangleSelection (rect);
+			var rect = new Cairo.Rectangle (0, 0, ImageSize.Width, ImageSize.Height);
+			Selection.CreateRectangleSelection (rect);
+			PreviousSelection.CreateRectangleSelection (rect);
 
 			ShowSelection = false;
 		}
@@ -738,11 +738,11 @@ namespace Pinta.Core
 		/// </summary>
 		private void RotateImage (double angle)
 		{
-		    var new_size = Layer.RotateDimensions (ImageSize, angle);
+			var new_size = Layer.RotateDimensions (ImageSize, angle);
 			foreach (var layer in UserLayers)
 				layer.Rotate (angle, new_size);
 
-		    ImageSize = new_size;
+			ImageSize = new_size;
 			Workspace.CanvasSize = new_size;
 
 			PintaCore.Actions.View.UpdateCanvasScale ();
@@ -855,7 +855,7 @@ namespace Pinta.Core
 
 			// Copy the paste to the temp layer, which should be at least the size of this document.
 			CreateSelectionLayer (Math.Max(ImageSize.Width, cbImage.Width),
-			                      Math.Max(ImageSize.Height, cbImage.Height));
+								  Math.Max(ImageSize.Height, cbImage.Height));
 			ShowSelectionLayer = true;
 			
 			using (Cairo.Context g = new Cairo.Context (SelectionLayer.Surface))
@@ -908,8 +908,8 @@ namespace Pinta.Core
 			markup = string.Format (markup, primary, secondary);
 
 			var md = new MessageDialog (Pinta.Core.PintaCore.Chrome.MainWindow, DialogFlags.Modal,
-						    MessageType.Error, ButtonsType.None, true,
-						    markup);
+							MessageType.Error, ButtonsType.None, true,
+							markup);
 
 			md.AddButton (Stock.Ok, ResponseType.Yes);
 
@@ -949,19 +949,19 @@ namespace Pinta.Core
 			PintaCore.Layers.RaiseLayerPropertyChangedEvent (sender, e);
 		}
 
-	    private void OnSelectionChanged ()
-	    {
-            if (SelectionChanged != null)
-                SelectionChanged.Invoke(this, EventArgs.Empty);
-        }
-        #endregion
+		private void OnSelectionChanged ()
+		{
+			if (SelectionChanged != null)
+				SelectionChanged.Invoke(this, EventArgs.Empty);
+		}
+		#endregion
 
-        #region Public Events
-        public event EventHandler IsDirtyChanged;
+		#region Public Events
+		public event EventHandler IsDirtyChanged;
 		public event EventHandler Renamed;
 		public event LayerCloneEvent LayerCloned;
-	    public event EventHandler SelectionChanged;
+		public event EventHandler SelectionChanged;
 
-	    #endregion
+		#endregion
 	}
 }

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -421,7 +421,6 @@ namespace Pinta.Core
 			Layer layer = SelectionLayer;
 
 			using (Cairo.Context g = new Cairo.Context (CurrentUserLayer.Surface)) {
-				//layer.Draw(g);
 				selection.Clip (g);
 				layer.DrawWithOperator(g, layer.Surface, Operator.Source, 1.0f, true);
 			}

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -421,7 +421,9 @@ namespace Pinta.Core
 			Layer layer = SelectionLayer;
 
 			using (Cairo.Context g = new Cairo.Context (CurrentUserLayer.Surface)) {
-				layer.Draw(g);
+				//layer.Draw(g);
+                selection.Clip (g);
+                layer.DrawWithOperator(g, layer.Surface, Operator.Source, 1.0f, true);
 			}
 
 			DestroySelectionLayer ();
@@ -538,7 +540,7 @@ namespace Pinta.Core
 					if (!ToolLayer.Hidden && include_tool_layer)
 						paint.Add (ToolLayer);
 
-					if (ShowSelectionLayer)
+					if (ShowSelectionLayer && (!SelectionLayer.Hidden))
 						paint.Add (SelectionLayer);
 				}
 

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -133,42 +133,42 @@ namespace Pinta.Core
 		{
 			ctx.Save ();
 
-            if (transform)
-			    ctx.Transform (Transform);
+			if (transform)
+				ctx.Transform (Transform);
 
-            ctx.BlendSurface (surface, BlendMode, opacity);
+			ctx.BlendSurface (surface, BlendMode, opacity);
 
 			ctx.Restore ();
 		}
 
-        public void DrawWithOperator (Context ctx, ImageSurface surface, Operator op, double opacity = 1.0, bool transform = true)
-        {
-            ctx.Save ();
+		public void DrawWithOperator (Context ctx, ImageSurface surface, Operator op, double opacity = 1.0, bool transform = true)
+		{
+			ctx.Save ();
 
-            if (transform)
-                ctx.Transform (Transform);
-            ctx.Operator = op;
-            ctx.SetSourceSurface (surface, 0, 0);
-            if (opacity >= 1.0)
-                ctx.Paint ();
-            else 
-                ctx.PaintWithAlpha (opacity);
-            ctx.Restore ();
-        }
+			if (transform)
+				ctx.Transform (Transform);
+			ctx.Operator = op;
+			ctx.SetSourceSurface (surface, 0, 0);
+			if (opacity >= 1.0)
+				ctx.Paint ();
+			else 
+				ctx.PaintWithAlpha (opacity);
+			ctx.Restore ();
+		}
 		
 		public virtual void ApplyTransform (Matrix xform, Size new_size)
 		{
-		    var old_size = PintaCore.Workspace.ImageSize;
-		    var dest = new ImageSurface (Format.ARGB32, new_size.Width, new_size.Height);
+			var old_size = PintaCore.Workspace.ImageSize;
+			var dest = new ImageSurface (Format.ARGB32, new_size.Width, new_size.Height);
 			using (var g = new Context (dest))
 			{
-                g.Transform (xform);
-			    g.SetSource (Surface);
+				g.Transform (xform);
+				g.SetSource (Surface);
 				g.Paint ();
 			}
 			
 			Surface old = Surface;
-		    Surface = dest;
+			Surface = dest;
 			old.Dispose ();
 		}
 
@@ -286,13 +286,13 @@ namespace Pinta.Core
 				g.Translate (-rect.X, -rect.Y);
 				g.Antialias = Antialias.None;
 
-                // Optionally, respect the given path.
-                if (selection != null)
-                {
-                    g.AppendPath (selection);
-                    g.FillRule = Cairo.FillRule.EvenOdd;
-                    g.Clip ();
-                }
+				// Optionally, respect the given path.
+				if (selection != null)
+				{
+					g.AppendPath (selection);
+					g.FillRule = Cairo.FillRule.EvenOdd;
+					g.Clip ();
+				}
 
 				g.SetSource (Surface);
 				g.Paint ();

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -140,6 +140,21 @@ namespace Pinta.Core
 
 			ctx.Restore ();
 		}
+
+        public void DrawWithOperator (Context ctx, ImageSurface surface, Operator op, double opacity = 1.0, bool transform = true)
+        {
+            ctx.Save ();
+
+            if (transform)
+                ctx.Transform (Transform);
+            ctx.Operator = op;
+            ctx.SetSourceSurface (surface, 0, 0);
+            if (opacity >= 1.0)
+                ctx.Paint ();
+            else 
+                ctx.PaintWithAlpha (opacity);
+            ctx.Restore ();
+        }
 		
 		public virtual void ApplyTransform (Matrix xform, Size new_size)
 		{

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -87,8 +87,8 @@ namespace Pinta.Core
 
 			//TODO Use the current tool layer instead.
 			live_preview_surface = new Cairo.ImageSurface (Cairo.Format.Argb32,
-			                                  PintaCore.Workspace.ImageSize.Width,
-			                                  PintaCore.Workspace.ImageSize.Height);
+											  PintaCore.Workspace.ImageSize.Width,
+											  PintaCore.Workspace.ImageSize.Height);
 
 			// Handle selection path.
 			PintaCore.Tools.Commit ();
@@ -241,7 +241,7 @@ namespace Pinta.Core
 				ctx.Save ();
 				PintaCore.Workspace.ActiveDocument.Selection.Clip (ctx);
 			
-                layer.DrawWithOperator(ctx, live_preview_surface, Cairo.Operator.Source);
+				layer.DrawWithOperator(ctx, live_preview_surface, Cairo.Operator.Source);
 				ctx.Restore ();
 			}
 			
@@ -381,7 +381,7 @@ namespace Pinta.Core
 			int height = (int)Math.Ceiling (y2) - y;
 
 			// Tell GTK to expose the drawing area.			
-            PintaCore.Workspace.ActiveWorkspace.Canvas.QueueDrawArea (x, y, width, height);
+			PintaCore.Workspace.ActiveWorkspace.Canvas.QueueDrawArea (x, y, width, height);
 		}	
 	}
 }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -241,9 +241,7 @@ namespace Pinta.Core
 				ctx.Save ();
 				PintaCore.Workspace.ActiveDocument.Selection.Clip (ctx);
 			
-				ctx.Operator = Cairo.Operator.Source;
-				
-				layer.Draw(ctx, live_preview_surface, 1);
+                layer.DrawWithOperator(ctx, live_preview_surface, Cairo.Operator.Source);
 				ctx.Restore ();
 			}
 			

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -49,7 +49,7 @@ namespace Pinta.Tools
 			get { return Catalog.GetString ("Left click and drag the selection to move selected content. Right click and drag the selection to rotate selected content."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
-            get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Move.png"), 0, 0); }
+			get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Move.png"), 0, 0); }
 		}
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.M; } }
 		public override int Priority { get { return 7; } }
@@ -70,8 +70,8 @@ namespace Pinta.Tools
 
 			// If there is no selection, select the whole image.
 			if (doc.Selection.SelectionPolygons.Count == 0) {
-                doc.Selection.CreateRectangleSelection (
-                    new Cairo.Rectangle (0, 0, doc.ImageSize.Width, doc.ImageSize.Height));
+				doc.Selection.CreateRectangleSelection (
+					new Cairo.Rectangle (0, 0, doc.ImageSize.Width, doc.ImageSize.Height));
 			}
 
 			original_selection = new List<List<IntPoint>> (doc.Selection.SelectionPolygons);
@@ -119,7 +119,7 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			doc.Selection.SelectionClipper.Clear ();
 			doc.Selection.SelectionPolygons = newSelectionPolygons;
-            doc.Selection.MarkDirty ();
+			doc.Selection.MarkDirty ();
 
 			doc.ShowSelection = true;
 			doc.SelectionLayer.Transform.InitMatrix (original_transform);

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -84,6 +84,10 @@ namespace Pinta.Tools
 				// Copy the selection to the temp layer
 				doc.CreateSelectionLayer ();
 				doc.ShowSelectionLayer = true;
+				//Use same BlendMode, Opacity and Visibility for SelectionLayer
+				doc.SelectionLayer.BlendMode = doc.CurrentUserLayer.BlendMode;
+				doc.SelectionLayer.Opacity = doc.CurrentUserLayer.Opacity;
+				doc.SelectionLayer.Hidden = doc.CurrentUserLayer.Hidden;					
 
 				using (Cairo.Context g = new Cairo.Context (doc.SelectionLayer.Surface)) {
 					g.AppendPath (doc.Selection.SelectionPath);

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -52,7 +52,7 @@ namespace Pinta.Actions
 			int response = dialog.Run ();
 
 			if (response == (int)Gtk.ResponseType.Ok
-			    && dialog.AreLayerPropertiesUpdated) {
+				&& dialog.AreLayerPropertiesUpdated) {
 
 				var historyMessage = GetLayerPropertyUpdateMessage (
 						dialog.InitialLayerProperties,
@@ -72,11 +72,11 @@ namespace Pinta.Actions
 			} else {
 
 				var layer = PintaCore.Workspace.ActiveDocument.CurrentUserLayer;
-                var selectionLayer = PintaCore.Workspace.ActiveDocument.SelectionLayer;
+				var selectionLayer = PintaCore.Workspace.ActiveDocument.SelectionLayer;
 				var initial = dialog.InitialLayerProperties;
 				initial.SetProperties (layer);
-                if (selectionLayer != null)
-                    initial.SetProperties (selectionLayer);
+				if (selectionLayer != null)
+					initial.SetProperties (selectionLayer);
 
 				if ((layer.Opacity != initial.Opacity) || (layer.BlendMode != initial.BlendMode) || (layer.Hidden != initial.Hidden)) 
 					PintaCore.Workspace.ActiveWorkspace.Invalidate ();

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -72,10 +72,13 @@ namespace Pinta.Actions
 			} else {
 
 				var layer = PintaCore.Workspace.ActiveDocument.CurrentUserLayer;
+                var selectionLayer = PintaCore.Workspace.ActiveDocument.SelectionLayer;
 				var initial = dialog.InitialLayerProperties;
 				initial.SetProperties (layer);
+                if (selectionLayer != null)
+                    initial.SetProperties (selectionLayer);
 
-				if (layer.Opacity != initial.Opacity)
+				if ((layer.Opacity != initial.Opacity) || (layer.BlendMode != initial.BlendMode) || (layer.Hidden != initial.Hidden)) 
 					PintaCore.Workspace.ActiveWorkspace.Invalidate ();
 			}
 

--- a/Pinta/Dialogs/LayerPropertiesDialog.cs
+++ b/Pinta/Dialogs/LayerPropertiesDialog.cs
@@ -118,11 +118,11 @@ namespace Pinta
 		{
 			hidden = !visibilityCheckbox.Active;
 			PintaCore.Layers.CurrentLayer.Hidden = hidden;
-            if (PintaCore.Layers.SelectionLayer != null) {
-				//Update Visiblity for SelectionLayer and force redraw            
-                PintaCore.Layers.SelectionLayer.Hidden = PintaCore.Layers.CurrentLayer.Hidden;
-            }
-            PintaCore.Workspace.Invalidate ();
+			if (PintaCore.Layers.SelectionLayer != null) {
+				//Update Visiblity for SelectionLayer and force redraw			
+				PintaCore.Layers.SelectionLayer.Hidden = PintaCore.Layers.CurrentLayer.Hidden;
+			}
+			PintaCore.Workspace.Invalidate ();
 		}
 		
 		private void OnOpacitySliderChanged (object sender, EventArgs e)
@@ -142,22 +142,22 @@ namespace Pinta
 			//TODO check redraws are being throttled.
 			opacity = opacitySpinner.Value / 100d;
 			PintaCore.Layers.CurrentLayer.Opacity = opacity;
-            if (PintaCore.Layers.SelectionLayer != null) {
-				//Update Opacity for SelectionLayer and force redraw            
-                PintaCore.Layers.SelectionLayer.Opacity = PintaCore.Layers.CurrentLayer.Opacity;
-            }
-            PintaCore.Workspace.Invalidate ();		
+			if (PintaCore.Layers.SelectionLayer != null) {
+				//Update Opacity for SelectionLayer and force redraw			
+				PintaCore.Layers.SelectionLayer.Opacity = PintaCore.Layers.CurrentLayer.Opacity;
+			}
+			PintaCore.Workspace.Invalidate ();		
 		}
 
 		private void OnBlendModeChanged (object sender, EventArgs e)
 		{
 			blendmode = UserBlendOps.GetBlendModeByName (blendComboBox.ActiveText);
 			PintaCore.Layers.CurrentLayer.BlendMode = blendmode;
-            if (PintaCore.Layers.SelectionLayer != null) {
+			if (PintaCore.Layers.SelectionLayer != null) {
 				//Update BlendMode for SelectionLayer and force redraw
-                PintaCore.Layers.SelectionLayer.BlendMode = PintaCore.Layers.CurrentLayer.BlendMode;     
-            }
-            PintaCore.Workspace.Invalidate ();		
+				PintaCore.Layers.SelectionLayer.BlendMode = PintaCore.Layers.CurrentLayer.BlendMode;	 
+			}
+			PintaCore.Workspace.Invalidate ();		
 		}
 
 		private void Build ()

--- a/Pinta/Dialogs/LayerPropertiesDialog.cs
+++ b/Pinta/Dialogs/LayerPropertiesDialog.cs
@@ -118,6 +118,11 @@ namespace Pinta
 		{
 			hidden = !visibilityCheckbox.Active;
 			PintaCore.Layers.CurrentLayer.Hidden = hidden;
+            if (PintaCore.Layers.SelectionLayer != null) {
+				//Update Visiblity for SelectionLayer and force redraw            
+                PintaCore.Layers.SelectionLayer.Hidden = PintaCore.Layers.CurrentLayer.Hidden;
+            }
+            PintaCore.Workspace.Invalidate ();
 		}
 		
 		private void OnOpacitySliderChanged (object sender, EventArgs e)
@@ -137,12 +142,22 @@ namespace Pinta
 			//TODO check redraws are being throttled.
 			opacity = opacitySpinner.Value / 100d;
 			PintaCore.Layers.CurrentLayer.Opacity = opacity;
+            if (PintaCore.Layers.SelectionLayer != null) {
+				//Update Opacity for SelectionLayer and force redraw            
+                PintaCore.Layers.SelectionLayer.Opacity = PintaCore.Layers.CurrentLayer.Opacity;
+            }
+            PintaCore.Workspace.Invalidate ();		
 		}
 
 		private void OnBlendModeChanged (object sender, EventArgs e)
 		{
 			blendmode = UserBlendOps.GetBlendModeByName (blendComboBox.ActiveText);
 			PintaCore.Layers.CurrentLayer.BlendMode = blendmode;
+            if (PintaCore.Layers.SelectionLayer != null) {
+				//Update BlendMode for SelectionLayer and force redraw
+                PintaCore.Layers.SelectionLayer.BlendMode = PintaCore.Layers.CurrentLayer.BlendMode;     
+            }
+            PintaCore.Workspace.Invalidate ();		
 		}
 
 		private void Build ()


### PR DESCRIPTION
- changing ctx.Operator before a call to layer.Draw(...) has no effect because the BlendMode is overwritten by layer.Draw(...).
The error can be seen e.g. when having a colored semi-transparent image and apply a black and white filter. In the regions of the image where alpha is != 255 there remain colored parts.

- Layerproperties are corretly applied if "MoveSelectionTool" is active, but not if "MoveSelectedTool" is active.
- MoveSelectedTool does not react on changes in Opacity, Visibility and BlendMode
