### PR TITLE
Enable NRT for Pinta.Core and Pinta.Resources.

### DIFF
--- a/Pinta.Core/Actions/AddinActions.cs
+++ b/Pinta.Core/Actions/AddinActions.cs
@@ -30,7 +30,7 @@ namespace Pinta.Core
 {
 	public class AddinActions
 	{
-		private GLib.Menu addins_menu;
+		private GLib.Menu addins_menu = null!; // NRT - Set by RegisterActions
 
 		public Command AddinManager { get; private set; }
 

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -37,7 +37,7 @@ namespace Pinta.Core
 		public Command About { get; private set; }
 		public Command Exit { get; private set; }
 		
-		public event EventHandler BeforeQuit;
+		public event EventHandler? BeforeQuit;
 		
 		public AppActions ()
 		{

--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -39,22 +39,22 @@ namespace Pinta.Core
         {
             get { return Action.Name; }
         }
-        public ActivatedHandler Activated;
+        public ActivatedHandler? Activated;
         public void Activate()
         {
             Action.Activate(null);
         }
 
         public string Label { get; private set; }
-        public string ShortLabel { get; set; }
-        public string Tooltip { get; private set; }
-        public string IconName { get; private set; }
+        public string? ShortLabel { get; set; }
+        public string? Tooltip { get; private set; }
+        public string? IconName { get; private set; }
         public string FullName { get { return string.Format("app.{0}", Name); } }
         public bool IsImportant { get; set; } = false;
 
         public bool Sensitive { get { return Action.Enabled; } set { Action.Enabled = value; } }
 
-        public Command(string name, string label, string tooltip, string icon_name, GLib.Variant state = null)
+        public Command(string name, string label, string? tooltip, string? icon_name, GLib.Variant? state = null)
         {
             Action = new SimpleAction(name, null, state);
             Action.Activated += (o, args) =>
@@ -75,7 +75,7 @@ namespace Pinta.Core
 
     public class ToggleCommand : Command
     {
-        public ToggleCommand(string name, string label, string tooltip, string stock_id)
+        public ToggleCommand(string name, string label, string? tooltip, string? stock_id)
             : base(name, label, tooltip, stock_id, new GLib.Variant(false))
         {
             Activated += (o, args) =>
@@ -93,6 +93,6 @@ namespace Pinta.Core
         }
 
         public delegate void ToggledHandler(bool value);
-        public ToggledHandler Toggled;
+        public ToggledHandler? Toggled;
     }
 }

--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -52,7 +52,7 @@ namespace Pinta.Core
 		public Command ResetPalette { get; private set; }
 		public Command ResizePalette { get; private set; }
 		
-		private string lastPaletteDir = null;
+		private string? lastPaletteDir = null;
 		
 		public EditActions ()
 		{
@@ -406,7 +406,7 @@ namespace Pinta.Core
 
 				if (response == (int)Gtk.ResponseType.Ok)
 				{
-					var format = PintaCore.System.PaletteFormats.Formats.FirstOrDefault(f => f.Filter == fcd.Filter);
+					var format = PintaCore.System.PaletteFormats.Formats.First(f => f.Filter == fcd.Filter);
 
 					string finalFileName = fcd.Filename;
 
@@ -443,7 +443,7 @@ namespace Pinta.Core
 			doc.Workspace.Invalidate ();
 		}
 
-		private void WorkspaceActiveDocumentChanged (object sender, EventArgs e)
+		private void WorkspaceActiveDocumentChanged (object? sender, EventArgs e)
 		{
 			if (!PintaCore.Workspace.HasOpenDocuments) {
 				Undo.Sensitive = false;

--- a/Pinta.Core/Actions/FileActions.cs
+++ b/Pinta.Core/Actions/FileActions.cs
@@ -42,8 +42,8 @@ namespace Pinta.Core
 		public Command SaveAs { get; private set; }
 		public Command Print { get; private set; }
 		
-		public event EventHandler<ModifyCompressionEventArgs> ModifyCompression;
-		public event EventHandler<DocumentCancelEventArgs> SaveDocument;
+		public event EventHandler<ModifyCompressionEventArgs>? ModifyCompression;
+		public event EventHandler<DocumentCancelEventArgs>? SaveDocument;
 		
 		public FileActions ()
 		{

--- a/Pinta.Core/Actions/ImageActions.cs
+++ b/Pinta.Core/Actions/ImageActions.cs
@@ -284,7 +284,7 @@ namespace Pinta.Core
 		}
 #endregion
 
-		static void CropImageToRectangle (Document doc, Gdk.Rectangle rect, Path selection)
+		static void CropImageToRectangle (Document doc, Gdk.Rectangle rect, Path? selection)
 		{
 			if (rect.Width > 0 && rect.Height > 0)
 			{

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -129,7 +129,7 @@ namespace Pinta.Core
 		#endregion
 
 		#region Action Handlers
-		private void EnableOrDisableLayerActions (object sender, EventArgs e)
+		private void EnableOrDisableLayerActions (object? sender, EventArgs e)
 		{
 			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.UserLayers.Count > 1) {
 				PintaCore.Actions.Layers.DeleteLayer.Sensitive = true;

--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -196,7 +196,7 @@ namespace Pinta.Core
 			};
 		}
 
-		private string temp_zoom;
+		private string? temp_zoom;
 		private bool suspend_zoom_change;
 		
 		private void Entry_FocusInEvent (object o, Gtk.FocusInEventArgs args)
@@ -307,7 +307,7 @@ namespace Pinta.Core
 			}
 		}
 
-		private void HandlePintaCoreActionsViewZoomComboBoxComboBoxChanged (object sender, EventArgs e)
+		private void HandlePintaCoreActionsViewZoomComboBoxComboBoxChanged (object? sender, EventArgs e)
 		{
 			if (suspend_zoom_change)
 				return;

--- a/Pinta.Core/Actions/WindowActions.cs
+++ b/Pinta.Core/Actions/WindowActions.cs
@@ -33,7 +33,7 @@ namespace Pinta.Core
 {
 	public class WindowActions
 	{
-		private GLib.Menu doc_section;
+		private GLib.Menu doc_section = null!; // NRT - Set in RegisterActions
 		private static readonly string doc_action_id = "active_document";
 		private GLib.SimpleAction active_doc_action;
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -49,9 +49,9 @@ namespace Pinta.Core
 			internal ThreadPriority ThreadPriority { get; set; }
 		}		
 		
-		BaseEffect effect;
-		Cairo.ImageSurface source_surface;
-		Cairo.ImageSurface dest_surface;
+		BaseEffect? effect;
+		Cairo.ImageSurface? source_surface;
+		Cairo.ImageSurface? dest_surface;
 		Gdk.Rectangle render_bounds;
 		
 		bool is_rendering;
@@ -164,7 +164,7 @@ namespace Pinta.Core
 		
 		protected abstract void OnUpdate (double progress, Gdk.Rectangle updatedBounds);
 		
-		protected abstract void OnCompletion (bool canceled, Exception[] exceptions);
+		protected abstract void OnCompletion (bool canceled, Exception[]? exceptions);
 		
 		internal void Dispose ()
 		{
@@ -248,22 +248,23 @@ namespace Pinta.Core
 		// Runs on a background thread.
 		void RenderTile (int renderId, int threadId, int tileIndex)
 		{
-			Exception exception = null;
+			Exception? exception = null;
 			Gdk.Rectangle bounds = new Gdk.Rectangle ();
 			
 			try {
 				
 				bounds = GetTileBounds (tileIndex);
-				
+
+				// NRT - These are set in Start () before getting here
 				if (!cancel_render_flag) {
-					dest_surface.Flush ();
-					effect.Render (source_surface, dest_surface, new [] { bounds });
+					dest_surface!.Flush ();
+					effect!.Render (source_surface!, dest_surface, new [] { bounds });
 					dest_surface.MarkDirty (bounds.ToCairoRectangle ());
 				}
 				
 			} catch (Exception ex) {		
 				exception = ex;
-				Debug.WriteLine ("AsyncEffectRenderer Error while rendering effect: " + effect.Name + " exception: " + ex.Message + "\n" + ex.StackTrace);
+				Debug.WriteLine ("AsyncEffectRenderer Error while rendering effect: " + effect!.Name + " exception: " + ex.Message + "\n" + ex.StackTrace);
 			}
 			
 			// Ignore completions of tiles after a cancel or from a previous render.

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -44,19 +44,19 @@ namespace Pinta.Core
 		protected static Cairo.Point point_empty = new Cairo.Point (-500, -500);
 
 	    
-		protected ToggleToolButton tool_item;
-		protected ToolItem tool_label;
-		protected ToolItem tool_image;
-		protected ToolItem tool_sep;
-		protected ToolBarDropDownButton antialiasing_button;
-		private ToolBarItem aaOn, aaOff;
-		protected ToolBarDropDownButton alphablending_button;
-		private ToolBarItem abOn, abOff;
-		public event MouseHandler MouseMoved;
-		public event MouseHandler MousePressed;
-		public event MouseHandler MouseReleased;
+		protected ToggleToolButton? tool_item;
+		protected ToolItem? tool_label;
+		protected ToolItem? tool_image;
+		protected ToolItem? tool_sep;
+		protected ToolBarDropDownButton? antialiasing_button;
+		private ToolBarItem? aaOn, aaOff;
+		protected ToolBarDropDownButton? alphablending_button;
+		private ToolBarItem? abOn, abOff;
+		public event MouseHandler? MouseMoved;
+		public event MouseHandler? MousePressed;
+		public event MouseHandler? MouseReleased;
 
-        public Cursor CurrentCursor { get; private set; }
+        public Cursor? CurrentCursor { get; private set; }
 
 		protected BaseTool ()
 		{
@@ -71,7 +71,7 @@ namespace Pinta.Core
 		public virtual string StatusBarText { get { return string.Empty; } }
 		public virtual ToggleToolButton ToolItem { get { if (tool_item == null) tool_item = CreateToolButton (); return tool_item; } }
 		public virtual bool Enabled { get { return true; } }
-		public virtual Gdk.Cursor DefaultCursor { get { return null; } }
+		public virtual Gdk.Cursor? DefaultCursor { get { return null; } }
 		public virtual Gdk.Key ShortcutKey { get { return (Gdk.Key)0; } }
 
 		//Whether or not the tool is an editable ShapeTool.
@@ -83,7 +83,7 @@ namespace Pinta.Core
 			{
                 return (antialiasing_button != null) &&
                         ShowAntialiasingButton &&
-                        (bool)antialiasing_button.SelectedItem.Tag;
+			antialiasing_button.SelectedItem is ToolBarItem tbi && tbi.Tag is bool toggle && toggle == true;
 			}
 
 			set
@@ -101,7 +101,7 @@ namespace Pinta.Core
 			{
 				return alphablending_button != null &&
 					   ShowAlphaBlendingButton &&
-					   (bool)alphablending_button.SelectedItem.Tag;
+					   alphablending_button.SelectedItem is ToolBarItem tbi && tbi.Tag is bool toggle && toggle == true;
 			}
 			set
 			{
@@ -325,7 +325,7 @@ namespace Pinta.Core
 			return tool_item;
 		}
 		
-		public void SetCursor (Gdk.Cursor cursor)
+		public void SetCursor (Gdk.Cursor? cursor)
 		{
             CurrentCursor = cursor;
 
@@ -451,7 +451,7 @@ namespace Pinta.Core
 			tb.AppendItem (antialiasing_button);
 		}
 
-		private void Workspace_ActiveDocumentChanged (object sender, EventArgs e)
+		private void Workspace_ActiveDocumentChanged (object? sender, EventArgs e)
 		{
             if (PintaCore.Tools.CurrentTool == this)
 			    SetCursor (DefaultCursor);

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -41,7 +41,7 @@ namespace Pinta.Core
 	// Workspace - Data about Pinta's state for the image
 	public class Document
 	{
-		private string filename;
+		private string filename = string.Empty;
 		private bool is_dirty;
 		private int layer_name_int = 2;
 		private int current_layer = -1;
@@ -52,7 +52,7 @@ namespace Pinta.Core
 		// The layer used for selections
 		private Layer selection_layer;
 
-		private DocumentSelection selection;
+		private DocumentSelection selection = null!; // NRT - Set by constructor via Selection property
 		public DocumentSelection Selection
 		{
 			get { return selection; }
@@ -104,11 +104,11 @@ namespace Pinta.Core
 		public int CurrentUserLayerIndex {
 			get { return current_layer; }
 		}
-		
+
 		/// <summary>
 		/// Just the file name, like "dog.jpg".
 		/// </summary>
-		public string Filename { 
+		public string Filename {
 			get { return filename; }
 			set {
 				if (filename != value) {
@@ -146,7 +146,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Just the directory name, like "C:\MyPictures".
 		/// </summary>
-		public string Pathname { get; set; }
+		public string Pathname { get; set; } = string.Empty;
 
 		/// <summary>
 		/// Directory and file name, like "C:\MyPictures\dog.jpg".
@@ -158,7 +158,7 @@ namespace Pinta.Core
 					Pathname = string.Empty;
 					Filename = string.Empty;
 				} else {
-					Pathname = System.IO.Path.GetDirectoryName (value);
+					Pathname = System.IO.Path.GetDirectoryName (value) ?? string.Empty;
 					Filename = System.IO.Path.GetFileName (value);
 				}
 			}
@@ -792,7 +792,7 @@ namespace Pinta.Core
 			PintaCore.Tools.Commit ();
 
 			// Don't dispose this, as we're going to give it to the history
-			Gdk.Pixbuf cbImage = null;
+			Gdk.Pixbuf? cbImage = null;
 
 			if (cb.WaitIsImageAvailable ()) {
 				cbImage = cb.WaitForImage ();
@@ -925,7 +925,7 @@ namespace Pinta.Core
 		#endregion
 
 		#region Private Methods
-		private void RaiseLayerPropertyChangedEvent (object sender, PropertyChangedEventArgs e)
+		private void RaiseLayerPropertyChangedEvent (object? sender, PropertyChangedEventArgs e)
 		{
 			PintaCore.Layers.RaiseLayerPropertyChangedEvent (sender, e);
 		}
@@ -938,10 +938,10 @@ namespace Pinta.Core
 		#endregion
 
 		#region Public Events
-		public event EventHandler IsDirtyChanged;
-		public event EventHandler Renamed;
-		public event LayerCloneEvent LayerCloned;
-		public event EventHandler SelectionChanged;
+		public event EventHandler? IsDirtyChanged;
+		public event EventHandler? Renamed;
+		public event LayerCloneEvent? LayerCloned;
+		public event EventHandler? SelectionChanged;
 
 		#endregion
 	}

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -34,7 +34,7 @@ namespace Pinta.Core
 {
 	public class DocumentSelection : IDisposable
 	{
-		private Path selection_path;
+		private Path? selection_path;
 
 		public List<List<IntPoint>> SelectionPolygons = new List<List<IntPoint>>();
 		public Clipper SelectionClipper = new Clipper();
@@ -70,7 +70,7 @@ namespace Pinta.Core
 		    }
 		}
 
-	    public event EventHandler SelectionModified;
+	    public event EventHandler? SelectionModified;
 
         /// <summary>
         /// Indicate that the selection has changed.

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -47,12 +47,12 @@ namespace Pinta.Core
 		}
 
         #region Public Events
-        public event EventHandler<CanvasInvalidatedEventArgs> CanvasInvalidated;
-        public event EventHandler CanvasSizeChanged;
-        #endregion
+        public event EventHandler<CanvasInvalidatedEventArgs>? CanvasInvalidated;
+        public event EventHandler? CanvasSizeChanged;
+		#endregion
 
 		#region Public Properties
-        public Gtk.DrawingArea Canvas { get; set; }
+		public Gtk.DrawingArea Canvas { get; set; } = null!; // NRT - This is set soon after creation
 
 		public bool CanvasFitsInWindow {
 			get {

--- a/Pinta.Core/Classes/DocumentWorkspaceHistory.cs
+++ b/Pinta.Core/Classes/DocumentWorkspaceHistory.cs
@@ -49,7 +49,7 @@ namespace Pinta.Core
 			get { return historyPointer; }
 		}
 		
-		public BaseHistoryItem Current {
+		public BaseHistoryItem? Current {
 			get { 
 				if (historyPointer > -1 && historyPointer < history.Count)
 					return history[historyPointer]; 

--- a/Pinta.Core/Classes/GradientRenderer.cs
+++ b/Pinta.Core/Classes/GradientRenderer.cs
@@ -87,9 +87,6 @@ namespace Pinta.Core
 					endAlpha = this.endColor.A;
 				}
 				
-				this.lerpAlphas = new byte[256];
-				this.lerpColors = new ColorBgra[256];
-				
 				for (int i = 0; i < 256; ++i) {
 					byte a = (byte)i;
 					this.lerpColors[a] = ColorBgra.Blend (this.startColor, this.endColor, a);
@@ -224,6 +221,8 @@ namespace Pinta.Core
 		{
 			this.normalBlendOp = normalBlendOp;
 			this.alphaOnly = alphaOnly;
+			this.lerpAlphas = new byte[256];
+			this.lerpColors = new ColorBgra[256];
 		}
 	}
 }

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -39,10 +39,6 @@ namespace Pinta.Core
 		private string name;
 		private BlendMode blend_mode;
 		private Matrix transform = new Matrix();
-
-		public Layer () : this (null)
-		{
-		}
 		
 		public Layer (ImageSurface surface) : this (surface, false, 1f, "")
 		{
@@ -277,7 +273,7 @@ namespace Pinta.Core
 			Surface = dest;
 		}
 
-		public virtual void Crop (Gdk.Rectangle rect, Path selection)
+		public virtual void Crop (Gdk.Rectangle rect, Path? selection)
 		{
 			ImageSurface dest = new ImageSurface (Format.Argb32, rect.Width, rect.Height);
 

--- a/Pinta.Core/Classes/ObservableObject.cs
+++ b/Pinta.Core/Classes/ObservableObject.cs
@@ -36,7 +36,7 @@ namespace Pinta.Core
 		{
 		}
 				
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 				
 		protected void SetValue<T> (string propertyName, ref T member, T value)
 		{

--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -36,7 +36,7 @@ namespace Pinta.Core
 {
 	public sealed class Palette
 	{
-		public event EventHandler PaletteChanged;
+		public event EventHandler? PaletteChanged;
 	
 		private List<Color> colors;
 

--- a/Pinta.Core/Classes/Re-editable/ReEditableLayer.cs
+++ b/Pinta.Core/Classes/Re-editable/ReEditableLayer.cs
@@ -34,7 +34,7 @@ namespace Pinta.Core
 {
 	public class ReEditableLayer
 	{
-		Layer actualLayer;
+		Layer? actualLayer;
 
 		//Whether or not the actualLayer has already been setup.
 		private bool isLayerSetup = false;
@@ -54,7 +54,7 @@ namespace Pinta.Core
 					SetupLayer();
 				}
 
-				return actualLayer;
+				return actualLayer!; // NRT - Set in SetupLayer
 			}
 
 			set

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -26,7 +26,7 @@ namespace Pinta.Core
         private TextPosition selectionStart;
 
         public TextAlignment Alignment { get; set; }
-        public string FontFace { get; private set; }
+        public string FontFace { get; private set; } = null!; // NRT - I don't know if this can be null or not.
         public int FontSize { get; private set; }
         public bool Bold { get; private set; }
         public bool Italic { get; private set; }
@@ -37,7 +37,7 @@ namespace Pinta.Core
 		public TextMode State;
         public Point Origin { get; set; }
 
-        public event EventHandler Modified;
+        public event EventHandler? Modified;
 
         public TextEngine ()
             : this (new List<string> () { string.Empty })
@@ -549,7 +549,7 @@ namespace Pinta.Core
 		
         private void OnModified ()
         {
-            EventHandler handler = Modified;
+            EventHandler? handler = Modified;
             if (handler != null)
                 handler (this, EventArgs.Empty);
         }

--- a/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
@@ -35,7 +35,7 @@ namespace Pinta.Core
 {
     public class TextLayout
     {
-        private TextEngine engine;
+        private TextEngine engine = null!; // NRT - Not sure how this is set, but all callers assume it is not-null
 
         public TextEngine Engine {
             get { return engine; }
@@ -125,9 +125,9 @@ namespace Pinta.Core
 			return new Point (x, y);
 		}
 
-        private void OnEngineModified (object sender, EventArgs e)
+        private void OnEngineModified (object? sender, EventArgs e)
         {
-			string markup = SecurityElement.Escape (engine.ToString ());
+			string? markup = SecurityElement.Escape (engine.ToString ());
 
 			if (engine.Underline)
 				markup = string.Format ("<u>{0}</u>", markup);

--- a/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
@@ -33,7 +33,7 @@ namespace Pinta.Core
         }
 
         #region Operators
-        public override bool Equals (object obj)
+        public override bool Equals (object? obj)
         {
             return obj is TextPosition && this == (TextPosition)obj;
         }

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -110,7 +110,7 @@ namespace Pinta.Core
 			return (lhs.numerator * rhs.denominator) >= (rhs.numerator * lhs.denominator);
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			if (obj is ScaleFactor) {
 				ScaleFactor rhs = (ScaleFactor)obj;

--- a/Pinta.Core/Classes/SelectionModeHandler.cs
+++ b/Pinta.Core/Classes/SelectionModeHandler.cs
@@ -33,8 +33,8 @@ namespace Pinta.Core
 {
     public class SelectionModeHandler
     {
-        private ToolBarLabel selection_label;
-        private ToolBarComboBox selection_combo_box;
+        private ToolBarLabel? selection_label;
+        private ToolBarComboBox? selection_combo_box;
 
         private CombineMode selected_mode;
         private Dictionary<string, CombineMode> combine_modes;

--- a/Pinta.Core/Classes/SurfaceDiff.cs
+++ b/Pinta.Core/Classes/SurfaceDiff.cs
@@ -75,7 +75,7 @@ namespace Pinta.Core
 			this.pixels = pixels;
 		}
 
-		public static unsafe SurfaceDiff Create (ImageSurface original, ImageSurface updated_surf, bool force = false)
+		public static unsafe SurfaceDiff? Create (ImageSurface original, ImageSurface updated_surf, bool force = false)
 		{
 			if (original.Width != updated_surf.Width || original.Height != updated_surf.Height) {
 				// If the surface changed size, only throw an error if the user forced the use of a diff.

--- a/Pinta.Core/Classes/Translations.cs
+++ b/Pinta.Core/Classes/Translations.cs
@@ -30,7 +30,7 @@ namespace Pinta.Core
 {
     public static class Translations
     {
-        private static ICatalog catalog;
+        private static ICatalog catalog = null!; // NRT - Always set by Init
 
         public static void Init(string domain, string locale_dir)
         {

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -44,21 +44,14 @@ namespace Pinta.Core
 		public ReEditableLayer TextLayer;
 
 		//Call the base class constructor and setup the engines.
-		public UserLayer(ImageSurface surface) : base(surface)
+		public UserLayer(ImageSurface surface) : this(surface, false, 1f, "")
 		{
-			setupUserLayer();
 		}
 
 		//Call the base class constructor and setup the engines.
 		public UserLayer(ImageSurface surface, bool hidden, double opacity, string name) : base(surface, hidden, opacity, name)
 		{
-			setupUserLayer();
-		}
-
-		private void setupUserLayer()
-		{
 			tEngine = new TextEngine();
-
 			TextLayer = new ReEditableLayer(this);
 		}
 
@@ -93,7 +86,7 @@ namespace Pinta.Core
             ApplyTransform (xform, new_size);
         }
 
-        public override void Crop (Gdk.Rectangle rect, Path selection)
+        public override void Crop (Gdk.Rectangle rect, Path? selection)
 		{
 			base.Crop (rect, selection);
 

--- a/Pinta.Core/Effects/BaseEffect.cs
+++ b/Pinta.Core/Effects/BaseEffect.cs
@@ -58,7 +58,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns the keyboard shortcut for this adjustment. Only affects adjustments, not effects. Default is no shortcut.
 		/// </summary>
-		public virtual string AdjustmentMenuKey { get { return null; } }
+		public virtual string? AdjustmentMenuKey { get { return null; } }
 
 		/// <summary>
 		/// Returns the modifier(s) to the keyboard shortcut. Only affects adjustments, not effects. Default is Primary+Shift.
@@ -73,7 +73,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// The user configurable data this effect uses.
 		/// </summary>
-		public EffectData EffectData { get; protected set; }
+		public EffectData? EffectData { get; protected set; }
 
 		/// <summary>
 		/// Launches the configuration dialog for this effect/adjustment.
@@ -161,7 +161,7 @@ namespace Pinta.Core
 			var effect = (BaseEffect) this.MemberwiseClone ();
 
 			if (effect.EffectData != null)
-				effect.EffectData = EffectData.Clone ();
+				effect.EffectData = EffectData?.Clone ();
 
 			return effect;
 		}		

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -164,7 +164,7 @@ namespace Pinta.Core
         /// <summary>
         /// Compares two ColorBgra instance to determine if they are equal.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             
             if (obj != null && obj is ColorBgra && ((ColorBgra)obj).Bgra == this.Bgra)

--- a/Pinta.Core/Effects/Histogram.cs
+++ b/Pinta.Core/Effects/Histogram.cs
@@ -65,7 +65,7 @@ namespace Pinta.Core
             }
         }
 
-        public event EventHandler HistogramChanged;
+        public event EventHandler? HistogramChanged;
         protected void OnHistogramUpdated()
         {
             if (HistogramChanged != null)
@@ -74,7 +74,7 @@ namespace Pinta.Core
             }
         }
 
-        protected ColorBgra[] visualColors;
+        protected ColorBgra[] visualColors = null!; // NRT - Set by constructor of only subclass
         public ColorBgra GetVisualColor(int channel)
         {
             return visualColors[channel];

--- a/Pinta.Core/Effects/HsvColor.cs
+++ b/Pinta.Core/Effects/HsvColor.cs
@@ -39,9 +39,9 @@ namespace Pinta.Core
             return !(lhs == rhs);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return this == (HsvColor)obj;
+            return obj is HsvColor hsv && this == hsv;
         }
 
         public override int GetHashCode()

--- a/Pinta.Core/Effects/Scanline.cs
+++ b/Pinta.Core/Effects/Scanline.cs
@@ -48,7 +48,7 @@ namespace Pinta.Core
             }
         }
         
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is Scanline)
             {

--- a/Pinta.Core/Effects/SplineInterpolator.cs
+++ b/Pinta.Core/Effects/SplineInterpolator.cs
@@ -14,7 +14,7 @@ namespace Pinta.Core
     public sealed class SplineInterpolator
     {
         private SortedList<double, double> points = new SortedList<double, double>();
-        private double[] y2;
+        private double[]? y2;
 
         public int Count
         {
@@ -74,7 +74,7 @@ namespace Pinta.Core
             
             // Cubic spline polynomial is now evaluated.
             return a * ya[klo] + b * ya[khi] + 
-                ((a * a * a - a) * y2[klo] + (b * b * b - b) * y2[khi]) * (h * h) / 6.0;
+                ((a * a * a - a) * y2![klo] + (b * b * b - b) * y2[khi]) * (h * h) / 6.0; // NRT - y2 is set above by PreCompute ()
         }
 
         private void PreCompute()

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -242,8 +242,12 @@ namespace Pinta.Core
 		
 		public static string GetStaticName (Type type)
 		{
-			PropertyInfo pi = type.GetProperty ("StaticName", BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty);
-			return (string)pi.GetValue (null, null);
+			var pi = type.GetProperty ("StaticName", BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty);
+			
+			if (pi != null)
+				return (pi.GetValue (null, null) as string) ?? type.Name;
+
+			return type.Name;
 		}
 
 		public static byte FastScaleByteByByte (byte a, byte b)
@@ -255,7 +259,7 @@ namespace Pinta.Core
 
 		public static Gdk.Point[] GetLinePoints(Gdk.Point first, Gdk.Point second)
         {
-            Gdk.Point[] coords = null;
+            Gdk.Point[]? coords = null;
 
             int x1 = first.X;
             int y1 = first.Y;

--- a/Pinta.Core/EventArgs/LivePreviewEndedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewEndedEventArgs.cs
@@ -36,7 +36,7 @@ namespace Pinta.Core
 	
 	public class LivePreviewEndedEventArgs : EventArgs
 	{
-		public LivePreviewEndedEventArgs (RenderStatus status, Exception exception)
+		public LivePreviewEndedEventArgs (RenderStatus status, Exception? exception)
 		{
 			this.Status = status;
 			this.Exception = exception;
@@ -44,6 +44,6 @@ namespace Pinta.Core
 		
 		public RenderStatus Status { get; private set; }
 		
-		public Exception Exception { get; private set; }
+		public Exception? Exception { get; private set; }
 	}	
 }

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -135,9 +135,13 @@ namespace Pinta.Core
 		/// <summary>
 		/// Update the image preview widget of a FileChooserDialog
 		/// </summary>
-		private static void OnUpdateImagePreview (object sender, EventArgs e)
+		private static void OnUpdateImagePreview (object? sender, EventArgs e)
 		{
-			FileChooserDialog dialog = (FileChooserDialog)sender;
+			FileChooserDialog? dialog = (FileChooserDialog?)sender;
+
+			if (dialog is null)
+				return;
+
 			Image preview = (Image)dialog.PreviewWidget;
 
 			if (preview.Pixbuf != null) {
@@ -145,10 +149,10 @@ namespace Pinta.Core
 			}
 
 			try {
-				Gdk.Pixbuf pixbuf = null;
+				Gdk.Pixbuf? pixbuf = null;
 				string filename = dialog.PreviewFilename;
 
-				IImageImporter importer = PintaCore.System.ImageFormats.GetImporterByFile (filename);
+				IImageImporter? importer = PintaCore.System.ImageFormats.GetImporterByFile (filename);
 
 				if (importer != null) {
 					pixbuf = importer.LoadThumbnail (filename, MaxPreviewWidth, MaxPreviewHeight, dialog);
@@ -182,13 +186,13 @@ namespace Pinta.Core
 
         public static int GetItemCount (this ComboBox combo)
         {
-            return (combo.Model as ListStore).IterNChildren ();
+            return ((ListStore)combo.Model).IterNChildren ();
         }
 
         public static int FindValue<T> (this ComboBox combo, T value)
         {
             for (var i = 0; i < combo.GetItemCount (); i++)
-                if (combo.GetValueAt<T> (i).Equals (value))
+                if (combo.GetValueAt<T> (i)?.Equals (value) == true)
                     return i;
 
             return -1;
@@ -199,7 +203,7 @@ namespace Pinta.Core
             TreeIter iter;
             
             // Set the tree iter to the correct row
-            (combo.Model as ListStore).IterNthChild (out iter, index);
+            ((ListStore)combo.Model).IterNthChild (out iter, index);
 
             // Retrieve the value of the first column at that row
             return (T)combo.Model.GetValue (iter, 0);
@@ -210,7 +214,7 @@ namespace Pinta.Core
             TreeIter iter;
 
             // Set the tree iter to the correct row
-            (combo.Model as ListStore).IterNthChild (out iter, index);
+            ((ListStore)combo.Model).IterNthChild (out iter, index);
 
             // Set the value of the first column at that row
             combo.Model.SetValue (iter, 0, value);

--- a/Pinta.Core/Extensions/ToolBarFontComboBox.cs
+++ b/Pinta.Core/Extensions/ToolBarFontComboBox.cs
@@ -32,7 +32,7 @@ namespace Pinta.Core
 {
 	public class ToolBarFontComboBox : ToolBarComboBox
 	{
-		private CellRendererText cell_renderer;
+		private CellRendererText? cell_renderer;
 
 		public ToolBarFontComboBox (int width, int activeIndex, params string[] contents) : base (width, activeIndex, false, contents)
 		{
@@ -55,7 +55,7 @@ namespace Pinta.Core
 		{
 			string fontName = (string)model.GetValue (iter, 0);
 
-			CellRendererText cell = renderer as CellRendererText;
+			CellRendererText cell = (CellRendererText)renderer;
 
 			cell.Text = fontName;
 			cell.Font = string.Format ("{0} 10", fontName);

--- a/Pinta.Core/Extensions/ToolBarLabel.cs
+++ b/Pinta.Core/Extensions/ToolBarLabel.cs
@@ -41,8 +41,8 @@ namespace Pinta.Core
 		}
 
 		public string Text {
-			get { return (Child as Label).Text; }
-			set { (Child as Label).Text = value; }
+			get { return ((Label)Child).Text; }
+			set { ((Label)Child).Text = value; }
 		}
 	}
 }

--- a/Pinta.Core/HistoryItems/AddLayerHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/AddLayerHistoryItem.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core
 	public class AddLayerHistoryItem : BaseHistoryItem
 	{
 		private int layer_index;
-		private UserLayer layer;
+		private UserLayer? layer;
 
 		public AddLayerHistoryItem (string icon, string text, int newLayerIndex) : base (icon, text)
 		{
@@ -48,10 +48,10 @@ namespace Pinta.Core
 
 		public override void Redo ()
 		{
-			PintaCore.Layers.Insert (layer, layer_index);
+			PintaCore.Layers.Insert (layer!, layer_index); // NRT - layer is set by Undo()
 
 			// Make new layer the current layer
-			PintaCore.Layers.SetCurrentLayer (layer);
+			PintaCore.Layers.SetCurrentLayer (layer!);
 
 			layer = null;
 		}

--- a/Pinta.Core/HistoryItems/BaseHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/BaseHistoryItem.cs
@@ -33,8 +33,8 @@ namespace Pinta.Core
 
 	public class BaseHistoryItem : IDisposable
 	{
-		public string Icon { get; set; }
-		public string Text { get; set; }
+		public string? Icon { get; set; }
+		public string? Text { get; set; }
 		public HistoryItemState State { get; set; }
 		public TreeIter Id;
 		public virtual bool CausesDirty { get { return true; } }

--- a/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
@@ -33,7 +33,7 @@ namespace Pinta.Core
 	public class CompoundHistoryItem : BaseHistoryItem
 	{
 		protected List<BaseHistoryItem> history_stack = new List<BaseHistoryItem> ();
-		private List<ImageSurface> snapshots;
+		private List<ImageSurface>? snapshots;
 
 		public CompoundHistoryItem () : base ()
 		{
@@ -78,7 +78,7 @@ namespace Pinta.Core
 
 		public void FinishSnapshotOfImage ()
 		{
-			for (int i = 0; i < snapshots.Count; ++i) {
+			for (int i = 0; i < snapshots!.Count; ++i) { // NRT - Set in StartSnapshotOfImage
 				history_stack.Add (new SimpleHistoryItem (string.Empty, string.Empty, snapshots[i], i));
 			}
 			snapshots.Clear ();

--- a/Pinta.Core/HistoryItems/DeleteLayerHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/DeleteLayerHistoryItem.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core
 	public class DeleteLayerHistoryItem : BaseHistoryItem
 	{
 		private int layer_index;
-		private UserLayer layer;
+		private UserLayer? layer;
 
 		public DeleteLayerHistoryItem(string icon, string text, UserLayer layer, int layerIndex) : base(icon, text)
 		{
@@ -41,10 +41,10 @@ namespace Pinta.Core
 
 		public override void Undo ()
 		{
-			PintaCore.Layers.Insert (layer, layer_index);
+			PintaCore.Layers.Insert (layer!, layer_index); // NRT - layer is set by constructor
 
 			// Make new layer the current layer
-			PintaCore.Layers.SetCurrentLayer (layer);
+			PintaCore.Layers.SetCurrentLayer (layer!);
 
 			layer = null;
 		}

--- a/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
@@ -31,8 +31,8 @@ namespace Pinta.Core
 {
 	public class FinishPixelsHistoryItem : BaseHistoryItem
 	{
-		private ImageSurface old_selection_layer;
-		private ImageSurface old_surface;
+		private ImageSurface? old_selection_layer;
+		private ImageSurface? old_surface;
 		private readonly Matrix old_transform = new Matrix();
 
 		public override bool CausesDirty { get { return false; } }
@@ -52,9 +52,9 @@ namespace Pinta.Core
 			ImageSurface swap_surf = PintaCore.Layers.CurrentLayer.Surface;
 			ImageSurface swap_sel = PintaCore.Layers.SelectionLayer.Surface;
 
-			PintaCore.Layers.SelectionLayer.Surface = old_selection_layer;
+			PintaCore.Layers.SelectionLayer.Surface = old_selection_layer!; // NRT - Set in TakeSnapshot
 			PintaCore.Layers.SelectionLayer.Transform.InitMatrix(old_transform);
-			PintaCore.Layers.CurrentLayer.Surface = old_surface;
+			PintaCore.Layers.CurrentLayer.Surface = old_surface!;
 
 			old_transform.InitMatrix(swap_transfrom);
 			old_surface = swap_surf;
@@ -71,8 +71,8 @@ namespace Pinta.Core
 			ImageSurface swap_surf = PintaCore.Layers.CurrentLayer.Surface.Clone ();
 			ImageSurface swap_sel = PintaCore.Layers.SelectionLayer.Surface;
 
-			PintaCore.Layers.CurrentLayer.Surface = old_surface;
-			PintaCore.Layers.SelectionLayer.Surface = old_selection_layer;
+			PintaCore.Layers.CurrentLayer.Surface = old_surface!; // NRT - Set in TakeSnapshot
+			PintaCore.Layers.SelectionLayer.Surface = old_selection_layer!;
 			PintaCore.Layers.SelectionLayer.Transform.InitMatrix(old_transform);
 
 			old_surface = swap_surf;

--- a/Pinta.Core/HistoryItems/MovePixelsHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/MovePixelsHistoryItem.cs
@@ -37,9 +37,9 @@ namespace Pinta.Core
 		// - Subsequent moves only move the selection
 		//   around the temporary layer
 		private Document doc;
-		private DocumentSelection old_selection;
+		private DocumentSelection? old_selection;
 		private readonly Matrix old_transform = new Matrix();
-		private ImageSurface old_surface;
+		private ImageSurface? old_surface;
 		private int layer_index;
 		private bool lifted;		// Whether this item has lift
 		private bool is_lifted;		// Track state of undo/redo lift
@@ -61,7 +61,7 @@ namespace Pinta.Core
 
 		public override void Dispose ()
 		{
-            old_selection.Dispose ();
+            old_selection?.Dispose ();
 
 			if (old_surface != null)
 				(old_surface as IDisposable).Dispose ();
@@ -70,7 +70,7 @@ namespace Pinta.Core
 		private void Swap ()
 		{
 			DocumentSelection swap_selection = PintaCore.Workspace.ActiveDocument.Selection;
-			PintaCore.Workspace.ActiveDocument.Selection = old_selection;
+			PintaCore.Workspace.ActiveDocument.Selection = old_selection!; // NRT - Set in TakeSnapshot
 			old_selection = swap_selection;
 
 			Matrix swap_transform = new Matrix();
@@ -83,7 +83,7 @@ namespace Pinta.Core
 				ImageSurface surf = PintaCore.Layers[layer_index].Surface;
 
 				// Undo to the "old" surface
-				PintaCore.Layers[layer_index].Surface = old_surface;
+				PintaCore.Layers[layer_index].Surface = old_surface!; // NRT - Set in TakeSnapshot
 
 				// Store the original surface for Redo
 				old_surface = surf;

--- a/Pinta.Core/HistoryItems/ResizeHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/ResizeHistoryItem.cs
@@ -42,7 +42,7 @@ namespace Pinta.Core
 			Text = Translations.GetString ("Resize Image");
 		}
 
-		public DocumentSelection RestoreSelection;
+		public DocumentSelection? RestoreSelection;
 		
 		public override void Undo ()
 		{

--- a/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
@@ -31,8 +31,8 @@ namespace Pinta.Core
 {
 	public class SelectionHistoryItem : BaseHistoryItem
 	{
-		private DocumentSelection old_selection;
-		private DocumentSelection old_previous_selection;
+		private DocumentSelection? old_selection;
+		private DocumentSelection? old_previous_selection;
 
 		private bool hide_tool_layer;
 
@@ -54,8 +54,8 @@ namespace Pinta.Core
 
 		public override void Dispose ()
 		{
-            old_selection.Dispose ();
-            old_previous_selection.Dispose ();
+            old_selection?.Dispose ();
+            old_previous_selection?.Dispose ();
 		}
 
 		private void Swap ()
@@ -64,15 +64,15 @@ namespace Pinta.Core
 			DocumentSelection swap_selection = doc.Selection;
 			bool swap_hide_tool_layer = doc.ToolLayer.Hidden;
 
-			doc.Selection = old_selection;
+			doc.Selection = old_selection!; // NRT - Set in TakeSnapshot
 			doc.ToolLayer.Hidden = hide_tool_layer;
 
 			old_selection = swap_selection;
 			hide_tool_layer = swap_hide_tool_layer;
 
-            swap_selection = old_previous_selection;
+            swap_selection = old_previous_selection!;
             old_previous_selection = doc.PreviousSelection;
-            doc.PreviousSelection = swap_selection;
+            doc.PreviousSelection = swap_selection!;
 
 			PintaCore.Workspace.Invalidate ();
 		}

--- a/Pinta.Core/HistoryItems/SimpleHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/SimpleHistoryItem.cs
@@ -31,8 +31,8 @@ namespace Pinta.Core
 {
 	public class SimpleHistoryItem : BaseHistoryItem
 	{
-		private SurfaceDiff surface_diff;
-		ImageSurface old_surface;
+		private SurfaceDiff? surface_diff;
+		ImageSurface? old_surface;
 		int layer_index;
 
 		public SimpleHistoryItem (string icon, string text, ImageSurface oldSurface, int layerIndex) : base (icon, text)
@@ -71,7 +71,7 @@ namespace Pinta.Core
 				PintaCore.Workspace.Invalidate (surface_diff.GetBounds ());
 			} else {
 				// Undo to the "old" surface
-				PintaCore.Layers[layer_index].Surface = old_surface;
+				PintaCore.Layers[layer_index].Surface = old_surface!; // NRT - Will be not-null if surface_diff is null
 
 				// Store the original surface for Redo
 				old_surface = surf;

--- a/Pinta.Core/HistoryItems/TextHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/TextHistoryItem.cs
@@ -33,11 +33,11 @@ namespace Pinta.Core
 	{
 		UserLayer userLayer;
 
-		SurfaceDiff text_surface_diff;
-		ImageSurface textSurface;
+		SurfaceDiff? text_surface_diff;
+		ImageSurface? textSurface;
 
-		SurfaceDiff user_surface_diff;
-		ImageSurface userSurface;
+		SurfaceDiff? user_surface_diff;
+		ImageSurface? userSurface;
 
 		TextEngine tEngine;
 		Gdk.Rectangle textBounds;
@@ -87,10 +87,6 @@ namespace Pinta.Core
 			textBounds = new Gdk.Rectangle(userLayer.textBounds.X, userLayer.textBounds.Y, userLayer.textBounds.Width, userLayer.textBounds.Height);
 		}
 
-		public TextHistoryItem(string icon, string text) : base(icon, text)
-		{
-		}
-
 		public override void Undo()
 		{
 			Swap();
@@ -114,7 +110,7 @@ namespace Pinta.Core
 			else
 			{
 				// Undo to the "old" surface
-				userLayer.TextLayer.Layer.Surface = textSurface;
+				userLayer.TextLayer.Layer.Surface = textSurface!; // NRT - Will be not-null if text_surface_diff is null
 
 				// Store the original surface for Redo
 				textSurface = surf;
@@ -133,7 +129,7 @@ namespace Pinta.Core
 			else
 			{
 				// Undo to the "old" surface
-				userLayer.Surface = userSurface;
+				userLayer.Surface = userSurface!; // NRT - Will be not-null if user_surface_diff is null
 
 				// Store the original surface for Redo
 				userSurface = surf;

--- a/Pinta.Core/ImageFormats/FormatDescriptor.cs
+++ b/Pinta.Core/ImageFormats/FormatDescriptor.cs
@@ -46,13 +46,13 @@ namespace Pinta.Core
 		/// The importer for this file format. This may be null if only exporting
 		/// is supported for this format.
 		/// </summary>
-		public IImageImporter Importer { get; private set; }
+		public IImageImporter? Importer { get; private set; }
 
 		/// <summary>
 		/// The exporter for this file format. This may be null if only importing
 		/// is supported for this format.
 		/// </summary>
-		public IImageExporter Exporter { get; private set; }
+		public IImageExporter? Exporter { get; private set; }
 
 		/// <summary>
 		/// A file filter for use in the file dialog.
@@ -67,7 +67,7 @@ namespace Pinta.Core
 		/// <param name="importer">The importer for this file format, or null if importing is not supported.</param>
 		/// <param name="exporter">The exporter for this file format, or null if exporting is not supported.</param>
 		public FormatDescriptor (string displayPrefix, string[] extensions,
-		                         IImageImporter importer, IImageExporter exporter)
+		                         IImageImporter? importer, IImageExporter? exporter)
 		{
 			if (extensions == null || (importer == null && exporter == null)) {
 				throw new ArgumentNullException ("Format descriptor is initialized incorrectly");

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -70,11 +70,11 @@ namespace Pinta.Core
 			bg.Dispose ();
 		}
 
-		public Pixbuf LoadThumbnail (string filename, int maxWidth, int maxHeight, Gtk.Window parent)
+		public Pixbuf? LoadThumbnail (string filename, int maxWidth, int maxHeight, Gtk.Window parent)
 		{
 			int imageWidth;
 			int imageHeight;
-			Pixbuf pixbuf = null;
+			Pixbuf? pixbuf = null;
 
 			var imageInfo = Gdk.Pixbuf.GetFileInfo (filename, out imageWidth, out imageHeight);
 
@@ -140,7 +140,7 @@ namespace Pinta.Core
         [DllImport("libgdk_pixbuf-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		private static extern bool gdk_pixbuf_savev_utf8 (IntPtr raw, IntPtr filename, IntPtr type, IntPtr[] option_keys, IntPtr[] option_values, out IntPtr error);
 
-		public static bool SavevUtf8 (this Pixbuf pb, string filename, string type, string[] option_keys, string[] option_values)
+		public static bool SavevUtf8 (this Pixbuf pb, string filename, string type, string?[]? option_keys, string?[]? option_values)
 		{
 			if (PintaCore.System.OperatingSystem == OS.Windows) {
 				IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup (filename);
@@ -149,13 +149,13 @@ namespace Pinta.Core
 				int num = (option_keys == null) ? 0 : option_keys.Length;
 				IntPtr[] native_keys = new IntPtr[num];
 				for (int i = 0; i < num; i++) {
-					native_keys[i] = GLib.Marshaller.StringToPtrGStrdup (option_keys[i]);
+					native_keys[i] = GLib.Marshaller.StringToPtrGStrdup (option_keys![i]); // NRT - num is null-checked length of option_keys
 				}
 
 				int num2 = (option_values == null) ? 0 : option_values.Length;
 				IntPtr[] native_values = new IntPtr[num2];
 				for (int j = 0; j < num2; j++) {
-					native_values[j] = GLib.Marshaller.StringToPtrGStrdup (option_values[j]);
+					native_values[j] = GLib.Marshaller.StringToPtrGStrdup (option_values![j]); // NRT - num2 is null-checked length of option_values
 				}
 
 				IntPtr error = IntPtr.Zero;

--- a/Pinta.Core/ImageFormats/IImageImporter.cs
+++ b/Pinta.Core/ImageFormats/IImageImporter.cs
@@ -56,7 +56,7 @@ namespace Pinta.Core
 		/// Window to be used as a parent for any dialogs that are shown.
 		/// </param>
 		/// <returns>The thumbnail, or null if the image could not be loaded.</returns>
-		Gdk.Pixbuf LoadThumbnail (string filename, int maxWidth, int maxHeight,
+		Gdk.Pixbuf? LoadThumbnail (string filename, int maxWidth, int maxHeight,
 		                          Gtk.Window parent);
 	}
 }

--- a/Pinta.Core/ImageFormats/JpegFormat.cs
+++ b/Pinta.Core/ImageFormats/JpegFormat.cs
@@ -66,7 +66,7 @@ namespace Pinta.Core
 			PintaCore.Settings.PutSetting(JpgCompressionQualitySetting, level);
 
 			//Save the file.
-			pb.SavevUtf8(fileName, fileType, new string[] { "quality", null }, new string[] { level.ToString(), null });
+			pb.SavevUtf8(fileName, fileType, new string?[] { "quality", null }, new string?[] { level.ToString(), null });
 		}
 	}
 }

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -47,8 +47,10 @@ namespace Pinta.Core
 			ZipFile file = new ZipFile (fileName);
 			XmlDocument stackXml = new XmlDocument ();
 			stackXml.Load (file.GetInputStream (file.GetEntry ("stack.xml")));
-			
-			XmlElement imageElement = stackXml.DocumentElement;
+
+			// NRT - This makes a lot of assumptions that the file will be perfectly
+			// valid that we need to guard against.
+			XmlElement imageElement = stackXml.DocumentElement!;
 			int width = int.Parse (imageElement.GetAttribute ("w"));
 			int height = int.Parse (imageElement.GetAttribute ("h"));
 
@@ -57,7 +59,7 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.CreateAndActivateDocument (fileName, imagesize);
 			doc.HasFile = true;
 			
-			XmlElement stackElement = (XmlElement) stackXml.GetElementsByTagName ("stack")[0];
+			XmlElement stackElement = (XmlElement) stackXml.GetElementsByTagName ("stack")[0]!;
 			XmlNodeList layerElements = stackElement.GetElementsByTagName ("layer");
 			
 			if (layerElements.Count == 0)
@@ -67,7 +69,7 @@ namespace Pinta.Core
 			doc.Workspace.CanvasSize = imagesize;
 
 			for (int i = 0; i < layerElements.Count; i++) {
-				XmlElement layerElement = (XmlElement) layerElements[i];
+				XmlElement layerElement = (XmlElement) layerElements[i]!;
 				int x = int.Parse (GetAttribute (layerElement, "x", "0"));
 				int y = int.Parse (GetAttribute (layerElement, "y", "0"));
 				string name = GetAttribute (layerElement, "name", string.Format ("Layer {0}", i));

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -31,25 +31,27 @@ namespace Pinta.Core
 {
 	public class ChromeManager
 	{
-		private Toolbar tool_toolbar;
-		private Window main_window;
-		private IProgressDialog progress_dialog;
+		// NRT - These are all initialized via the Initialize* functions
+		// but it would be nice to rewrite it to provably non-null.
+		private Toolbar tool_toolbar = null!;
+		private Window main_window = null!;
+		private IProgressDialog progress_dialog = null!;
 		private bool main_window_busy;
 		private Gdk.Point last_canvas_cursor_point;
-		private Toolbar main_toolbar;
-		private ErrorDialogHandler error_dialog_handler;
-		private UnsupportedFormatDialogHandler unsupported_format_dialog_handler;
+		private Toolbar main_toolbar = null!;
+		private ErrorDialogHandler error_dialog_handler = null!;
+		private UnsupportedFormatDialogHandler unsupported_format_dialog_handler = null!;
 
-		public Application Application { get; private set; }
+		public Application Application { get; private set; } = null!;
 		public Toolbar ToolToolBar { get { return tool_toolbar; } }
 		public Toolbar MainToolBar { get { return main_toolbar; } }
 		public Window MainWindow { get { return main_window; } }
-		public Statusbar StatusBar { get; private set; }
-		public Toolbar ToolBox { get; private set; }
+		public Statusbar StatusBar { get; private set; } = null!;
+		public Toolbar ToolBox { get; private set; } = null!;
 
 		public IProgressDialog ProgressDialog { get { return progress_dialog; } }
-		public GLib.Menu AdjustmentsMenu { get; private set; }
-		public GLib.Menu EffectsMenu { get; private set; }
+		public GLib.Menu AdjustmentsMenu { get; private set; } = null!;
+		public GLib.Menu EffectsMenu { get; private set; } = null!;
 
 		public ChromeManager ()
 		{
@@ -165,8 +167,8 @@ namespace Pinta.Core
 #endregion
 		
 		#region Public Events
-		public event EventHandler LastCanvasCursorPointChanged;
-		public event EventHandler<TextChangedEventArgs> StatusBarTextChanged;
+		public event EventHandler? LastCanvasCursorPointChanged;
+		public event EventHandler<TextChangedEventArgs>? StatusBarTextChanged;
 		#endregion
 	}
 		

--- a/Pinta.Core/Managers/FontManager.cs
+++ b/Pinta.Core/Managers/FontManager.cs
@@ -54,7 +54,7 @@ namespace Pinta.Core
 			return families.Select (f => f.Name).ToList ();
 		}
 
-		public FontFamily GetFamily (string fontname)
+		public FontFamily? GetFamily (string fontname)
 		{
 			return families.Find (f => f.Name == fontname);
 		}

--- a/Pinta.Core/Managers/HistoryManager.cs
+++ b/Pinta.Core/Managers/HistoryManager.cs
@@ -43,7 +43,7 @@ namespace Pinta.Core
 			get { return PintaCore.Workspace.ActiveWorkspace.History.Pointer; }
 		}
 		
-		public BaseHistoryItem Current {
+		public BaseHistoryItem? Current {
 			get { return PintaCore.Workspace.ActiveWorkspace.History.Current; }
 		}
 		
@@ -94,10 +94,10 @@ namespace Pinta.Core
 		#endregion
 		 
 		#region Events
-		public event EventHandler<HistoryItemAddedEventArgs> HistoryItemAdded;
-		public event EventHandler<HistoryItemRemovedEventArgs> HistoryItemRemoved;
-		public event EventHandler ActionUndone;
-		public event EventHandler ActionRedone;
+		public event EventHandler<HistoryItemAddedEventArgs>? HistoryItemAdded;
+		public event EventHandler<HistoryItemRemovedEventArgs>? HistoryItemRemoved;
+		public event EventHandler? ActionUndone;
+		public event EventHandler? ActionRedone;
 		#endregion
 	}
 }

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -59,7 +59,7 @@ namespace Pinta.Core
 				}
 				
 				GdkPixbufFormat importer = new GdkPixbufFormat (format.Name.ToLowerInvariant ());
-				IImageExporter exporter;
+				IImageExporter? exporter;
 
 				if (formatName == "jpeg")
 					exporter = importer = new JpegFormat ();
@@ -125,7 +125,7 @@ namespace Pinta.Core
 		/// Finds the correct exporter to use for opening the given file, or null
 		/// if no exporter exists for the file.
 		/// </summary>
-		public IImageExporter GetExporterByFile (string file)
+		public IImageExporter? GetExporterByFile (string file)
 		{
 			string extension = Path.GetExtension (file);
 			return GetExporterByExtension (extension);
@@ -135,7 +135,7 @@ namespace Pinta.Core
 		/// Finds the file format for the given file name, or null
 		/// if no file format exists for that file.
 		/// </summary>
-		public FormatDescriptor GetFormatByFile (string file)
+		public FormatDescriptor? GetFormatByFile (string file)
 		{
 			string extension = Path.GetExtension (file);
 
@@ -148,7 +148,7 @@ namespace Pinta.Core
 		/// Finds the correct importer to use for opening the given file, or null
 		/// if no importer exists for the file.
 		/// </summary>
-		public IImageImporter GetImporterByFile (string file)
+		public IImageImporter? GetImporterByFile (string file)
 		{
 			string extension = Path.GetExtension (file);
 
@@ -174,9 +174,9 @@ namespace Pinta.Core
 		/// Finds the correct exporter to use for the given file extension, or null
 		/// if no exporter exists for that extension.
 		/// </summary>
-		private IImageExporter GetExporterByExtension (string extension)
+		private IImageExporter? GetExporterByExtension (string extension)
 		{
-			FormatDescriptor format = GetFormatByExtension (extension);
+			FormatDescriptor? format = GetFormatByExtension (extension);
 
 			if (format == null)
 				return null;
@@ -188,9 +188,9 @@ namespace Pinta.Core
 		/// Finds the correct importer to use for the given file extension, or null
 		/// if no importer exists for that extension.
 		/// </summary>
-		private IImageImporter GetImporterByExtension (string extension)
+		private IImageImporter? GetImporterByExtension (string extension)
 		{
-			FormatDescriptor format = GetFormatByExtension (extension);
+			FormatDescriptor? format = GetFormatByExtension (extension);
 
 			if (format == null)
 				return null;
@@ -202,7 +202,7 @@ namespace Pinta.Core
 		/// Finds the file format for the given file extension, or null
 		/// if no file format exists for that extension.
 		/// </summary>
-		private FormatDescriptor GetFormatByExtension (string extension)
+		private FormatDescriptor? GetFormatByExtension (string extension)
 		{
 			extension = NormalizeExtension (extension);
 

--- a/Pinta.Core/Managers/LayerManager.cs
+++ b/Pinta.Core/Managers/LayerManager.cs
@@ -233,7 +233,7 @@ namespace Pinta.Core
 			return PintaCore.Workspace.ActiveDocument.CreateLayer (name, width, height);
 		}
 		
-		internal void RaiseLayerPropertyChangedEvent (object sender, PropertyChangedEventArgs e)
+		internal void RaiseLayerPropertyChangedEvent (object? sender, PropertyChangedEventArgs e)
 		{
 			if (LayerPropertyChanged != null)
 				LayerPropertyChanged (sender, e);
@@ -244,10 +244,10 @@ namespace Pinta.Core
 		#endregion
 
 		#region Events
-		public event EventHandler LayerAdded;
-		public event EventHandler LayerRemoved;
-		public event EventHandler SelectedLayerChanged;
-		public event PropertyChangedEventHandler LayerPropertyChanged;
+		public event EventHandler? LayerAdded;
+		public event EventHandler? LayerRemoved;
+		public event EventHandler? SelectedLayerChanged;
+		public event PropertyChangedEventHandler? LayerPropertyChanged;
 		#endregion
 	}
 }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -39,19 +39,20 @@ namespace Pinta.Core
 
 	public class LivePreviewManager
 	{
+		// NRT - These are set in Start(). This should be rewritten to be provably non-null.
 		bool live_preview_enabled;		
-		Layer layer;
-		BaseEffect effect;
-		Cairo.Path selection_path;
+		Layer layer = null!;
+		BaseEffect effect = null!;
+		Cairo.Path? selection_path;
 		
 		bool apply_live_preview_flag;
 		bool cancel_live_preview_flag;
 		
-		Cairo.ImageSurface live_preview_surface;
+		Cairo.ImageSurface live_preview_surface = null!;
 		Gdk.Rectangle render_bounds;
-		SimpleHistoryItem history_item;
+		SimpleHistoryItem history_item = null!;
 		
-		AsyncEffectRenderer renderer;
+		AsyncEffectRenderer renderer = null!;
 		
 		internal LivePreviewManager ()
 		{
@@ -64,9 +65,9 @@ namespace Pinta.Core
 		public Cairo.ImageSurface LivePreviewSurface { get { return live_preview_surface; } }
 		public Gdk.Rectangle RenderBounds { get { return render_bounds; } }
 		
-		public event EventHandler<LivePreviewStartedEventArgs> Started;
-		public event EventHandler<LivePreviewRenderUpdatedEventArgs> RenderUpdated;
-		public event EventHandler<LivePreviewEndedEventArgs> Ended;
+		public event EventHandler<LivePreviewStartedEventArgs>? Started;
+		public event EventHandler<LivePreviewRenderUpdatedEventArgs>? RenderUpdated;
+		public event EventHandler<LivePreviewEndedEventArgs>? Ended;
 		
 		public void Start (BaseEffect effect)
 		{			
@@ -226,7 +227,7 @@ namespace Pinta.Core
 			}
 		}
 		
-		void HandleProgressDialogCancel (object o, EventArgs e)
+		void HandleProgressDialogCancel (object? o, EventArgs e)
 		{
 			Cancel();
 		}
@@ -246,7 +247,7 @@ namespace Pinta.Core
 			}
 			
 			PintaCore.History.PushNewItem (history_item);
-			history_item = null;
+			history_item = null!;
 			
 			FireLivePreviewEndedEvent(RenderStatus.Completed, null);
 			
@@ -266,19 +267,19 @@ namespace Pinta.Core
 			if (effect != null) {
 				if (effect.EffectData != null)
 					effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;
-				effect = null;
+				effect = null!;
 			}
 							
-			live_preview_surface = null;
+			live_preview_surface = null!;
 			
 			if (renderer != null) {
 				renderer.Dispose ();
-				renderer = null;
+				renderer = null!;
 			}
 
 			if (history_item != null) {
 				history_item.Dispose ();
-				history_item = null;
+				history_item = null!;
 			}
 			
 			// Hide progress dialog and clean up events.
@@ -289,7 +290,7 @@ namespace Pinta.Core
 			PintaCore.Chrome.MainWindowBusy = false;
 		}
 		
-		void EffectData_PropertyChanged (object sender, PropertyChangedEventArgs e)
+		void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
 		{
 			//TODO calculate bounds.
 			renderer.Start (effect, layer.Surface, live_preview_surface, render_bounds);
@@ -312,7 +313,7 @@ namespace Pinta.Core
 				manager.FireLivePreviewRenderUpdatedEvent (progress, updatedBounds);
 			}	
 			
-			protected override void OnCompletion (bool cancelled, Exception[] exceptions)
+			protected override void OnCompletion (bool cancelled, Exception[]? exceptions)
 			{
 				Debug.WriteLine (DateTime.Now.ToString("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancelled);
 				
@@ -326,7 +327,7 @@ namespace Pinta.Core
 			}
 		}
 		
-		void FireLivePreviewEndedEvent (RenderStatus status, Exception ex)
+		void FireLivePreviewEndedEvent (RenderStatus status, Exception? ex)
 		{
 			if (Ended != null) {
 				var args = new LivePreviewEndedEventArgs (status, ex);
@@ -342,7 +343,7 @@ namespace Pinta.Core
 			}			
 		}
 
-		private void LivePreview_RenderUpdated (object o, LivePreviewRenderUpdatedEventArgs args)
+		private void LivePreview_RenderUpdated (object? o, LivePreviewRenderUpdatedEventArgs args)
 		{
 			double scale = PintaCore.Workspace.Scale;
 			var offset = PintaCore.Workspace.Offset;

--- a/Pinta.Core/Managers/PaintBrushManager.cs
+++ b/Pinta.Core/Managers/PaintBrushManager.cs
@@ -33,8 +33,8 @@ namespace Pinta.Core
 	{
 		private List<BasePaintBrush> paint_brushes = new List<BasePaintBrush> ();
 
-		public event EventHandler<BrushEventArgs> BrushAdded;
-		public event EventHandler<BrushEventArgs> BrushRemoved;
+		public event EventHandler<BrushEventArgs>? BrushAdded;
+		public event EventHandler<BrushEventArgs>? BrushRemoved;
 
 		/// <summary>
 		/// Register a new brush.
@@ -91,10 +91,10 @@ namespace Pinta.Core
 
 		class BrushSorter : Comparer<BasePaintBrush>
 		{
-			public override int Compare (BasePaintBrush x, BasePaintBrush y)
+			public override int Compare (BasePaintBrush? x, BasePaintBrush? y)
 			{
-				var xstr = x.Priority == 0 ? x.Name : x.Priority.ToString ();
-				var ystr = y.Priority == 0 ? y.Name : y.Priority.ToString ();
+				var xstr = x is BasePaintBrush x2 && x2.Priority != 0 ? x2.Priority.ToString () : x?.Name;
+				var ystr = y is BasePaintBrush y2 && y2.Priority != 0 ? y2.Priority.ToString () : y?.Name;
 
 				return string.Compare (xstr, ystr);
 			}

--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -36,7 +36,7 @@ namespace Pinta.Core
 	{
 		private Color primary;
 		private Color secondary;
-		private Palette palette;
+		private Palette? palette;
 
 		private const int MAX_RECENT_COLORS = 10;
 		private readonly List<Color> recently_used = new List<Color> (MAX_RECENT_COLORS);
@@ -175,9 +175,9 @@ namespace Pinta.Core
 		#endregion
 		
 		#region Events
-		public event EventHandler PrimaryColorChanged;
-		public event EventHandler SecondaryColorChanged;
-		public event EventHandler RecentColorsChanged;
+		public event EventHandler? PrimaryColorChanged;
+		public event EventHandler? SecondaryColorChanged;
+		public event EventHandler? RecentColorsChanged;
 		#endregion
 	}
 }

--- a/Pinta.Core/Managers/ResourceManager.cs
+++ b/Pinta.Core/Managers/ResourceManager.cs
@@ -42,7 +42,7 @@ namespace Pinta
 			return ResourceLoader.GetIcon (name, size);
 		}
 
-        public Stream GetResourceIconStream (string name)
+        public Stream? GetResourceIconStream (string name)
         {
             return ResourceLoader.GetResourceIconStream (name);
         }

--- a/Pinta.Core/Managers/SettingsManager.cs
+++ b/Pinta.Core/Managers/SettingsManager.cs
@@ -36,7 +36,7 @@ namespace Pinta.Core
 {
 	public class SettingsManager
 	{
-		private Dictionary<string, object> settings;
+		private Dictionary<string, object> settings = null!; // NRT - Set by LoadSettings in constructor
 
         public string LayoutFile { get { return "layouts.xml"; } }
         public string LayoutFilePath { get { return Path.Combine (GetUserSettingsDirectory (), LayoutFile); } }
@@ -80,9 +80,11 @@ namespace Pinta.Core
 				
 			XmlDocument doc = new XmlDocument ();
 			doc.Load (filename);
-			
+
+			// NRT - Assumes file is formatted valid, should rewrite more defensively.
+
 			// Kinda cheating for now because I know there is only a few things stored in here
-			foreach (XmlElement setting in doc.DocumentElement.ChildNodes) {
+			foreach (XmlElement setting in doc.DocumentElement!.ChildNodes) {
 				switch (setting.GetAttribute ("type")) {
 					case "System.Int32":
 						properties[setting.GetAttribute ("name")] = int.Parse (setting.InnerText);
@@ -102,7 +104,7 @@ namespace Pinta.Core
 
 		private static void Serialize (string filename, Dictionary<string, object> settings)
 		{
-			string path = Path.GetDirectoryName (filename);
+			string path = Path.GetDirectoryName (filename)!; // NRT - We build the filename so we know it has a directory
 
 			if (!Directory.Exists (path))
 				Directory.CreateDirectory (path);

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -111,7 +111,8 @@ namespace Pinta.Core
 
 		public static string GetExecutableDirectory ()
 		{
-			return Path.GetDirectoryName (GetExecutablePathName ());
+			// NRT - We use Path.GetFullPath so it should contain a directory
+			return Path.GetDirectoryName (GetExecutablePathName ())!;
 		}
 
 		/// <summary>
@@ -161,7 +162,7 @@ namespace Pinta.Core
 				buf = Marshal.AllocHGlobal (8192);
 				// This is a hacktastic way of getting sysname from uname ()
 				if (uname (buf) == 0) {
-					string os = Marshal.PtrToStringAnsi (buf);
+					string? os = Marshal.PtrToStringAnsi (buf);
 					if (os == "Darwin")
 						return true;
 				}

--- a/Pinta.Core/Managers/ToolManager.cs
+++ b/Pinta.Core/Managers/ToolManager.cs
@@ -41,8 +41,8 @@ namespace Pinta.Core
 		private Gdk.Key LastUsedKey;
 		private int PressedShortcutCounter;
 
-		public event EventHandler<ToolEventArgs> ToolAdded;
-		public event EventHandler<ToolEventArgs> ToolRemoved;
+		public event EventHandler<ToolEventArgs>? ToolAdded;
+		public event EventHandler<ToolEventArgs>? ToolRemoved;
 
 		public ToolManager ()
 		{
@@ -94,11 +94,17 @@ namespace Pinta.Core
 			}
 		}
 
-		void HandlePbToolItemClicked (object sender, EventArgs e)
+		void HandlePbToolItemClicked (object? sender, EventArgs e)
 		{
-			ToggleToolButton tb = (ToggleToolButton)sender;
+			ToggleToolButton? tb = (ToggleToolButton?)sender;
 
-			BaseTool t = FindTool (tb.Label);
+			if (tb is null)
+				return;
+
+			BaseTool? t = FindTool (tb.Label);
+
+			if (t is null)
+				return;
 
 			// Don't let the user unselect the current tool	
 			if (CurrentTool != null && t.Name == CurrentTool.Name) {
@@ -110,7 +116,7 @@ namespace Pinta.Core
 			SetCurrentTool(t);
 		}
 
-		private BaseTool FindTool (string name)
+		private BaseTool? FindTool (string name)
 		{
 			name = name.ToLowerInvariant ();
 			
@@ -171,7 +177,7 @@ namespace Pinta.Core
 
 		public bool SetCurrentTool (string tool)
 		{
-			BaseTool t = FindTool (tool);
+			BaseTool? t = FindTool (tool);
 			
 			if (t != null) {
 				SetCurrentTool(t);
@@ -183,13 +189,13 @@ namespace Pinta.Core
 		
 		public void SetCurrentTool (Gdk.Key shortcut)
 		{
-			BaseTool tool = FindNextTool (shortcut);
+			BaseTool? tool = FindNextTool (shortcut);
 			
 			if (tool != null)
 				SetCurrentTool(tool);
 		}
 
-		private BaseTool FindNextTool (Gdk.Key shortcut)
+		private BaseTool? FindNextTool (Gdk.Key shortcut)
 		{
 			shortcut = shortcut.ToUpper();
 
@@ -244,9 +250,10 @@ namespace Pinta.Core
 
 		class ToolSorter : Comparer<BaseTool>
 		{
-			public override int Compare (BaseTool x, BaseTool y)
+			public override int Compare (BaseTool? x, BaseTool? y)
 			{
-				return x.Priority - y.Priority;
+
+				return (x?.Priority ?? 0) - (y?.Priority ?? 0);
 			}
 		}
 	}

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -91,7 +91,7 @@ namespace Pinta.Core
 		public List<Document> OpenDocuments { get; private set; }
 		public bool HasOpenDocuments { get { return OpenDocuments.Count > 0; } }
 		
-		public Document CreateAndActivateDocument (string filename, Gdk.Size size)
+		public Document CreateAndActivateDocument (string? filename, Gdk.Size size)
 		{
 			Document doc = new Document (size);
 			
@@ -175,7 +175,7 @@ namespace Pinta.Core
 		}
 
 		// TODO: Standardize add to recent files
-		public bool OpenFile (string file, Window parent = null)
+		public bool OpenFile (string file, Window? parent = null)
 		{
 			bool fileOpened = false;
 
@@ -184,7 +184,7 @@ namespace Pinta.Core
 
 			try {
 				// Open the image and add it to the layers
-				IImageImporter importer = PintaCore.System.ImageFormats.GetImporterByFile (file);
+				IImageImporter? importer = PintaCore.System.ImageFormats.GetImporterByFile (file);
 				if (importer == null)
 					throw new FormatException( Translations.GetString ("Unsupported file format"));
 
@@ -367,11 +367,11 @@ namespace Pinta.Core
 		}
 
 		#region Public Events
-		public event EventHandler ActiveDocumentChanged;
-		public event EventHandler<DocumentEventArgs> DocumentCreated;
-		public event EventHandler<DocumentEventArgs> DocumentOpened;
-		public event EventHandler<DocumentEventArgs> DocumentClosed;
-		public event EventHandler SelectionChanged;
+		public event EventHandler? ActiveDocumentChanged;
+		public event EventHandler<DocumentEventArgs>? DocumentCreated;
+		public event EventHandler<DocumentEventArgs>? DocumentOpened;
+		public event EventHandler<DocumentEventArgs>? DocumentClosed;
+		public event EventHandler? SelectionChanged;
 #endregion
 		
 	}

--- a/Pinta.Core/PaletteFormats/GimpPalette.cs
+++ b/Pinta.Core/PaletteFormats/GimpPalette.cs
@@ -39,21 +39,21 @@ namespace Pinta.Core
 		{
 			List<Color> colors = new List<Color> ();
 			StreamReader reader = new StreamReader (fileName);
-			string line = reader.ReadLine ();
+			string? line = reader.ReadLine ();
 
-			if (!line.StartsWith ("GIMP"))
+			if (line is null || !line.StartsWith ("GIMP"))
 				throw new InvalidDataException("Not a valid GIMP palette file.");
 
 			// skip everything until the first color
 			while (!char.IsDigit(line[0]))
-				line = reader.ReadLine ();
+				line = reader.ReadLine ()!; // NRT - This assumes a valid formed file
 
 			// then read the palette
 			do {
 				if (line.IndexOf ('#') == 0)
 					continue;
 
-				string[] split = line.Split ((char[]) null, StringSplitOptions.RemoveEmptyEntries);
+				string[] split = line.Split ((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
 				double r = int.Parse (split[0]) / 255f;
 				double g = int.Parse (split[1]) / 255f;
 				double b = int.Parse (split[2]) / 255f;

--- a/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
@@ -41,9 +41,9 @@ namespace Pinta.Core
 			StreamReader reader = new StreamReader (fileName);
 
 			try {
-				string line = reader.ReadLine ();
+				string? line = reader.ReadLine ();
 				do {
-					if (line.IndexOf (';') == 0)
+					if (line is null || line.IndexOf (';') == 0)
 						continue;
 
 					uint color = uint.Parse (line.Substring (0, 8), NumberStyles.HexNumber);

--- a/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
@@ -38,18 +38,22 @@ namespace Pinta.Core
 		{
 			List<Color> colors = new List<Color> ();
 			StreamReader reader = new StreamReader (fileName);
-			string line = reader.ReadLine ();
+			string? line = reader.ReadLine ();
 
-			if (!line.StartsWith ("JASC-PAL"))
+			if (line is null || !line.StartsWith ("JASC-PAL"))
 				throw new InvalidDataException("Not a valid PaintShopPro palette file.");
 
 			line = reader.ReadLine (); // version
 
-			int numberOfColors = int.Parse(reader.ReadLine());
+			int numberOfColors = int.Parse(reader.ReadLine()!); // NRT - Assumes valid formatted file
 			PintaCore.Palette.CurrentPalette.Resize (numberOfColors);
 
 			while (!reader.EndOfStream) {
 				line = reader.ReadLine ();
+
+				if (line is null)
+					break;
+
 				string[] split = line.Split (' ');
 				double r = int.Parse (split[0]) / 255f;
 				double g = int.Parse (split[1]) / 255f;

--- a/Pinta.Core/PaletteFormats/PaletteDescriptor.cs
+++ b/Pinta.Core/PaletteFormats/PaletteDescriptor.cs
@@ -42,10 +42,6 @@ namespace Pinta.Core
 
 		public PaletteDescriptor (string displayPrefix, string[] extensions, IPaletteLoader loader, IPaletteSaver saver)
 		{
-			if (extensions == null || (loader == null && saver == null)) {
-				throw new ArgumentNullException ("Palette descriptor is initialized incorrectly");
-			}
-
 			this.Extensions = extensions;
 			this.Loader = loader;
 			this.Saver = saver;

--- a/Pinta.Core/PaletteFormats/PaletteFormats.cs
+++ b/Pinta.Core/PaletteFormats/PaletteFormats.cs
@@ -49,7 +49,7 @@ namespace Pinta.Core
 
 		public IEnumerable<PaletteDescriptor> Formats { get { return formats; } }
 
-		public IPaletteLoader GetLoaderByFilename (string fileName)
+		public IPaletteLoader? GetLoaderByFilename (string fileName)
 		{
 			string extension = System.IO.Path.GetExtension (fileName);
 			extension = NormalizeExtension (extension);

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>Pinta.Core</RootNamespace>
     <AssemblyName>Pinta.Core</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
 
     <Version>1.8.0.0</Version>
     <Authors>PintaProject</Authors>

--- a/Pinta.Core/Widgets/ToolBarDropDownButton.cs
+++ b/Pinta.Core/Widgets/ToolBarDropDownButton.cs
@@ -11,11 +11,11 @@ namespace Pinta.Core
         private const string action_prefix = "tool";
 
         private Gtk.MenuButton menu_button;
-		private Label label_widget;
+		private Label? label_widget;
 		private GLib.Menu dropdown;
 		private GLib.SimpleActionGroup action_group;
 		private Image image;
-		private ToolBarItem selected_item;
+		private ToolBarItem? selected_item;
 
 		public List<ToolBarItem> Items { get; private set; }
 
@@ -58,7 +58,7 @@ namespace Pinta.Core
 			return AddItem (text, imageId, null);
 		}
 
-		public ToolBarItem AddItem (string text, string imageId, object tag)
+		public ToolBarItem AddItem (string text, string imageId, object? tag)
 		{
 			ToolBarItem item = new ToolBarItem (text, imageId, tag);
 			action_group.AddAction(item.Action);
@@ -73,10 +73,11 @@ namespace Pinta.Core
 			return item;
 		}
 
-		public ToolBarItem SelectedItem {
+		public ToolBarItem? SelectedItem {
 			get { return selected_item; }
 			set {
-				if (selected_item != value)
+				// We don't support setting the selected item back to nothing
+				if (value != null && selected_item != value)
 					SetSelectedItem (value);
 			}
 		}
@@ -100,16 +101,11 @@ namespace Pinta.Core
 				SelectedItemChanged (this, EventArgs.Empty);
 		}
 
-		public event EventHandler SelectedItemChanged;
+		public event EventHandler? SelectedItemChanged;
 	}
 
 	public class ToolBarItem
 	{
-		public ToolBarItem ()
-		{
-
-		}
-
 		public ToolBarItem (string text, string imageId)
 		{
 			Text = text;
@@ -119,13 +115,13 @@ namespace Pinta.Core
             Action = new GLib.SimpleAction(action_name, null);
 		}
 
-		public ToolBarItem (string text, string imageId, object tag) : this (text, imageId)
+		public ToolBarItem (string text, string imageId, object? tag) : this (text, imageId)
 		{
 			Tag = tag;
 		}
 
 		public string ImageId { get; set; }
-		public object Tag { get; set; }
+		public object? Tag { get; set; }
 		public string Text { get; set; }
 		public GLib.SimpleAction Action { get; private set; }
 	}

--- a/Pinta.Resources/Pinta.Resources.csproj
+++ b/Pinta.Resources/Pinta.Resources.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Pinta.Resources</RootNamespace>
     <AssemblyName>Pinta.Resources</AssemblyName>
+    <Nullable>enable</Nullable>
 
     <Version>1.8.0.0</Version>
     <Authors>PintaProject</Authors>

--- a/Pinta.Resources/ResourceManager.cs
+++ b/Pinta.Resources/ResourceManager.cs
@@ -25,122 +25,119 @@
 // THE SOFTWARE.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using Gdk;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Gdk;
 
 namespace Pinta.Resources
 {
 	public static class ResourceLoader
 	{
-
-		private static bool HasResource(Assembly asm, string name)
-		{
-			string[] resources = asm.GetManifestResourceNames ();
-
-			if (Array.IndexOf (resources, name) > -1)
-				return true;
-			else
-				return false;
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
+		[MethodImpl (MethodImplOptions.NoInlining)]
 		public static Pixbuf GetIcon (string name, int size)
 		{
-			Gdk.Pixbuf result = null;
-			try {
-                // First see if it's a built-in gtk icon, like gtk-new.
-                // This will also load any icons added by Gtk.IconFactory.AddDefault() . 
-                using (var icon = Gtk.IconTheme.Default.LookupIcon(name, size, Gtk.IconLookupFlags.ForceSize))
-                {
-					if (icon != null)
-                        result = icon.LoadIcon();
-                }
-                // Otherwise, get it from our embedded resources.
-                if (result == null) {
+			// First see if it's a built-in gtk icon, like gtk-new.
+			if (TryGetIconFromTheme (name, size, out var theme_result))
+				return theme_result;
 
-					if (HasResource(Assembly.GetExecutingAssembly(), name)) //Assembly.GetCallingAssembly() is wrong here!
-						result = Gdk.Pixbuf.LoadFromResource (name);
-				}
+			// Otherwise, get it from our embedded resources.
+			if (TryGetIconFromResources (name, out var resource_result))
+				return resource_result;
 
-				//Maybe we can find the icon in the resource of a different assembly (e.g. Plugin)
-				if (result == null) {
-					foreach (System.Reflection.Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
-					{
-						if (HasResource(asm, name))
-							result = new Pixbuf(asm, name);
-					}
-				}
-			}
-			catch (Exception ex) {
-				System.Console.Error.WriteLine (ex.Message);
-			}
+			// We can't find this image, but we are going to return *some* image rather than null to prevent crashes
+			// Try to return GTK's default "missing image" image
+			if (name != Gtk.Stock.MissingImage)
+				return GetIcon (Gtk.Stock.MissingImage, size);
 
-			// Ensure that we don't crash if an icon is missing for some reason.
-			if (result == null) {
-				try
-				{
-					// Try to return gtk's default missing image
-					if (name != Gtk.Stock.MissingImage) {
-						result = GetIcon (Gtk.Stock.MissingImage, size);
-					} else {
-						// If gtk is missing it's "missing image", we'll create one on the fly
-						result = CreateMissingImage (size);
-					}
-				}
-				catch (Exception ex) {
-					System.Console.Error.WriteLine (ex.Message);
-				}
-			}
-
-			return result;
+			// If even the "missing image" is missing, make one on the fly
+			return CreateMissingImage (size);
 		}
 
-		public static Stream GetResourceIconStream (string name)
+		public static Stream? GetResourceIconStream (string name)
 		{
-			var ass = typeof (Pinta.Resources.ResourceLoader).Assembly;
+			var asm = typeof (ResourceLoader).Assembly;
 
-			return ass.GetManifestResourceStream (name);
+			return asm.GetManifestResourceStream (name);
+		}
+
+		private static bool TryGetIconFromTheme (string name, int size, [NotNullWhen (true)] out Pixbuf? image)
+		{
+			image = null;
+
+			try {
+				// This will also load any icons added by Gtk.IconFactory.AddDefault() . 
+				using (var icon = Gtk.IconTheme.Default.LookupIcon (name, size, Gtk.IconLookupFlags.ForceSize)) {
+					if (icon != null)
+						image = icon.LoadIcon ();
+				}
+
+			} catch (Exception ex) {
+				Console.Error.WriteLine (ex.Message);
+			}
+
+			return image != null;
+		}
+
+		private static bool TryGetIconFromResources (string name, [NotNullWhen (true)] out Pixbuf? image)
+		{
+			// Check 'Pinta.Resources' for our image
+			if (TryGetIconFromAssembly (Assembly.GetExecutingAssembly (), name, out image))
+				return true;
+
+			// Maybe we can find the icon in the resource of a different assembly (e.g. Plugin)
+			foreach (var asm in AppDomain.CurrentDomain.GetAssemblies ())
+				if (TryGetIconFromAssembly (asm, name, out image))
+					return true;
+
+			return false;
+		}
+
+		private static bool TryGetIconFromAssembly (Assembly assembly, string name, [NotNullWhen (true)] out Pixbuf? image)
+		{
+			image = null;
+
+			try {
+				if (HasResource (assembly, name))
+					image = new Pixbuf (assembly, name);
+			} catch (Exception ex) {
+				Console.Error.WriteLine (ex.Message);
+			}
+
+			return image != null;
+		}
+
+		private static bool HasResource (Assembly asm, string name)
+		{
+			return asm.GetManifestResourceNames ().Any (n => n == name);
 		}
 
 		// From MonoDevelop:
 		// https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/gtk-gui/generated.cs
 		private static Pixbuf CreateMissingImage (int size)
 		{
-			using (var surf = new Cairo.ImageSurface(Cairo.Format.Argb32, size, size))
-			using (var g = new Cairo.Context(surf))
-            {
-				g.SetSourceColor(new Cairo.Color(1, 1, 1));
-				g.Rectangle(0, 0, size, size);
-				g.Fill();
+			using (var surf = new Cairo.ImageSurface (Cairo.Format.Argb32, size, size))
+			using (var g = new Cairo.Context (surf)) {
+				g.SetSourceColor (new Cairo.Color (1, 1, 1));
+				g.Rectangle (0, 0, size, size);
+				g.Fill ();
 
-				g.SetSourceColor(new Cairo.Color(0, 0, 0));
-				g.Rectangle(0, 0, size - 1, size - 1);
-				g.Fill();
+				g.SetSourceColor (new Cairo.Color (0, 0, 0));
+				g.Rectangle (0, 0, size - 1, size - 1);
+				g.Fill ();
 
 				g.LineWidth = 3;
 				g.LineCap = Cairo.LineCap.Round;
 				g.LineJoin = Cairo.LineJoin.Round;
-				g.SetSourceColor(new Cairo.Color(1, 0, 0));
-				g.MoveTo(size / 4, size / 4);
-				g.LineTo((size - 1) - (size / 4), (size - 1) - (size / 4));
-				g.MoveTo((size - 1) - (size / 4), size / 4);
-				g.LineTo(size / 4, (size - 1) - (size / 4));
+				g.SetSourceColor (new Cairo.Color (1, 0, 0));
+				g.MoveTo (size / 4, size / 4);
+				g.LineTo ((size - 1) - (size / 4), (size - 1) - (size / 4));
+				g.MoveTo ((size - 1) - (size / 4), size / 4);
+				g.LineTo (size / 4, (size - 1) - (size / 4));
 
-				return new Gdk.Pixbuf(surf, 0, 0, surf.Width, surf.Height);
-			}
-		}
-
-		private static Gtk.IconSize GetIconSize(int size)
-		{
-			switch (size) {
-				case 16:
-					return Gtk.IconSize.SmallToolbar;
-				case 32:
-					return Gtk.IconSize.Dnd;
-				default:
-					return Gtk.IconSize.Invalid;
+				return new Pixbuf (surf, 0, 0, surf.Width, surf.Height);
 			}
 		}
 	}


### PR DESCRIPTION
Enables nullable reference types (NRT) for `Pinta.Core` and `Pinta.Resources`.

There are many places where it would be nice to refactor things to be provably null, but I tried to refrain from making many large changes in this PR to keep the diff manageable.

Any section that uses the null forgiveness operator (`!`) is marked with a `// NRT -` comment for future refactoring.