### PR TITLE
Target net5.0.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     # Run every week just to make sure the CI environment still works.
     - cron: '0 0 * * 0'
 
+env:
+  DOTNET_VERSION: 5.0.x
+
 # TODO - add Windows / Mac CI builds with the installers being built (see master branch).
 jobs:
   build-ubuntu:
@@ -19,11 +22,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # TODO - upload an artifact with the build results (see master branch)
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{env.DOTNET_VERSION}}
     - name: Build
-      run: dotnet build Pinta.sln
+      run: dotnet build Pinta.sln --configuration Release
     - name: Test
-      run: dotnet test Pinta.sln
+      run: dotnet test Pinta.sln --configuration Release
+    # TODO - upload an artifact with the build results (see master branch)
 
   build-macos:
     runs-on: macos-latest
@@ -31,10 +38,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     # dotnet and gettext are already available on the CI environment.
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{env.DOTNET_VERSION}}
     - name: Build
-      run: dotnet build Pinta.sln
+      run: dotnet build Pinta.sln --configuration Release
     - name: Test
-      run: dotnet test Pinta.sln
+      run: dotnet test Pinta.sln --configuration Release
     - name: Build Installer
       run: |
         cd osx
@@ -45,3 +56,18 @@ jobs:
         name: "Pinta.app.zip"
         path: osx/Pinta.app.zip
         if-no-files-found: error
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{env.DOTNET_VERSION}}
+    - name: Build
+      run: dotnet build Pinta.sln --configuration Release
+    - name: Test
+      run: dotnet test Pinta.sln --configuration Release
+    # TODO - upload an artifact with the build results (see master branch)

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Core</RootNamespace>
     <AssemblyName>Pinta.Core</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Pinta.Docking/Pinta.Docking.csproj
+++ b/Pinta.Docking/Pinta.Docking.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <RootNamespace>Pinta.Docking</RootNamespace>

--- a/Pinta.Effects/Pinta.Effects.csproj
+++ b/Pinta.Effects/Pinta.Effects.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Effects</RootNamespace>
     <AssemblyName>Pinta.Effects</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
+++ b/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Gui.Widgets</RootNamespace>
     <AssemblyName>Pinta.Gui.Widgets</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Pinta.Resources/Pinta.Resources.csproj
+++ b/Pinta.Resources/Pinta.Resources.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Resources</RootNamespace>
     <AssemblyName>Pinta.Resources</AssemblyName>
 

--- a/Pinta.Tools/Pinta.Tools.csproj
+++ b/Pinta.Tools/Pinta.Tools.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Tools</RootNamespace>
     <AssemblyName>Pinta.Tools</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Pinta/Pinta.csproj
+++ b/Pinta/Pinta.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Pinta</RootNamespace>
     <AssemblyName>Pinta</AssemblyName>

--- a/tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj
+++ b/tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Core.Tests</RootNamespace>
     <AssemblyName>Pinta.Core.Tests</AssemblyName>
     <IsPublishable>false</IsPublishable>


### PR DESCRIPTION
Given that .NET 5.0 is stable now and contains many performance improvements, we will probably want the eventual release to target it.

Also adds a Windows CI build.