### PR TITLE
[Prototype] Explore cleaned up UX.

### DIFF
--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -99,7 +99,7 @@ namespace Pinta.Core
 				ToPercent (0.05),
 				Translations.GetString ("Window")
 			};
-			ZoomComboBox = new ToolBarComboBox (90, DefaultZoomIndex(), true, ZoomCollection);
+			ZoomComboBox = new ToolBarComboBox (90, DefaultZoomIndex (), true, ZoomCollection) { Margin = 4 };
 
             // The toolbar is shown by default.
             ToolBar.Value = true;
@@ -151,12 +151,12 @@ namespace Pinta.Core
 			metric_menu.Append(Translations.GetString("Centimeters"), $"app.{RulerMetric.Name}(2)");
 		}
 
-		public void CreateToolBar (Gtk.Toolbar toolbar)
+		public void CreateToolBar (Statusbar toolbar)
 		{
-			toolbar.AppendItem (new Gtk.SeparatorToolItem ());
-			toolbar.AppendItem (ZoomOut.CreateToolBarItem ());
-			toolbar.AppendItem (ZoomComboBox);
 			toolbar.AppendItem (ZoomIn.CreateToolBarItem ());
+			toolbar.AppendItem (ZoomComboBox);
+			toolbar.AppendItem (ZoomOut.CreateToolBarItem ());
+			toolbar.AppendItem (new Gtk.SeparatorToolItem (), 10);
 		}
 		
 		public void RegisterHandlers ()

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -50,7 +50,13 @@ namespace Pinta.Core
 			tb.Insert (item, tb.NItems);
 		}
 
