### PR TITLE
Hold control to resize selection when you're in the move-selected tool

### DIFF
--- a/Pinta.Tools/Tools/BaseTransformTool.cs
+++ b/Pinta.Tools/Tools/BaseTransformTool.cs
@@ -149,8 +149,8 @@ namespace Pinta.Tools
 
         protected override void OnKeyDown (Gtk.DrawingArea canvas, Gtk.KeyPressEventArgs args)
         {
-            rotateBySteps = (args.Event.Key == Gdk.Key.Shift_L);
-            is_scaling = (args.Event.Key == Gdk.Key.Control_L);
+            rotateBySteps = (args.Event.Key == Gdk.Key.Shift_L || args.Event.Key == Gdk.Key.Shift_R);
+            is_scaling = (args.Event.Key == Gdk.Key.Control_L || args.Event.Key == Gdk.Key.Control_R);
         }
 
         protected override void OnKeyUp (Gtk.DrawingArea canvas, Gtk.KeyReleaseEventArgs args)

--- a/Pinta.Tools/Tools/BaseTransformTool.cs
+++ b/Pinta.Tools/Tools/BaseTransformTool.cs
@@ -39,6 +39,7 @@ namespace Pinta.Tools
 		private bool is_dragging = false;
 		private bool is_rotating = false;
         private bool rotateBySteps = false;
+        private bool is_scaling = false;
         #endregion
 
         #region Constructor
@@ -115,12 +116,18 @@ namespace Pinta.Tools
 
 			transform.InitIdentity ();
 
-			if (is_rotating)
+			if (is_scaling)
 			{
-                if (rotateBySteps)
-                    angle = Utility.GetNearestStepAngle (angle, rotate_steps);
+				transform.Translate(center.X, center.Y);
+				transform.Scale( (cx1 + dx) / cx1, (cy1 + dy) / cy1 );
+				transform.Translate(-center.X, -center.Y);
+			}
+			else if (is_rotating)
+			{
+				if (rotateBySteps)
+					angle = Utility.GetNearestStepAngle (angle, rotate_steps);
 
-                transform.Translate(center.X, center.Y);
+				transform.Translate(center.X, center.Y);
 				transform.Rotate(-angle);
 				transform.Translate(-center.X, -center.Y);
 			}
@@ -143,11 +150,13 @@ namespace Pinta.Tools
         protected override void OnKeyDown (Gtk.DrawingArea canvas, Gtk.KeyPressEventArgs args)
         {
             rotateBySteps = (args.Event.Key == Gdk.Key.Shift_L);
+            is_scaling = (args.Event.Key == Gdk.Key.Control_L);
         }
 
         protected override void OnKeyUp (Gtk.DrawingArea canvas, Gtk.KeyReleaseEventArgs args)
         {
             rotateBySteps = false;
+            is_scaling = false;
         }
         #endregion
     }

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 			get { return "Tools.Move.png"; }
 		}
 		public override string StatusBarText {
-			get { return Catalog.GetString ("Left click and drag the selection to move selected content. Right click and drag the selection to rotate selected content. Hold Shift to rotate in steps."); }
+			get { return Catalog.GetString ("Left click and drag the selection to move selected content. Right click and drag the selection to rotate selected content. Hold Shift to rotate in steps. Hold Ctrl to scale."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
 			get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Move.png"), 0, 0); }

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 			get { return "Tools.Move.png"; }
 		}
 		public override string StatusBarText {
-			get { return Catalog.GetString ("Left click and drag the selection to move selected content. Right click and drag the selection to rotate selected content. Hold Shift to rotate in steps. Hold Ctrl to scale."); }
+			get { return Catalog.GetString ("Left click and drag the selection to move selected content. Hold Ctrl to scale instead of move. Right click and drag the selection to rotate selected content. Hold Shift to rotate in steps."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
 			get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.Move.png"), 0, 0); }

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -45,7 +45,7 @@ namespace Pinta.Tools
 			get { return "Tools.MoveSelection.png"; }
 		}
 		public override string StatusBarText {
-			get { return Catalog.GetString ("Left click and drag the selection to move selection outline. Right click and drag the selection to rotate selection outline. Hold Shift to rotate in steps."); }
+			get { return Catalog.GetString ("Left click and drag the selection to move selection outline. Right click and drag the selection to rotate selection outline. Hold Shift to rotate in steps. Hold Ctrl to scale."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
             get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.MoveSelection.png"), 0, 0); }

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -45,7 +45,7 @@ namespace Pinta.Tools
 			get { return "Tools.MoveSelection.png"; }
 		}
 		public override string StatusBarText {
-			get { return Catalog.GetString ("Left click and drag the selection to move selection outline. Right click and drag the selection to rotate selection outline. Hold Shift to rotate in steps. Hold Ctrl to scale."); }
+			get { return Catalog.GetString ("Left click and drag the selection to move selection outline. Hold Ctrl to scale instead of move. Right click and drag the selection to rotate selection outline. Hold Shift to rotate in steps."); }
 		}
 		public override Gdk.Cursor DefaultCursor {
             get { return new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Tools.MoveSelection.png"), 0, 0); }


### PR DESCRIPTION
Resizing the actual contents of a selection is something I noticed right away that was missing when compared to Paint.NET. This PR introduces behavior that doesn't mirror Paint.NET's resize handles directly, but it at least provides a way to resize the contents of the current selection without copying your selection in to a temporary file and resizing the whole canvas.