### PR TITLE
Support loading icons from other assemblies (e.g. Plugins)

### DIFF
--- a/Pinta.Resources/ResourceManager.cs
+++ b/Pinta.Resources/ResourceManager.cs
@@ -34,19 +34,19 @@ namespace Pinta.Resources
 	public static class ResourceLoader
 	{
 
-        private static bool HasResource(Assembly asm, string name)
-        {
-            string[] resources = asm.GetManifestResourceNames ();
+		private static bool HasResource(Assembly asm, string name)
+		{
+			string[] resources = asm.GetManifestResourceNames ();
 
-            if (Array.IndexOf (resources, name) > -1)
-                return true;
-            else
-                return false;
-        }
+			if (Array.IndexOf (resources, name) > -1)
+				return true;
+			else
+				return false;
+		}
 
 		public static Pixbuf GetIcon (string name, int size)
 		{
-            Gdk.Pixbuf result = null;
+			Gdk.Pixbuf result = null;
 			try {
 				// First see if it's a built-in gtk icon, like gtk-new.
 				// This will also load any icons added by Gtk.IconFactory.AddDefault() . 
@@ -56,51 +56,51 @@ namespace Pinta.Resources
 							Gtk.StateType.Normal, GetIconSize (size), null, null);
 					}
 				}
-                // Otherwise, get it from our embedded resources.
-                if (result == null) {
+				// Otherwise, get it from our embedded resources.
+				if (result == null) {
 
-                    if (HasResource(Assembly.GetExecutingAssembly(), name)) //Assembly.GetCallingAssembly() is wrong here!
-                        result = Gdk.Pixbuf.LoadFromResource (name);
-                }
+					if (HasResource(Assembly.GetExecutingAssembly(), name)) //Assembly.GetCallingAssembly() is wrong here!
+						result = Gdk.Pixbuf.LoadFromResource (name);
+				}
 
-                //Maybe we can find the icon in the resource of a different assembly (e.g. Plugin)
-                if (result == null) {
-                    foreach (System.Reflection.Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
-                    {
-                        if (HasResource(asm, name))
-                            result = new Pixbuf(asm, name);
-                    }
-                }
+				//Maybe we can find the icon in the resource of a different assembly (e.g. Plugin)
+				if (result == null) {
+					foreach (System.Reflection.Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+					{
+						if (HasResource(asm, name))
+							result = new Pixbuf(asm, name);
+					}
+				}
 			}
 			catch (Exception ex) {
-                System.Console.Error.WriteLine (ex.Message);
-            }
-
-            // Ensure that we don't crash if an icon is missing for some reason.
-            if (result == null) {
-                try
-                {
-                    // Try to return gtk's default missing image
-                    if (name != Gtk.Stock.MissingImage) {
-                        result = GetIcon (Gtk.Stock.MissingImage, size);
-                    } else {
-                        // If gtk is missing it's "missing image", we'll create one on the fly
-                        result = CreateMissingImage (size);
-                    }
-                }
-                catch (Exception ex) {
-                    System.Console.Error.WriteLine (ex.Message);
-                }
+				System.Console.Error.WriteLine (ex.Message);
 			}
-            return result;
+
+			// Ensure that we don't crash if an icon is missing for some reason.
+			if (result == null) {
+				try
+				{
+					// Try to return gtk's default missing image
+					if (name != Gtk.Stock.MissingImage) {
+						result = GetIcon (Gtk.Stock.MissingImage, size);
+					} else {
+						// If gtk is missing it's "missing image", we'll create one on the fly
+						result = CreateMissingImage (size);
+					}
+				}
+				catch (Exception ex) {
+					System.Console.Error.WriteLine (ex.Message);
+				}
+			}
+			return result;
 		}
 
-        public static Stream GetResourceIconStream (string name)
-        {
-            var ass = typeof (Pinta.Resources.ResourceLoader).Assembly;
+		public static Stream GetResourceIconStream (string name)
+		{
+			var ass = typeof (Pinta.Resources.ResourceLoader).Assembly;
 
-            return ass.GetManifestResourceStream (name);
-        }
+			return ass.GetManifestResourceStream (name);
+		}
 
 		// From MonoDevelop:
 		// https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/gtk-gui/generated.cs


### PR DESCRIPTION
GetIcon() does not support loading icons if the icon is in the resource of a different assembly. This is needed to support icons in plugins.