-		public static Gtk.ToolButton CreateToolBarItem (this Command action)
+        public static void AppendItem (this Statusbar tb, ToolItem item, uint padding = 0)
+        {
+            item.Show ();
+            tb.PackEnd (item, false, false, padding);
+        }
+
+        public static Gtk.ToolButton CreateToolBarItem (this Command action)
         {
 			var item = new ToolButton(null, action.ShortLabel ?? action.Label)
 			{

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -95,28 +95,19 @@ namespace Pinta.Core
 			toolbar.AppendItem (new SeparatorToolItem ());
 			toolbar.AppendItem (Image.CropToSelection.CreateToolBarItem ());
 			toolbar.AppendItem (Edit.Deselect.CreateToolBarItem ());
-			View.CreateToolBar (toolbar);
 
+		}
+		
+        public void CreateStatusBar (Statusbar toolbar)
+        {
+            View.CreateToolBar (toolbar);
 
-			toolbar.AppendItem (new SeparatorToolItem ());
-			toolbar.AppendItem (new ToolBarImage (Resources.Icons.CursorPosition));
+			//toolbar.AppendItem (new SeparatorToolItem ());
 
-			ToolBarLabel cursor = new ToolBarLabel ("  0, 0");
-
-			toolbar.AppendItem (cursor);
-
-			PintaCore.Chrome.LastCanvasCursorPointChanged += delegate {
-				Gdk.Point pt = PintaCore.Chrome.LastCanvasCursorPoint;
-				cursor.Text = string.Format ("  {0}, {1}", pt.X, pt.Y);
-			};
-
-
-			toolbar.AppendItem(new SeparatorToolItem());
-			toolbar.AppendItem(new ToolBarImage(Resources.Icons.ToolSelectRectangle));
-
-			ToolBarLabel SelectionSize = new ToolBarLabel("  0, 0");
+			ToolBarLabel SelectionSize = new ToolBarLabel ("  0, 0");
 
 			toolbar.AppendItem(SelectionSize);
+			toolbar.AppendItem(new ToolBarImage (Resources.Icons.ToolSelectRectangle));
 
 			PintaCore.Workspace.SelectionChanged += delegate
 			{
@@ -173,9 +164,22 @@ namespace Pinta.Core
 
 				SelectionSize.Text = string.Format("  {0}, {1}", xDiff, yDiff);
 			};
-		}
-		
-		public void RegisterHandlers ()
+
+
+			toolbar.AppendItem(new SeparatorToolItem(), 10);
+
+			ToolBarLabel cursor = new ToolBarLabel ("  0, 0");
+
+			toolbar.AppendItem (cursor);
+			toolbar.AppendItem (new ToolBarImage (Resources.Icons.CursorPosition));
+
+			PintaCore.Chrome.LastCanvasCursorPointChanged += delegate {
+				Gdk.Point pt = PintaCore.Chrome.LastCanvasCursorPoint;
+				cursor.Text = string.Format ("  {0}, {1}", pt.X, pt.Y);
+			};
+        }
+
+        public void RegisterHandlers ()
 		{
 			File.RegisterHandlers ();
 			Edit.RegisterHandlers ();

--- a/Pinta.Gui.Widgets/Widgets/SlimColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/SlimColorPaletteWidget.cs
@@ -1,0 +1,323 @@
+// 
+// ColorPaletteWidget.cs
+//  
+// Author:
+//       Jonathan Pobst <monkey@jpobst.com>
+// 
+// Copyright (c) 2010 Jonathan Pobst
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Cairo;
+using Pinta.Core;
+
+namespace Pinta.Gui.Widgets
+{
+	[System.ComponentModel.ToolboxItem (true)]
+	public class SlimColorPaletteWidget : Gtk.DrawingArea
+	{
+		private Rectangle primary_rect = new Rectangle (3, 3, 24, 24);
+		private Rectangle secondary_rect = new Rectangle (16, 16, 24, 24);
+		private Rectangle swap_rect = new Rectangle (26, 2, 15, 15);
+		private Rectangle reset_rect = new Rectangle (1, 27, 15, 15);
+
+        const int primarySecondaryAreaSize = 35;
+        const int swatchSize = 19;
+        const int swatchAreaMargin = 2;
+        const int swatchLeftMargin = 12;
+
+        OrientationEnum orientation;
+
+        const int defaultNumOfJRows = 2;
+        int jRows;
+        int iRows;
+
+		private Gdk.Pixbuf swap_icon;
+		private Gdk.Pixbuf reset_icon;
+		private Palette palette;
+
+        enum OrientationEnum
+        {
+            Horizontal,
+            Vertical
+        }
+
+		public SlimColorPaletteWidget ()
+		{
+			// Insert initialization code here.
+			this.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
+			
+			swap_icon = PintaCore.Resources.GetIcon ("ColorPalette.SwapIcon.png");
+			reset_icon = PintaCore.Resources.GetIcon ("ColorPalette.ResetIcon.png");
+			palette = PintaCore.Palette.CurrentPalette;
+
+			HasTooltip = true;
+			QueryTooltip += HandleQueryTooltip;
+		}
+
+		public void Initialize ()
+		{
+			PintaCore.Palette.PrimaryColorChanged += new EventHandler (Palette_ColorChanged);
+			PintaCore.Palette.SecondaryColorChanged += new EventHandler (Palette_ColorChanged);
+			PintaCore.Palette.CurrentPalette.PaletteChanged += new EventHandler (Palette_ColorChanged);
+		}
+		
+		private void Palette_ColorChanged (object sender, EventArgs e)
+		{
+			// Color change events may be received while the widget is minimized,
+			// so we only call Invalidate() if the widget is shown.
+			if (IsRealized)
+			{
+				Window.Invalidate ();
+			}
+		}
+
+		protected override bool OnButtonPressEvent (Gdk.EventButton ev)
+		{
+			if (swap_rect.ContainsPoint (ev.X, ev.Y)) {
+				Color temp = PintaCore.Palette.PrimaryColor;
+				PintaCore.Palette.PrimaryColor = PintaCore.Palette.SecondaryColor;
+				PintaCore.Palette.SecondaryColor = temp;
+				Window.Invalidate ();
+			} else if (reset_rect.ContainsPoint (ev.X, ev.Y)) {
+				PintaCore.Palette.PrimaryColor = new Color (0, 0, 0);
+				PintaCore.Palette.SecondaryColor = new Color (1, 1, 1);
+				Window.Invalidate ();
+			}
+
+			if (primary_rect.ContainsPoint (ev.X, ev.Y)) {
+                using (var ccd = new Gtk.ColorChooserDialog(Translations.GetString("Choose Primary Color"), PintaCore.Chrome.MainWindow))
+                {
+					ccd.UseAlpha = true;
+					ccd.Rgba = PintaCore.Palette.PrimaryColor.ToGdkRGBA();
+
+					var response = (Gtk.ResponseType)ccd.Run();
+					if (response == Gtk.ResponseType.Ok)
+						PintaCore.Palette.PrimaryColor = ccd.Rgba.ToCairoColor();
+				}
+			} else if (secondary_rect.ContainsPoint (ev.X, ev.Y)) {
+				using (var ccd = new Gtk.ColorChooserDialog(Translations.GetString("Choose Secondary Color"), PintaCore.Chrome.MainWindow))
+				{
+					ccd.UseAlpha = true;
+					ccd.Rgba = PintaCore.Palette.SecondaryColor.ToGdkRGBA();
+
+					var response = (Gtk.ResponseType)ccd.Run();
+					if (response == Gtk.ResponseType.Ok)
+						PintaCore.Palette.SecondaryColor = ccd.Rgba.ToCairoColor();
+				}
+			}
+			
+			int pal = PointToPalette ((int)ev.X, (int)ev.Y);
+			
+			if (pal >= 0) {
+				if (ev.Button == 3)
+					PintaCore.Palette.SecondaryColor = palette[pal];
+				else if (ev.Button == 1)
+					PintaCore.Palette.PrimaryColor = palette[pal];
+				else {
+					using (var ccd = new Gtk.ColorChooserDialog(Translations.GetString("Choose Palette Color"), PintaCore.Chrome.MainWindow))
+					{
+						ccd.UseAlpha = true;
+						ccd.Rgba = palette[pal].ToGdkRGBA();
+
+						var response = (Gtk.ResponseType)ccd.Run();
+						if (response == Gtk.ResponseType.Ok)
+							palette[pal] = ccd.Rgba.ToCairoColor();
+					}
+				}
+				
+				Window.Invalidate ();	
+			}
+				
+			// Insert button press handling code here.
+			return base.OnButtonPressEvent (ev);
+		}
+
+        protected override bool OnDrawn(Context g)
+        {
+			base.OnDrawn (g);
+
+            // Draw Primary / Secondary Area
+
+            g.FillRectangle (secondary_rect, PintaCore.Palette.SecondaryColor);
+        
+            g.DrawRectangle (new Rectangle (secondary_rect.X + 1, secondary_rect.Y + 1, secondary_rect.Width - 2, secondary_rect.Height - 2), new Color (1, 1, 1), 1);
+            g.DrawRectangle (secondary_rect, new Color (0, 0, 0), 1);
+
+            g.FillRectangle (primary_rect, PintaCore.Palette.PrimaryColor);
+            g.DrawRectangle (new Rectangle (primary_rect.X + 1, primary_rect.Y + 1, primary_rect.Width - 2, primary_rect.Height - 2), new Color (1, 1, 1), 1);
+            g.DrawRectangle (primary_rect, new Color (0, 0, 0), 1);
+
+            g.DrawPixbuf (swap_icon, swap_rect.Location ());
+            g.DrawPixbuf (reset_icon, reset_rect.Location ());
+
+            // Draw color swatches
+
+            int startI = primarySecondaryAreaSize;
+            int startJ = swatchAreaMargin;
+
+            int paletteIndex = 0;
+            for (int jRow = 0; jRow < jRows; jRow++)
+            {
+                for (int iRow = 0; iRow < iRows; iRow++)
+                {
+                    if (paletteIndex >= palette.Count)
+                        break;
+
+                    int x = (orientation == OrientationEnum.Horizontal) ? startI + iRow * swatchSize : startJ + jRow * swatchSize;
+                    int y = (orientation == OrientationEnum.Horizontal) ? startJ + jRow * swatchSize : startI + iRow * swatchSize;
+
+                    g.FillRectangle(new Rectangle(x + swatchLeftMargin, y, swatchSize, swatchSize), palette[paletteIndex]);
+
+                    paletteIndex++;
+                }
+            }
+			
+			return true;
+		}
+
+   //     protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
+   //     {
+			//minimum_width = natural_width = primarySecondaryAreaSize;
+   //     }
+
+        protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
+        {
+			minimum_height = natural_height = primarySecondaryAreaSize;
+        }
+
+        protected override void OnSizeAllocated(Gdk.Rectangle allocation)
+        {
+            base.OnSizeAllocated(allocation);
+
+            int iSpaceAvailable, jSpaceAvailable;
+
+            // The orientation is horizontal when the widget is wider than it is tall
+            // The direction of 'i' is the horizontal (left-to-right) when
+            // widget orientation is horizontal,
+            // and vertical (top-to-bottom) when widget orientation is vertical.
+            // 'j' is in the other direction.
+            if (Allocation.Width > Allocation.Height)
+            {
+                orientation = OrientationEnum.Horizontal;
+                iSpaceAvailable = Allocation.Width;
+                jSpaceAvailable = Allocation.Height;
+            }
+            else
+            {
+                orientation = OrientationEnum.Vertical;
+                iSpaceAvailable = Allocation.Height;
+                jSpaceAvailable = Allocation.Width;
+            }
+
+            iSpaceAvailable -= primarySecondaryAreaSize + swatchAreaMargin;
+            jSpaceAvailable -= 2 * swatchAreaMargin;
+
+            // Determine max number of rows that can be displayed in available area
+            int maxPossibleIRows = Math.Max(1, iSpaceAvailable / swatchSize);
+            int maxPossibleJRows = Math.Max(1, jSpaceAvailable / swatchSize);
+
+            int iRowsWithDefaultNumOfJRows = (int)Math.Ceiling((double)palette.Count / defaultNumOfJRows);
+
+            // Display palette in default configuration if space is available
+            // (it looks better)
+            if ((maxPossibleJRows >= defaultNumOfJRows) && (maxPossibleIRows >= iRowsWithDefaultNumOfJRows))
+            {
+                iRows = iRowsWithDefaultNumOfJRows;
+                jRows = defaultNumOfJRows;
+            }
+            else // Compress palette to fit within available space
+            {
+                iRows = (int)Math.Ceiling((double)palette.Count / maxPossibleJRows);
+                jRows = (int)Math.Ceiling((double)palette.Count / iRows);
+            }
+
+            //iRows = 15;
+        }
+		
+		private int PointToPalette (int x, int y)
+		{
+            int i, j;
+
+            if (orientation == OrientationEnum.Horizontal)
+            {
+                i = x;
+                j = y;
+            }
+            else
+            {
+                i = y;
+                j = x;
+            }
+
+            i -= primarySecondaryAreaSize;
+            j -= swatchAreaMargin;
+
+            i -= swatchLeftMargin;
+
+            // Determine the swatch position under the mouse pointer.
+            int iRow = i / swatchSize;
+            int jRow = j / swatchSize;
+
+            if ((i < 0) || (iRow >= iRows) || (j < 0) || (jRow >= jRows))
+            { // Mouse pointer is outside of swatch area
+                return -1;
+            }
+            else if ((jRow * iRows + iRow) >= palette.Count)
+            { // Mouse pointer is within swatch area, but not on valid color
+                return -1;
+            }
+            else
+            { // Return the palette color number under the mouse pointer
+                return jRow * iRows + iRow;
+            }
+		}
+
+		/// <summary>
+		/// Provide a custom tooltip based on the cursor location.
+		/// </summary>
+		private void HandleQueryTooltip (object o, Gtk.QueryTooltipArgs args)
+		{
+			int x = args.X;
+			int y = args.Y;
+			string text = null;
+
+			if (swap_rect.ContainsPoint (x, y)) {
+				text = string.Format (
+					"{0} {1}: {2}", 
+					Translations.GetString ("Click to switch between primary and secondary color."), 
+					Translations.GetString ("Shortcut key"), 
+					"X"
+				);
+			} else if (reset_rect.ContainsPoint (x, y)) {
+				text = Translations.GetString ("Click to reset primary and secondary color.");
+			} else if (primary_rect.ContainsPoint (x, y)) {
+				text = Translations.GetString ("Click to select primary color.");
+			} else if (secondary_rect.ContainsPoint (x, y)) {
+				text = Translations.GetString ("Click to select secondary color.");
+			} else if (PointToPalette (x, y) >= 0) {
+				text = Translations.GetString ("Left click to set primary color. Right click to set secondary color. Middle click to choose palette color.");
+			}
+
+			args.Tooltip.Text = text;
+			args.RetVal = (text != null);
+		}
+	}
+}

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -294,6 +294,7 @@ namespace Pinta
 			CreateMainMenu (window_shell);
 			CreateMainToolBar (window_shell);
 			CreateToolToolBar (window_shell);
+            CreateStatusBar ();
 
 			CreatePanels (window_shell);
 
@@ -373,10 +374,10 @@ namespace Pinta
 				main_toolbar.ToolbarStyle = ToolbarStyle.Icons;
 				main_toolbar.IconSize = IconSize.SmallToolbar;
 			}
