### PR TITLE
Enable alpha blending toolbar drop down for pencil tool

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -52,6 +52,7 @@ namespace Pinta.Core
 		protected ToolBarDropDownButton antialiasing_button;
 		private ToolBarItem aaOn, aaOff;
 		protected ToolBarDropDownButton alphablending_button;
+		private ToolBarItem abOn, abOff;
 		public event MouseHandler MouseMoved;
 		public event MouseHandler MousePressed;
 		public event MouseHandler MouseReleased;
@@ -106,7 +107,23 @@ namespace Pinta.Core
 			}
 		}
 
-		public virtual bool UseAlphaBlending { get { return ShowAlphaBlendingButton && (bool)alphablending_button.SelectedItem.Tag; } }
+		public virtual bool UseAlphaBlending
+		{
+			get
+			{
+				return alphablending_button != null &&
+					   ShowAlphaBlendingButton &&
+					   (bool)alphablending_button.SelectedItem.Tag;
+			}
+			set
+			{
+				if (!ShowAlphaBlendingButton || alphablending_button == null)
+					return;
+
+				alphablending_button.SelectedItem = value ? abOn : abOff;
+			}
+		}
+
 		public virtual int Priority { get { return 75; } }
 
 		public virtual bool CursorChangesOnZoom { get { return false; } }
@@ -425,8 +442,8 @@ namespace Pinta.Core
 
 			alphablending_button = new ToolBarDropDownButton ();
 
-			alphablending_button.AddItem (Catalog.GetString ("Normal Blending"), "Toolbar.BlendingEnabledIcon.png", true);
-			alphablending_button.AddItem (Catalog.GetString ("Overwrite"), "Toolbar.BlendingOverwriteIcon.png", false);
+			abOn = alphablending_button.AddItem (Catalog.GetString ("Normal Blending"), "Toolbar.BlendingEnabledIcon.png", true);
+			abOff = alphablending_button.AddItem (Catalog.GetString ("Overwrite"), "Toolbar.BlendingOverwriteIcon.png", false);
 
 			tb.AppendItem (alphablending_button);
 		}

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -509,7 +509,7 @@ namespace Pinta.Core
         /// the total summation of the weight values.
         /// </returns>
         /// <remarks>
-        /// "WAIP" stands for "weights, floating-point"</remarks>
+        /// "WFP" stands for "weights, floating-point"</remarks>
         public static ColorBgra BlendColorsWFP(ColorBgra[] c, double[] w)
         {
             if (c.Length != w.Length)

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -40,6 +40,8 @@ namespace Pinta.Tools
 		private bool surface_modified;
         protected uint mouse_button;
 
+		protected override bool ShowAlphaBlendingButton { get { return true; } }
+
 		public PencilTool ()
 		{
 		}
@@ -128,8 +130,11 @@ namespace Pinta.Tools
 				int shiftedX = (int)point.X;
 				int shiftedY = (int)point.Y;
 				ColorBgra source = surf.GetColorBgraUnchecked (shiftedX, shiftedY);
-				source = UserBlendOps.NormalBlendOp.ApplyStatic (source, tool_color.ToColorBgra ());
-				surf.SetColorBgra (source, shiftedX, shiftedY);
+				if (UseAlphaBlending)
+					source = UserBlendOps.NormalBlendOp.ApplyStatic (source, tool_color.ToColorBgra ());
+				else
+					source = tool_color.ToColorBgra ();
+				surf.SetColorBgra (source.ToPremultipliedAlpha (), shiftedX, shiftedY);
 				surf.MarkDirty ();
 			} else {
 				using (Context g = new Context (surf)) {
@@ -145,6 +150,10 @@ namespace Pinta.Tools
 					g.LineTo (x + 0.5, y + 0.5);
 
 					g.SetSourceColor (tool_color);
+					if (UseAlphaBlending)
+						g.SetBlendMode(BlendMode.Normal);
+					else
+						g.Operator = Operator.Source;
 					g.LineWidth = 1;
 					g.LineCap = LineCap.Square;
 				


### PR DESCRIPTION
Enabled a drop down that allows the user to select between normal blend mode and overwrite mode.
Also adds support for overwrite to the pencil tool.

Fixes: [#1688743](https://bugs.launchpad.net/pinta/+bug/1688743)
