### PR TITLE
Added support for JASC PaintShop Pro palette files

### DIFF
--- a/Pinta.Core/Managers/SettingsManager.cs
+++ b/Pinta.Core/Managers/SettingsManager.cs
@@ -149,7 +149,8 @@ namespace Pinta.Core
 			Serialize (settings_file, settings);
 			
 			string palette_file = Path.Combine (GetUserSettingsDirectory (), "palette.txt");
-			PintaCore.Palette.CurrentPalette.Save (palette_file, Palette.FileFormat.PDN);
+			PintaCore.Palette.CurrentPalette.Save (palette_file,
+				PintaCore.System.PaletteFormats.Formats.First(p => p.Extensions.Contains("txt")).Saver);
 		}
 	}
 }

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -43,6 +43,7 @@ namespace Pinta.Core
 		private RecentData recent_data;
 
 		public ImageConverterManager ImageFormats { get; private set; }
+		public PaletteFormats PaletteFormats { get; private set; }
 		public FontManager Fonts { get; private set; }
 		public int RenderThreads { get; set; }
 		public OS OperatingSystem { get { return operating_system; } }
@@ -50,6 +51,7 @@ namespace Pinta.Core
 		public SystemManager ()
 		{
 			ImageFormats = new ImageConverterManager ();
+			PaletteFormats = new PaletteFormats ();
 			RenderThreads = Environment.ProcessorCount;
 			Fonts = new FontManager ();
 

--- a/Pinta.Core/PaletteFormats/GimpPalette.cs
+++ b/Pinta.Core/PaletteFormats/GimpPalette.cs
@@ -1,0 +1,81 @@
+﻿//
+// PaintDotNetPalette.cs
+//
+// Author:
+//       Matthias Mailänder, Maia Kozheva
+//
+// Copyright (c) 2010 Maia Kozheva <sikon@ubuntu.com>
+// Copyright (c) 2017 Matthias Mailänder
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using Cairo;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Pinta.Core
+{
+	public class GimpPalette : IPaletteLoader, IPaletteSaver
+	{
+		public List<Color> Load (string fileName)
+		{
+			List<Color> colors = new List<Color> ();
+			StreamReader reader = new StreamReader (fileName);
+			string line = reader.ReadLine ();
+
+			if (!line.StartsWith ("GIMP"))
+				throw new InvalidDataException("Not a valid GIMP palette file.");
+
+			// skip everything until the first color
+			while (!char.IsDigit(line[0]))
+				line = reader.ReadLine ();
+
+			// then read the palette
+			do {
+				if (line.IndexOf ('#') == 0)
+					continue;
+
+				string[] split = line.Split ((char[]) null, StringSplitOptions.RemoveEmptyEntries);
+				double r = int.Parse (split[0]) / 255f;
+				double g = int.Parse (split[1]) / 255f;
+				double b = int.Parse (split[2]) / 255f;
+				colors.Add (new Color (r, g, b));
+			} while ((line = reader.ReadLine ()) != null);
+
+			return colors;
+		}
+
+		public void Save (List<Color> colors, string fileName)
+		{
+			StreamWriter writer = new StreamWriter (fileName);
+			writer.WriteLine ("GIMP Palette");
+			writer.WriteLine ("Name: Pinta Created {0}", DateTime.Now.ToString (DateTimeFormatInfo.InvariantInfo.RFC1123Pattern));
+			writer.WriteLine ("#");
+
+			foreach (Color color in colors) {
+				writer.WriteLine ("{0,3} {1,3} {2,3} Untitled", (int) (color.R * 255), (int) (color.G * 255), (int) (color.B * 255));
+			}
+
+			writer.Close ();
+		}
+	}
+}
+

--- a/Pinta.Core/PaletteFormats/IPaletteLoader.cs
+++ b/Pinta.Core/PaletteFormats/IPaletteLoader.cs
@@ -1,0 +1,39 @@
+// 
+// IPaletteLoader.cs
+//  
+// Author:
+//       Matthias Mailänder
+// 
+// Copyright (c) 2017 Matthias Mailänder
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Mono.Addins;
+using Cairo;
+using System.Collections.Generic;
+
+namespace Pinta.Core
+{
+	[TypeExtensionPoint]
+	public interface IPaletteLoader
+	{
+		List<Color> Load (string fileName);
+	}
+}

--- a/Pinta.Core/PaletteFormats/IPaletteSaver.cs
+++ b/Pinta.Core/PaletteFormats/IPaletteSaver.cs
@@ -1,0 +1,39 @@
+// 
+// IPaletteSaver.cs
+//  
+// Author:
+//       Matthias Mailänder
+// 
+// Copyright (c) 2017 Matthias Mailänder
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Mono.Addins;
+using System.Collections.Generic;
+using Cairo;
+
+namespace Pinta.Core
+{
+	[TypeExtensionPoint]
+	public interface IPaletteSaver
+	{
+		void Save (List<Color> colors, string fileName);
+	}
+}

--- a/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
@@ -1,0 +1,79 @@
+﻿//
+// PaintDotNetPalette.cs
+//
+// Author:
+//       Matthias Mailänder, Maia Kozheva
+//
+// Copyright (c) 2010 Maia Kozheva <sikon@ubuntu.com>
+// Copyright (c) 2017 Matthias Mailänder
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using Cairo;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Pinta.Core
+{
+	public class PaintDotNetPalette : IPaletteLoader, IPaletteSaver
+	{
+		public List<Color> Load (string fileName)
+		{
+			List<Color> colors = new List<Color> ();
+			StreamReader reader = new StreamReader (fileName);
+
+			try {
+				string line = reader.ReadLine ();
+				do {
+					if (line.IndexOf (';') == 0)
+						continue;
+
+					uint color = uint.Parse (line.Substring (0, 8), NumberStyles.HexNumber);
+					double b = (color & 0xff) / 255f;
+					double g = ((color >> 8) & 0xff) / 255f;
+					double r = ((color >> 16) & 0xff) / 255f;
+					double a = (color >> 24) / 255f;
+					colors.Add (new Color (r, g, b, a));
+				} while ((line = reader.ReadLine ()) != null);
+
+				return colors;
+			} finally {
+				reader.Close ();
+			}
+		}
+
+		public void Save (List<Color> colors, string fileName)
+		{
+			StreamWriter writer = new StreamWriter (fileName);
+			writer.WriteLine ("; Hexadecimal format: aarrggbb");
+
+			foreach (Color color in colors) {
+				byte a = (byte)(color.A * 255);
+				byte r = (byte)(color.R * 255);
+				byte g = (byte)(color.G * 255);
+				byte b = (byte)(color.B * 255);
+				writer.WriteLine ("{0:X}", (a << 24) | (r << 16) | (g << 8) | b);
+			}
+			writer.Close ();
+		}
+	}
+}
+

--- a/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
@@ -1,0 +1,78 @@
+﻿//
+// PaintShopProPalette.cs
+//
+// Author:
+//       Matthias Mailänder
+//
+// Copyright (c) 2017 Matthias Mailänder
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using Cairo;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Pinta.Core
+{
+	public class PaintShopProPalette : IPaletteLoader, IPaletteSaver
+	{
+		public List<Color> Load (string fileName)
+		{
+			List<Color> colors = new List<Color> ();
+			StreamReader reader = new StreamReader (fileName);
+			string line = reader.ReadLine ();
+
+			if (!line.StartsWith ("JASC-PAL"))
+				throw new InvalidDataException("Not a valid PaintShopPro palette file.");
+
+			line = reader.ReadLine (); // version
+
+			int numberOfColors = int.Parse(reader.ReadLine());
+			PintaCore.Palette.CurrentPalette.Resize (numberOfColors);
+
+			while (!reader.EndOfStream) {
+				line = reader.ReadLine ();
+				string[] split = line.Split (' ');
+				double r = int.Parse (split[0]) / 255f;
+				double g = int.Parse (split[1]) / 255f;
+				double b = int.Parse (split[2]) / 255f;
+				colors.Add (new Color (r, g, b));
+			}
+
+			return colors;
+		}
+
+		public void Save (List<Color> colors, string fileName)
+		{
+			StreamWriter writer = new StreamWriter (fileName);
+			writer.WriteLine ("JASC-PAL");
+			writer.WriteLine ("0100");
+			writer.WriteLine (colors.Count.ToString());
+
+			foreach (Color color in colors) {
+				writer.WriteLine ("{0} {1} {2}", (int) (color.R * 255), (int) (color.G * 255), (int) (color.B * 255));
+			}
+
+			writer.Close ();
+		}
+	}
+}
+

--- a/Pinta.Core/PaletteFormats/PaletteDescriptor.cs
+++ b/Pinta.Core/PaletteFormats/PaletteDescriptor.cs
@@ -1,0 +1,80 @@
+﻿//
+// PaletteDescriptor.cs
+//
+// Author:
+//       Matthias Mailänder
+//
+// Copyright (c) 2017 Matthias Mailänder
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Gtk;
+using System.Text;
+using Mono.Unix;
+
+namespace Pinta.Core
+{
+	public sealed class PaletteDescriptor
+	{
+		public string[] Extensions { get; private set; }
+
+		public IPaletteLoader Loader { get; private set; }
+
+		public IPaletteSaver Saver { get; private set; }
+
+		public FileFilter Filter { get; private set; }
+
+		public PaletteDescriptor (string displayPrefix, string[] extensions, IPaletteLoader loader, IPaletteSaver saver)
+		{
+			if (extensions == null || (loader == null && saver == null)) {
+				throw new ArgumentNullException ("Palette descriptor is initialized incorrectly");
+			}
+
+			this.Extensions = extensions;
+			this.Loader = loader;
+			this.Saver = saver;
+
+			FileFilter ff = new FileFilter ();
+			StringBuilder formatNames = new StringBuilder ();
+
+			foreach (string ext in extensions) {
+				if (formatNames.Length > 0)
+					formatNames.Append (", ");
+
+				string wildcard = string.Format ("*.{0}", ext);
+				ff.AddPattern (wildcard);
+				formatNames.Append (wildcard);
+			}
+
+			ff.Name = string.Format (Catalog.GetString ("{0} palette ({1})"), displayPrefix, formatNames);
+			this.Filter = ff;
+		}
+
+		public bool IsReadOnly ()
+		{
+			return Saver == null;
+		}
+
+		public bool IsWriteOnly ()
+		{
+			return Loader == null;
+		}
+	}
+}

--- a/Pinta.Core/PaletteFormats/PaletteFormats.cs
+++ b/Pinta.Core/PaletteFormats/PaletteFormats.cs
@@ -1,0 +1,61 @@
+﻿//
+// PaletteFormats.cs
+//
+// Author:
+//       Matthias Mailänder
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace Pinta.Core
+{
+	public class PaletteFormats
+	{
+		private List<PaletteDescriptor> formats;
+
+		public PaletteFormats ()
+		{
+			formats = new List<PaletteDescriptor> ();
+
+			PaintDotNetPalette pdnHandler = new PaintDotNetPalette ();
+			formats.Add (new PaletteDescriptor ("Paint.NET", new string[] { "txt", "TXT" }, pdnHandler, pdnHandler));
+
+			GimpPalette gimpHandler = new GimpPalette ();
+			formats.Add (new PaletteDescriptor ("GIMP", new string[] { "gpl", "GPL" }, gimpHandler, gimpHandler));
+		}
+
+		public IEnumerable<PaletteDescriptor> Formats { get { return formats; } }
+
+		public IPaletteLoader GetLoaderByFilename (string fileName)
+		{
+			string extension = System.IO.Path.GetExtension (fileName);
+			extension = NormalizeExtension (extension);
+			return formats.Where (p => p.Extensions.Contains (extension)).FirstOrDefault ().Loader;
+		}
+
+		private static string NormalizeExtension (string extension)
+		{
+			return extension.ToLowerInvariant ().TrimStart ('.').Trim ();
+		}
+	}
+}

--- a/Pinta.Core/PaletteFormats/PaletteFormats.cs
+++ b/Pinta.Core/PaletteFormats/PaletteFormats.cs
@@ -42,6 +42,9 @@ namespace Pinta.Core
 
 			GimpPalette gimpHandler = new GimpPalette ();
 			formats.Add (new PaletteDescriptor ("GIMP", new string[] { "gpl", "GPL" }, gimpHandler, gimpHandler));
+
+			PaintShopProPalette pspHandler = new PaintShopProPalette ();
+			formats.Add (new PaletteDescriptor ("PaintShop Pro", new string[] { "pal", "PAL" }, pspHandler, pspHandler));
 		}
 
 		public IEnumerable<PaletteDescriptor> Formats { get { return formats; } }

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -184,6 +184,12 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Widgets\MenuButton.cs" />
     <Compile Include="Widgets\ToolBarDropDownButton.cs" />
+    <Compile Include="PaletteFormats\PaletteDescriptor.cs" />
+    <Compile Include="PaletteFormats\IPaletteLoader.cs" />
+    <Compile Include="PaletteFormats\IPaletteSaver.cs" />
+    <Compile Include="PaletteFormats\PaintDotNetPalette.cs" />
+    <Compile Include="PaletteFormats\GimpPalette.cs" />
+    <Compile Include="PaletteFormats\PaletteFormats.cs" />
   </ItemGroup>
 
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -190,6 +190,7 @@
     <Compile Include="PaletteFormats\PaintDotNetPalette.cs" />
     <Compile Include="PaletteFormats\GimpPalette.cs" />
     <Compile Include="PaletteFormats\PaletteFormats.cs" />
+    <Compile Include="PaletteFormats\PaintShopProPalette.cs" />
   </ItemGroup>
 
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
[PaintShopPro.pal](https://raw.githubusercontent.com/Mailaender/ArtSrc/f3e8d2f33a34e1ce3258b3b8dd21543acd72a2d4/ra/palettes/PaintShopPro.pal) can be used as a test file.

I also made it easier for future palette file format additions and maybe even do this in addin form.