-			
-			PintaCore.Actions.CreateToolBar (main_toolbar);
 
-			PintaCore.Chrome.InitializeMainToolBar (main_toolbar);
+            PintaCore.Actions.CreateToolBar (main_toolbar);
+
+            PintaCore.Chrome.InitializeMainToolBar (main_toolbar);
 		}
 		
 		private void CreateToolToolBar (WindowShell shell)
@@ -393,8 +394,56 @@ namespace Pinta
 
 			PintaCore.Chrome.InitializeToolToolBar (tool_toolbar);
 		}
-		
-		private void CreatePanels (WindowShell shell)
+
+        private void CreateStatusBar ()
+        {
+            var sb = window_shell.CreateStatusBar ("statusbar");
+
+            var palette = new SlimColorPaletteWidget ();
+            sb.PackStart (palette, true, true, 0);
+
+            PintaCore.Actions.CreateStatusBar (sb);
+
+            //var ws = Services.GetRequiredService<IWorkspaceService> ();
+            //var resources = Services.GetRequiredService<IResourceService> ();
+
+            ////var values = new[] { "3600%", "2400%", "1600%", "1200%", "800%", "700%", "600%", "500%", "400%", "300%", "200%", "175%", "150%", "125%", "100%", "66%", "50%", "33%", "25%", "16%", "12%", "8%", "5%" };
+            //var brush_width = new ToolBarComboBox<string> (14, Workspace.PresetZoomLevels) {
+            //    SuppressEvents = true
+            //};
+
+            //var brush_width_plus = new ToolBarButton (resources.GetIcon ("Toolbar.PlusButton.png"), "", Catalog.GetString ("Increase brush size"));
+            //brush_width_plus.Clicked += (o, e) => ws.ActiveWorkspace?.ZoomIn ();
+            //sb.PackEnd (brush_width_plus, false, false, 0);
+            //brush_width.Show ();
+            //sb.PackEnd (brush_width, false, false, 0);
+
+            //brush_width.SelectedItemChanged += (o, e) => {
+            //    var value = brush_width.GetSelectedValue ();
+            //    var zoom = double.Parse (value.TrimEnd ('%')) / 100;
+
+            //    if (ws.ActiveWorkspace != null)
+            //        ws.ActiveWorkspace.Scale = zoom;
+            //};
+
+            //var brush_width_minus = new ToolBarButton (resources.GetIcon ("Toolbar.MinusButton.png"), "", Catalog.GetString ("Decrease brush size"));
+
+            //brush_width_minus.Clicked += (o, e) => ws.ActiveWorkspace?.ZoomOut ();
+
+            //sb.PackEnd (brush_width_minus, false, false, 0);
+
+            //sb.PackEnd (new ToolBarLabel ($" {Catalog.GetString ("Zoom")}: "), false, false, 0);
+
+            //ws.ZoomChanged += (o, e) => {
+            //    var zoom = (int)((ws.ActiveWorkspace?.Scale ?? 1) * 100) + "%";
+            //    //var index = values.ToList ().IndexOf (zoom);
+
+            //    //if (index >= 0)
+            //    brush_width.SetSelectedValue (zoom);
+            //};
+        }
+
+        private void CreatePanels (WindowShell shell)
 		{
 			HBox panel_container = shell.CreateWorkspace ();
 
@@ -408,16 +457,22 @@ namespace Pinta
 			fact.Add ("Pinta.png", new Gtk.IconSet (PintaCore.Resources.GetIcon ("Pinta.png")));
 			fact.AddDefault ();
 
+
+
 			// Dock widget
 			dock = new Dock ();
 
+            var tbp = new ToolBoxWidget ();
+            tbp.WidthRequest = 36;
+            container.PackStart (tbp, false, false, 0);
+
 			// Toolbox pad
-			var toolboxpad = new ToolBoxPad ();
-			toolboxpad.Initialize (dock, this, show_pad);
+			//var toolboxpad = new ToolBoxPad ();
+			//toolboxpad.Initialize (dock, this, show_pad);
 		
 			// Palette pad
-			var palettepad = new ColorPalettePad ();
-			palettepad.Initialize (dock, this, show_pad);
+			//var palettepad = new ColorPalettePad ();
+			//palettepad.Initialize (dock, this, show_pad);
 
 			// Canvas pad
 			canvas_pad = new CanvasPad ();

--- a/Pinta/WindowShell.cs
+++ b/Pinta/WindowShell.cs
@@ -82,7 +82,26 @@ namespace Pinta
 			return workspace_layout;
 		}
 
