### PR TITLE
Add shortcut key for switching palette color

### DIFF
--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using Gtk;
 using Cairo;
 
 namespace Pinta.Core
@@ -69,6 +70,15 @@ namespace Pinta.Core
 		{
 			PrimaryColor = new Color (0, 0, 0);
 			SecondaryColor = new Color (1, 1, 1);
+		}
+
+		public void DoKeyRelease (object o, KeyReleaseEventArgs e)
+		{
+			if (e.Event.Key == Gdk.Key.X || e.Event.Key == Gdk.Key.x) {
+				Color temp = PintaCore.Palette.PrimaryColor;
+				PintaCore.Palette.PrimaryColor = PintaCore.Palette.SecondaryColor;
+				PintaCore.Palette.SecondaryColor = temp;
+			}
 		}
 
 		#region Protected Methods

--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -74,7 +74,7 @@ namespace Pinta.Core
 
 		public void DoKeyRelease (object o, KeyReleaseEventArgs e)
 		{
-			if (e.Event.Key == Gdk.Key.X || e.Event.Key == Gdk.Key.x) {
+			if (e.Event.Key.ToString().ToUpper() == "X") {
 				Color temp = PintaCore.Palette.PrimaryColor;
 				PintaCore.Palette.PrimaryColor = PintaCore.Palette.SecondaryColor;
 				PintaCore.Palette.SecondaryColor = temp;

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -214,6 +214,7 @@ namespace Pinta.Gui.Widgets
 		public void DoKeyReleaseEvent (object o, KeyReleaseEventArgs e)
 		{
 			PintaCore.Tools.CurrentTool.DoKeyRelease (this, e);
+			PintaCore.Palette.DoKeyRelease (this, e);
 		}
 		#endregion
 	}

--- a/Pinta.Gui.Widgets/Widgets/ColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPaletteWidget.cs
@@ -310,7 +310,12 @@ namespace Pinta.Gui.Widgets
 			string text = null;
 
 			if (swap_rect.ContainsPoint (x, y)) {
-				text = Catalog.GetString ("Click to switch between primary and secondary color.") + Catalog.GetString(" Shortcut key") + ": X";
+				text = string.Format (
+					"{0} {1}: {2}", 
+					Catalog.GetString ("Click to switch between primary and secondary color."), 
+					Catalog.GetString ("Shortcut key"), 
+					"X"
+				);
 			} else if (reset_rect.ContainsPoint (x, y)) {
 				text = Catalog.GetString ("Click to reset primary and secondary color.");
 			} else if (primary_rect.ContainsPoint (x, y)) {

--- a/Pinta.Gui.Widgets/Widgets/ColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPaletteWidget.cs
@@ -310,7 +310,7 @@ namespace Pinta.Gui.Widgets
 			string text = null;
 
 			if (swap_rect.ContainsPoint (x, y)) {
-				text = Catalog.GetString ("Click to switch between primary and secondary color.");
+				text = Catalog.GetString ("Click to switch between primary and secondary color.") + Catalog.GetString(" Shortcut key") + ": X";
 			} else if (reset_rect.ContainsPoint (x, y)) {
 				text = Catalog.GetString ("Click to reset primary and secondary color.");
 			} else if (primary_rect.ContainsPoint (x, y)) {


### PR DESCRIPTION
In Paint.net one can switch between primary and secondary color with the shortcut key **X**. When using Pinta, I'm really missing that shortcut, so I added it in!