### PR TITLE
added pkg required to build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Be sure to install [Gtk# for Windows](http://download.xamarin.com/GTKforWindows/
 
 Building Pinta requires the following software:
 
-`mono mono-xbuild automake autoconf libmono-cairo2.0-cil gtk-sharp2 yelp-tools`
+`mono mono-xbuild automake autoconf libmono-cairo2.0-cil gtk-sharp2 yelp-tools intltool`
 
 For Ubuntu 16.04 and above, install `mono-reference-assemblies-4.0`.
 


### PR DESCRIPTION
Else you can have an error like this after running autogen :
```
checking for mono... /usr/bin/mono
checking for MONO... yes
./configure: line 3567: syntax error near unexpected token `0.35.0,'
./configure: line 3567: `AC_PROG_INTLTOOL(0.35.0, no-xml)'
```