-		public void AddDragDropSupport (params TargetEntry[] entries)
+        public Statusbar CreateStatusBar (string name)
+        {
+            var statusbar = new Statusbar {
+                Name = name,
+                Padding = 0,
+                Margin = 0
+            };
+
+            //statusbar.Child = null;
+            //statusbar.CenterWidget = null;
+            //statusbar.BaselinePosition = BaselinePosition.Top;
+            //statusbar.PackType = PackType.Start;
+            statusbar.Remove (statusbar.Children[0]);
+            shell_layout.PackEnd (statusbar, false, false, 0);
+            statusbar.Show ();
+
+            return statusbar;
+        }
+
+        public void AddDragDropSupport (params TargetEntry[] entries)
 		{
 			Gtk.Drag.DestSet (this, Gtk.DestDefaults.Motion | Gtk.DestDefaults.Highlight | Gtk.DestDefaults.Drop, entries, Gdk.DragAction.Copy);
 		}


### PR DESCRIPTION
**Prototype**

Given the GTK3 reboot of Pinta, I was playing around with cleaning up the UI.  A lot of it is inspired by Inkscape.  It feels like it is a bit clearer and cleaner, at the cost of making the location of the toolbox/palette fixed and the vertical height taken up by a status bar.

* Adds a status bar
* Moved common "status bar" items to status bar:
  * Zoom
  * Cursor position
  * Size information
* Moved palette to status bar
  * Swatches are a little larger for easier clicking
* Collapsed toolbox down to a single column
  * I think this should probably collapse several of the items into a single button with a drop down to select the actual tools.  ie: the 4 shapes would be a single button. (See image of Photoshop toolbox below.)
* My suggestion would be to kill the Images pad as well, as it's really just leftover from before we had tabs.

![prototype](https://user-images.githubusercontent.com/179295/101443833-e83d5f80-38e3-11eb-8eca-e95ea1882fd4.jpg)

![toolbox](https://user-images.githubusercontent.com/179295/101444363-f475ec80-38e4-11eb-8784-cf41e39857a1.jpg)

This code isn't commit quality, just enough to get the prototype working for discussion.