### PR TITLE
Fix PlainBrush to use premultiplied alpha for single pixel strokes

### DIFF
--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -51,7 +51,7 @@ namespace Pinta.Tools.Brushes
 
 				ColorBgra source = surface.GetColorBgraUnchecked (x, y);
 				source = UserBlendOps.NormalBlendOp.ApplyStatic (source, strokeColor.ToColorBgra ());
-				surface.SetColorBgra (source, x, y);
+				surface.SetColorBgra (source.ToPremultipliedAlpha (), x, y);
 				surface.MarkDirty ();
 
 				return new Gdk.Rectangle (x - 1, y - 1, 3, 3);


### PR DESCRIPTION
I found one other place where a call to SetColorBgra was made without using a premultiplied alpha and I verified that passing the result of ToPremultipliedAlpha to CairoExtensions.SetColorBgra does give the same result as the LineTo call without antialiasing.

I had to make a similar correct in this pull request: https://github.com/PintaProject/Pinta/pull/124