### PR TITLE
Fix a rounding problem causing the wrong pixel to be clicked on when drawing lines when zoomed in

### DIFF
--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -204,7 +204,7 @@ namespace Pinta.Core
 			ScaleFactor sf = new ScaleFactor (PintaCore.Workspace.ImageSize.Width,
 			                                  PintaCore.Workspace.CanvasSize.Width);
 			Cairo.PointD pt = sf.ScalePoint (new Cairo.PointD (x - Offset.X, y - Offset.Y));
-			return new Cairo.PointD((int)pt.X, (int)pt.Y);
+			return new Cairo.PointD(pt.X, pt.Y);
 		}
 
 		/// <summary>


### PR DESCRIPTION
To see the problem, zoom in to 1600% and then try to draw a 1 pixel wide line with the line/curve tool with anti-aliasing off.
Without this fix the line will often start and end on a different pixel than the one you click.