### PR TITLE
Update OSX Mono download URL

### DIFF
--- a/osx/pinta
+++ b/osx/pinta
@@ -23,7 +23,7 @@ REQUIRED_MINOR=8
  
 VERSION_TITLE="Cannot launch $APPNAME"
 VERSION_MSG="$APPNAME requires the Mono Framework version $REQUIRED_MAJOR.$REQUIRED_MINOR or later."
-DOWNLOAD_URL="http://www.go-mono.com/mono-downloads/download.html"
+DOWNLOAD_URL="http://www.mono-project.com/download/stable/"
  
 MONO_VERSION="$(mono --version | grep 'Mono JIT compiler version ' |  cut -f5 -d\ )"
 MONO_VERSION_MAJOR="$(echo $MONO_VERSION | cut -f1 -d.)"


### PR DESCRIPTION
I've updated DOWNLOAD_URL to point to the current stable download page for Mono. The go-mono URL returns a 404.