### PR TITLE
Fix parsing zoom level

### DIFF
--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -238,6 +238,7 @@ namespace Pinta.Core
 			text = text.Replace (format.PercentGroupSeparator, string.Empty);
 			text = text.Replace (format.PercentSymbol, string.Empty);
 			text = text.Replace (format.PercentDecimalSeparator, format.NumberDecimalSeparator);
+			text = text.Trim();
 
 			return double.TryParse (text,
 			                        NumberStyles.AllowDecimalPoint |


### PR DESCRIPTION
I'm not really sure why this is happening, but on linux (arch linux updotade version January 2019) I need to remove trailing whitespace in order to parse zoom level

```
$ mono --version
Mono JIT compiler version 5.16.0 (makepkg/bb3ae37d71a Sat Dec  8 13:21:35 CET 2018)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           __thread
	SIGSEGV:       altstack
	Notifications: epoll
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug 
	Interpreter:   yes
	LLVM:          supported, not enabled.
	GC:            sgen (concurrent by default)
```
Anyway this a a change that cannot cause any harm, so please consider to apply.

NOTE: Didn't see any report of this, so maybe this is only my machine, or this is stopping people to use pinta.