### PR TITLE
Update es.po - text breaks functionality

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -390,7 +390,7 @@ msgstr "Unidades de regla"
 #: ../Pinta.Core/Actions/ViewActions.cs:257
 #, csharp-format
 msgid "{0}%"
-msgstr "{0} %"
+msgstr "{0} %"
 
 #: ../Pinta.Core/Actions/WindowActions.cs:45
 msgid "Save All"


### PR DESCRIPTION
The current had an illegal character (0xC2) that breaks zooming, so that it just doesnt' work (neither Ctrl++ nor the buttons) when "es" is the current locale. See for example: https://bugs.launchpad.net/pinta/+bug/1464855

This fixes that by turning it into a space, that probably was what the translator meant.