### PR TITLE
Move Document layer functionality to DocumentLayers.

### DIFF
--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -195,9 +195,9 @@ namespace Pinta.Core
 
 			PintaCore.Tools.Commit ();
 
-			Cairo.ImageSurface old = doc.CurrentUserLayer.Surface.Clone ();
+			Cairo.ImageSurface old = doc.Layers.CurrentUserLayer.Surface.Clone ();
 
-			using (var g = new Cairo.Context (doc.CurrentUserLayer.Surface)) {
+			using (var g = new Cairo.Context (doc.Layers.CurrentUserLayer.Surface)) {
 				g.AppendPath (doc.Selection.SelectionPath);
 				g.FillRule = FillRule.EvenOdd;
 
@@ -206,7 +206,7 @@ namespace Pinta.Core
 			}
 
 			doc.Workspace.Invalidate ();
-			doc.History.PushNewItem (new SimpleHistoryItem (Resources.Icons.EditSelectionFill, Translations.GetString ("Fill Selection"), old, doc.CurrentUserLayerIndex));
+			doc.History.PushNewItem (new SimpleHistoryItem (Resources.Icons.EditSelectionFill, Translations.GetString ("Fill Selection"), old, doc.Layers.CurrentUserLayerIndex));
 		}
 
 		private void HandlePintaCoreActionsEditSelectAllActivated (object sender, EventArgs e)
@@ -231,9 +231,9 @@ namespace Pinta.Core
 
 			PintaCore.Tools.Commit ();
 
-			Cairo.ImageSurface old = doc.CurrentUserLayer.Surface.Clone ();
+			Cairo.ImageSurface old = doc.Layers.CurrentUserLayer.Surface.Clone ();
 
-			using (var g = new Cairo.Context (doc.CurrentUserLayer.Surface)) {
+			using (var g = new Cairo.Context (doc.Layers.CurrentUserLayer.Surface)) {
 				g.AppendPath (doc.Selection.SelectionPath);
 				g.FillRule = FillRule.EvenOdd;
 
@@ -244,9 +244,9 @@ namespace Pinta.Core
 			doc.Workspace.Invalidate ();
 
 			if (sender is string && (sender as string) == "Cut")
-				doc.History.PushNewItem (new SimpleHistoryItem (Resources.StandardIcons.EditCut, Translations.GetString ("Cut"), old, doc.CurrentUserLayerIndex));
+				doc.History.PushNewItem (new SimpleHistoryItem (Resources.StandardIcons.EditCut, Translations.GetString ("Cut"), old, doc.Layers.CurrentUserLayerIndex));
 			else
-				doc.History.PushNewItem (new SimpleHistoryItem (Resources.Icons.EditSelectionErase, Translations.GetString ("Erase Selection"), old, doc.CurrentUserLayerIndex));
+				doc.History.PushNewItem (new SimpleHistoryItem (Resources.Icons.EditSelectionErase, Translations.GetString ("Erase Selection"), old, doc.Layers.CurrentUserLayerIndex));
 		}
 
 		private void HandlePintaCoreActionsEditDeselectActivated (object sender, EventArgs e)
@@ -274,7 +274,7 @@ namespace Pinta.Core
 
 			PintaCore.Tools.Commit ();
 
-			using (ImageSurface src = doc.GetClippedLayer (doc.CurrentUserLayerIndex)) {
+			using (ImageSurface src = doc.Layers.GetClippedLayer (doc.Layers.CurrentUserLayerIndex)) {
 
 				Gdk.Rectangle rect = doc.GetSelectedBounds (true);
 				if (rect.Width == 0 || rect.Height == 0)
@@ -431,13 +431,13 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			// Clear the selection resize handles if necessary.
-			doc.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Clear ();
 
 			SelectionHistoryItem historyItem = new SelectionHistoryItem (Resources.Icons.EditSelectionInvert,
 			                                                             Translations.GetString ("Invert Selection"));
 			historyItem.TakeSnapshot ();
 
-			doc.Selection.Invert (doc.SelectionLayer.Surface, doc.ImageSize);
+			doc.Selection.Invert (doc.Layers.SelectionLayer.Surface, doc.ImageSize);
 
 			doc.History.PushNewItem (historyItem);
 			doc.Workspace.Invalidate ();

--- a/Pinta.Core/Actions/ImageActions.cs
+++ b/Pinta.Core/Actions/ImageActions.cs
@@ -151,14 +151,14 @@ namespace Pinta.Core
 
 			PintaCore.Tools.Commit ();
 
-			var oldBottomSurface = doc.UserLayers[0].Surface.Clone ();
+			var oldBottomSurface = doc.Layers.UserLayers[0].Surface.Clone ();
 
 			CompoundHistoryItem hist = new CompoundHistoryItem (Resources.Icons.ImageFlatten, Translations.GetString ("Flatten"));
 
-			for (int i = doc.UserLayers.Count - 1; i >= 1; i--)
-				hist.Push (new DeleteLayerHistoryItem (string.Empty, string.Empty, doc.UserLayers[i], i));
+			for (int i = doc.Layers.UserLayers.Count - 1; i >= 1; i--)
+				hist.Push (new DeleteLayerHistoryItem (string.Empty, string.Empty, doc.Layers.UserLayers[i], i));
 
-			doc.FlattenImage ();
+			doc.Layers.FlattenLayers ();
 
 			hist.Push (new SimpleHistoryItem (string.Empty, string.Empty, oldBottomSurface, 0));
 			doc.History.PushNewItem (hist);
@@ -306,7 +306,7 @@ namespace Pinta.Core
 
 				doc.Workspace.Canvas.Window.ThawUpdates();
 
-				foreach (var layer in doc.UserLayers)
+				foreach (var layer in doc.Layers.UserLayers)
                     layer.Crop (rect, selection);
 
 				hist.FinishSnapshotOfImage();

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -131,7 +131,7 @@ namespace Pinta.Core
 		#region Action Handlers
 		private void EnableOrDisableLayerActions (object? sender, EventArgs e)
 		{
-			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.UserLayers.Count > 1) {
+			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.Layers.UserLayers.Count > 1) {
 				PintaCore.Actions.Layers.DeleteLayer.Sensitive = true;
 				PintaCore.Actions.Image.Flatten.Sensitive = true;
 			} else {
@@ -139,7 +139,7 @@ namespace Pinta.Core
 				PintaCore.Actions.Image.Flatten.Sensitive = false;
 			}
 
-			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.CurrentUserLayerIndex > 0) {
+			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayerIndex > 0) {
 				PintaCore.Actions.Layers.MergeLayerDown.Sensitive = true;
 				PintaCore.Actions.Layers.MoveLayerDown.Sensitive = true;
 			} else {
@@ -147,7 +147,7 @@ namespace Pinta.Core
 				PintaCore.Actions.Layers.MoveLayerDown.Sensitive = false;
 			}
 
-			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.CurrentUserLayerIndex < PintaCore.Workspace.ActiveDocument.UserLayers.Count - 1)
+			if (PintaCore.Workspace.HasOpenDocuments && PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayerIndex < PintaCore.Workspace.ActiveDocument.Layers.UserLayers.Count - 1)
 				PintaCore.Actions.Layers.MoveLayerUp.Sensitive = true;
 			else
 				PintaCore.Actions.Layers.MoveLayerUp.Sensitive = false;
@@ -175,7 +175,7 @@ namespace Pinta.Core
 					PintaCore.System.LastDialogDirectory = fcd.CurrentFolder;
 
 					// Open the image and add it to the layers
-					UserLayer layer = doc.AddNewLayer(System.IO.Path.GetFileName(file));
+					UserLayer layer = doc.Layers.AddNewLayer (System.IO.Path.GetFileName(file));
 
 					using (var fs = new FileStream(file, FileMode.Open))
 					using (Pixbuf bg = new Pixbuf(fs))
@@ -185,9 +185,9 @@ namespace Pinta.Core
 						g.Paint();
 					}
 
-					doc.SetCurrentUserLayer(layer);
+					doc.Layers.SetCurrentUserLayer (layer);
 
-					AddLayerHistoryItem hist = new AddLayerHistoryItem(Resources.Icons.LayerImport, Translations.GetString("Import From File"), doc.UserLayers.IndexOf(layer));
+					AddLayerHistoryItem hist = new AddLayerHistoryItem(Resources.Icons.LayerImport, Translations.GetString("Import From File"), doc.Layers.IndexOf(layer));
 					doc.History.PushNewItem(hist);
 
 					doc.Workspace.Invalidate();
@@ -200,9 +200,9 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			doc.CurrentUserLayer.FlipVertical ();
+			doc.Layers.CurrentUserLayer.FlipVertical ();
 			doc.Workspace.Invalidate ();
-			doc.History.PushNewItem (new InvertHistoryItem (InvertType.FlipLayerVertical, doc.CurrentUserLayerIndex));
+			doc.History.PushNewItem (new InvertHistoryItem (InvertType.FlipLayerVertical, doc.Layers.CurrentUserLayerIndex));
 		}
 
 		private void HandlePintaCoreActionsLayersFlipHorizontalActivated (object sender, EventArgs e)
@@ -210,9 +210,9 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			doc.CurrentUserLayer.FlipHorizontal ();
+			doc.Layers.CurrentUserLayer.FlipHorizontal ();
 			doc.Workspace.Invalidate ();
-			doc.History.PushNewItem (new InvertHistoryItem (InvertType.FlipLayerHorizontal, doc.CurrentUserLayerIndex));
+			doc.History.PushNewItem (new InvertHistoryItem (InvertType.FlipLayerHorizontal, doc.Layers.CurrentUserLayerIndex));
 		}
 
 		private void HandlePintaCoreActionsLayersMoveLayerUpActivated (object sender, EventArgs e)
@@ -220,9 +220,9 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			SwapLayersHistoryItem hist = new SwapLayersHistoryItem (Resources.Icons.LayerMoveUp, Translations.GetString ("Move Layer Up"), doc.CurrentUserLayerIndex, doc.CurrentUserLayerIndex + 1);
+			SwapLayersHistoryItem hist = new SwapLayersHistoryItem (Resources.Icons.LayerMoveUp, Translations.GetString ("Move Layer Up"), doc.Layers.CurrentUserLayerIndex, doc.Layers.CurrentUserLayerIndex + 1);
 
-			doc.MoveCurrentLayerUp ();
+			doc.Layers.MoveCurrentLayerUp ();
 			doc.History.PushNewItem (hist);
 		}
 
@@ -231,9 +231,9 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			SwapLayersHistoryItem hist = new SwapLayersHistoryItem (Resources.Icons.LayerMoveDown, Translations.GetString ("Move Layer Down"), doc.CurrentUserLayerIndex, doc.CurrentUserLayerIndex - 1);
+			SwapLayersHistoryItem hist = new SwapLayersHistoryItem (Resources.Icons.LayerMoveDown, Translations.GetString ("Move Layer Down"), doc.Layers.CurrentUserLayerIndex, doc.Layers.CurrentUserLayerIndex - 1);
 
-			doc.MoveCurrentLayerDown ();
+			doc.Layers.MoveCurrentLayerDown ();
 			doc.History.PushNewItem (hist);
 		}
 
@@ -242,13 +242,13 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			int bottomLayerIndex = doc.CurrentUserLayerIndex - 1;
-			var oldBottomSurface = doc.UserLayers[bottomLayerIndex].Surface.Clone ();
+			int bottomLayerIndex = doc.Layers.CurrentUserLayerIndex - 1;
+			var oldBottomSurface = doc.Layers.UserLayers[bottomLayerIndex].Surface.Clone ();
 
 			CompoundHistoryItem hist = new CompoundHistoryItem (Resources.Icons.LayerMergeDown, Translations.GetString ("Merge Layer Down"));
-			DeleteLayerHistoryItem h1 = new DeleteLayerHistoryItem (string.Empty, string.Empty, doc.CurrentUserLayer, doc.CurrentUserLayerIndex);
+			DeleteLayerHistoryItem h1 = new DeleteLayerHistoryItem (string.Empty, string.Empty, doc.Layers.CurrentUserLayer, doc.Layers.CurrentUserLayerIndex);
 
-			doc.MergeCurrentLayerDown ();
+			doc.Layers.MergeCurrentLayerDown ();
 
 			SimpleHistoryItem h2 = new SimpleHistoryItem (string.Empty, string.Empty, oldBottomSurface, bottomLayerIndex);
 			hist.Push (h1);
@@ -262,12 +262,12 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			UserLayer l = doc.DuplicateCurrentLayer();
+			UserLayer l = doc.Layers.DuplicateCurrentLayer();
 			
 			// Make new layer the current layer
-			doc.SetCurrentUserLayer (l);
+			doc.Layers.SetCurrentUserLayer (l);
 
-			AddLayerHistoryItem hist = new AddLayerHistoryItem (Resources.Icons.LayerDuplicate, Translations.GetString ("Duplicate Layer"), doc.UserLayers.IndexOf (l));
+			AddLayerHistoryItem hist = new AddLayerHistoryItem (Resources.Icons.LayerDuplicate, Translations.GetString ("Duplicate Layer"), doc.Layers.IndexOf (l));
 			doc.History.PushNewItem (hist);
 		}
 
@@ -276,9 +276,9 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			DeleteLayerHistoryItem hist = new DeleteLayerHistoryItem (Resources.Icons.LayerDelete, Translations.GetString ("Delete Layer"), doc.CurrentUserLayer, doc.CurrentUserLayerIndex);
+			DeleteLayerHistoryItem hist = new DeleteLayerHistoryItem (Resources.Icons.LayerDelete, Translations.GetString ("Delete Layer"), doc.Layers.CurrentUserLayer, doc.Layers.CurrentUserLayerIndex);
 
-			doc.DeleteLayer (doc.CurrentUserLayerIndex, false);
+			doc.Layers.DeleteLayer (doc.Layers.CurrentUserLayerIndex, false);
 
 			doc.History.PushNewItem (hist);
 		}
@@ -288,12 +288,12 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			UserLayer l = doc.AddNewLayer(string.Empty);
+			UserLayer l = doc.Layers.AddNewLayer (string.Empty);
 
 			// Make new layer the current layer
-			doc.SetCurrentUserLayer (l);
+			doc.Layers.SetCurrentUserLayer (l);
 
-			AddLayerHistoryItem hist = new AddLayerHistoryItem (Resources.Icons.LayerNew, Translations.GetString ("Add New Layer"), doc.UserLayers.IndexOf (l));
+			AddLayerHistoryItem hist = new AddLayerHistoryItem (Resources.Icons.LayerNew, Translations.GetString ("Add New Layer"), doc.Layers.IndexOf (l));
 			doc.History.PushNewItem (hist);
 		}
 		#endregion

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Cairo;
+
+namespace Pinta.Core
+{
+	public class DocumentLayers
+	{
+		private readonly Document document;
+		private readonly List<UserLayer> user_layers = new ();
+
+		private int layer_name_int = 2;
+
+		// The layer for tools to use until their output is committed
+		private Layer? tool_layer;
+
+		// The layer used for selections
+		private Layer? selection_layer;
+
+		public DocumentLayers (Document document)
+		{
+			this.document = document;
+		}
+
+		/// <summary>
+		/// Gets the currently selected user created layer.
+		/// </summary>
+		public UserLayer CurrentUserLayer => user_layers[CurrentUserLayerIndex];
+
+		/// <summary>
+		/// Gets the index of the currently selected user created layer.
+		/// </summary>
+		public int CurrentUserLayerIndex { get; private set; } = -1;
+
+		/// <summary>
+		/// Gets the layer used for drawing and managing selections.
+		/// </summary>
+		public Layer SelectionLayer {
+			get {
+				if (selection_layer is null)
+					CreateSelectionLayer ();
+
+				return selection_layer;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets whether the Selection layer should be shown.
+		/// </summary>
+		public bool ShowSelectionLayer { get; set; }
+
+		/// <summary>
+		/// Gets a scratch layer for tools to temporarily use until their content
+		/// is committed to the actual layer.
+		/// </summary>
+		public Layer ToolLayer {
+			get {
+				if (tool_layer is null || tool_layer.Surface.Width != document.ImageSize.Width || tool_layer.Surface.Height != document.ImageSize.Height) {
+					tool_layer?.Surface.Dispose ();
+					tool_layer = CreateLayer ("Tool Layer");
+					tool_layer.Hidden = true;
+				}
+
+				return tool_layer;
+			}
+		}
+
+		/// <summary>
+		/// Collection of user layers.
+		/// </summary>
+		public IReadOnlyList<UserLayer> UserLayers => user_layers;
+
+		/// <summary>
+		/// Creates a new layer and adds it to the Layer collection after the
+		/// currently selected layer.
+		/// </summary>
+		public UserLayer AddNewLayer (string name)
+		{
+			UserLayer layer;
+
+			if (string.IsNullOrEmpty (name))
+				layer = CreateLayer ();
+			else
+				layer = CreateLayer (name);
+
+			user_layers.Insert (CurrentUserLayerIndex + 1, layer);
+
+			if (user_layers.Count == 1)
+				CurrentUserLayerIndex = 0;
+
+			layer.PropertyChanged += document.RaiseLayerPropertyChangedEvent;
+
+			PintaCore.Layers.OnLayerAdded ();
+			return layer;
+		}
+
+
+		/// <summary>
+		/// Disposes all user created and internal layers.
+		/// </summary>
+		internal void Close ()
+		{
+			// Dispose all of our layers
+			while (user_layers.Count > 0) {
+				var l = user_layers[user_layers.Count - 1];
+				user_layers.RemoveAt (user_layers.Count - 1);
+				l.Surface.Dispose ();
+			}
+
+			CurrentUserLayerIndex = -1;
+
+			tool_layer?.Surface.Dispose ();
+			selection_layer?.Surface.Dispose ();
+		}
+
+		/// <summary>
+		/// Creates a new layer, but does not add it to the layer collection.
+		/// </summary>
+		public UserLayer CreateLayer (string? name = null, int? width = null, int? height = null)
+		{
+			name ??= $"{Translations.GetString ("Layer")} {layer_name_int++}";
+			width ??= document.ImageSize.Width;
+			height ??= document.ImageSize.Height;
+
+			var surface = new ImageSurface (Format.ARGB32, width.Value, height.Value);
+			var layer = new UserLayer (surface) { Name = name };
+
+			return layer;
+		}
+
+		/// <summary>
+		/// Creates a new SelectionLayer.
+		/// </summary>
+		[MemberNotNull (nameof (selection_layer))]
+		public void CreateSelectionLayer ()
+		{
+			var old = selection_layer;
+
+			selection_layer = CreateLayer ();
+
+			old?.Surface.Dispose ();
+		}
+
+		/// <summary>
+		/// Creates a new SelectionLayer with the specified dimensions.
+		/// </summary>
+		[MemberNotNull (nameof (selection_layer))]
+		public void CreateSelectionLayer (int width, int height)
+		{
+			var old = selection_layer;
+
+			selection_layer = CreateLayer (null, width, height);
+
+			old?.Surface.Dispose ();
+		}
+
+		/// <summary>
+		/// Deletes the current layer and removes it from the layer collection.
+		/// </summary>
+		public void DeleteCurrentLayer ()
+		{
+			var layer = CurrentUserLayer;
+
+			user_layers.RemoveAt (CurrentUserLayerIndex);
+
+			// Only change this if this wasn't already the bottom layer
+			if (CurrentUserLayerIndex > 0)
+				CurrentUserLayerIndex--;
+
+			layer.PropertyChanged -= document.RaiseLayerPropertyChangedEvent;
+
+			PintaCore.Layers.OnLayerRemoved ();
+		}
+
+		/// <summary>
+		/// Deletes the user layer at the specified index and removes it from the
+		/// layer collection, optionally Disposing the layer surface.
+		/// </summary>
+		/// <param name="index"></param>
+		/// <param name="dispose"></param>
+		public void DeleteLayer (int index, bool dispose)
+		{
+			var layer = user_layers[index];
+
+			user_layers.RemoveAt (index);
+
+			if (dispose)
+				layer.Surface.Dispose ();
+
+			// Only change this if this wasn't already the bottom layer
+			if (CurrentUserLayerIndex > 0)
+				CurrentUserLayerIndex--;
+
+			layer.PropertyChanged -= document.RaiseLayerPropertyChangedEvent;
+
+			PintaCore.Layers.OnLayerRemoved ();
+		}
+
+		/// <summary>
+		/// Hide and reset the SelectionLayer.
+		/// </summary>
+		public void DestroySelectionLayer ()
+		{
+			ShowSelectionLayer = false;
+			SelectionLayer.Clear ();
+			SelectionLayer.Transform.InitIdentity ();
+		}
+
+		/// <summary>
+		/// Duplicate the currently selected user layer, adding the new
+		/// layer to the layer collection after the current layer.
+		/// </summary>
+		public UserLayer DuplicateCurrentLayer ()
+		{
+			var source = CurrentUserLayer;
+			var layer = CreateLayer ($"{source.Name} {Translations.GetString ("copy")}");
+
+			using (var g = new Context (layer.Surface)) {
+				g.SetSource (source.Surface);
+				g.Paint ();
+			}
+
+			layer.Hidden = source.Hidden;
+			layer.Opacity = source.Opacity;
+			layer.Tiled = source.Tiled;
+
+			user_layers.Insert (++CurrentUserLayerIndex, layer);
+
+			layer.PropertyChanged += document.RaiseLayerPropertyChangedEvent;
+
+			PintaCore.Layers.OnLayerAdded ();
+
+			return layer;
+		}
+
+		/// <summary>
+		/// Flatten all user layers to a single layer.
+		/// </summary>
+		public void FlattenLayers ()
+		{
+			if (user_layers.Count < 2)
+				throw new InvalidOperationException ("Cannot flatten image because there is only one layer.");
+
+			// Find the "bottom" layer
+			var bottom_layer = user_layers[0];
+			var old_surf = bottom_layer.Surface;
+
+			// Replace the bottom surface with the flattened image,
+			// and dispose the old surface
+			bottom_layer.Surface = GetFlattenedImage ();
+			old_surf.Dispose ();
+
+			// Reset our layer pointer to the only remaining layer
+			CurrentUserLayerIndex = 0;
+
+			// Delete all other layers
+			while (user_layers.Count > 1)
+				user_layers.RemoveAt (1);
+
+			PintaCore.Layers.OnLayerRemoved ();
+			document.Workspace.Invalidate ();
+		}
+
+		/// <summary>
+		/// Gets a copy of the specified layer, clipped to the current selection.
+		/// </summary>
+		public ImageSurface GetClippedLayer (int index)
+		{
+			var surf = new ImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
+
+			using (var g = new Context (surf)) {
+				g.AppendPath (document.Selection.SelectionPath);
+				g.Clip ();
+
+				g.SetSource (user_layers[index].Surface);
+				g.Paint ();
+			}
+
+			return surf;
+		}
+
+		/// <summary>
+		/// Returns all layers flattened to a new surface.
+		/// </summary>
+		internal ImageSurface GetFlattenedImage ()
+		{
+			// Create a new image surface
+			var surf = new ImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
+
+			// Blend each visible layer onto our surface
+			foreach (var layer in GetLayersToPaint (includeToolLayer: false)) {
+				using (var g = new Context (surf))
+					layer.Draw (g);
+			}
+
+			surf.MarkDirty ();
+			return surf;
+		}
+
+		/// <summary>
+		/// Returns all layers that are visible and need to be painted, optionally
+		/// including tool and selection layers.
+		/// </summary>
+		public List<Layer> GetLayersToPaint (bool includeToolLayer = true)
+		{
+			var paint_layers = new List<Layer> ();
+
+			foreach (var layer in user_layers) {
+				if (!layer.Hidden)
+					paint_layers.Add (layer);
+
+				if (layer == CurrentUserLayer) {
+					if (includeToolLayer && tool_layer is not null && !ToolLayer.Hidden)
+						paint_layers.Add (ToolLayer);
+
+					if (ShowSelectionLayer && (!SelectionLayer.Hidden))
+						paint_layers.Add (SelectionLayer);
+				}
+
+				if (!layer.Hidden) {
+					foreach (var rel in layer.ReEditableLayers) {
+						//Make sure that each UserLayer's ReEditableLayer is in use before adding it to the List of Layers to Paint.
+						if (rel.IsLayerSetup)
+							paint_layers.Add (rel.Layer);
+					}
+				}
+			}
+
+			return paint_layers;
+		}
+
+		/// <summary>
+		/// Returns the index of the specified user layer.
+		/// </summary>
+		public int IndexOf (UserLayer layer)
+		{
+			return user_layers.IndexOf (layer);
+		}
+
+		/// <summary>
+		/// Adds the provided layer at the requested index of the layer collection.
+		/// </summary>
+		public void Insert (UserLayer layer, int index)
+		{
+			user_layers.Insert (index, layer);
+
+			if (user_layers.Count == 1)
+				CurrentUserLayerIndex = 0;
+
+			layer.PropertyChanged += document.RaiseLayerPropertyChangedEvent;
+
+			PintaCore.Layers.OnLayerAdded ();
+		}
+
+		/// <summary>
+		/// Merges the current layer with the one below it.
+		/// </summary>
+		public void MergeCurrentLayerDown ()
+		{
+			if (CurrentUserLayerIndex == 0)
+				throw new InvalidOperationException ("Cannot flatten layer because current layer is the bottom layer.");
+
+			// Get our source and destination layers
+			var source = CurrentUserLayer;
+			var dest = user_layers[CurrentUserLayerIndex - 1];
+
+			// Blend the layers
+			using (var g = new Context (dest.Surface))
+				source.Draw (g);
+
+			DeleteCurrentLayer ();
+		}
+
+		/// <summary>
+		/// Moves the current layer down 1 position in the layer collection.
+		/// </summary>
+		public void MoveCurrentLayerDown ()
+		{
+			if (CurrentUserLayerIndex == 0)
+				throw new InvalidOperationException ("Cannot move layer down because current layer is the bottom layer.");
+
+			var layer = CurrentUserLayer;
+			user_layers.RemoveAt (CurrentUserLayerIndex);
+			user_layers.Insert (--CurrentUserLayerIndex, layer);
+
+			PintaCore.Layers.OnSelectedLayerChanged ();
+
+			document.Workspace.Invalidate ();
+		}
+
+		/// <summary>
+		/// Moves the current layer up 1 position in the layer collection.
+		/// </summary>
+		public void MoveCurrentLayerUp ()
+		{
+			if (CurrentUserLayerIndex == user_layers.Count)
+				throw new InvalidOperationException ("Cannot move layer up because current layer is the top layer.");
+
+			var layer = CurrentUserLayer;
+			user_layers.RemoveAt (CurrentUserLayerIndex);
+			user_layers.Insert (++CurrentUserLayerIndex, layer);
+
+			PintaCore.Layers.OnSelectedLayerChanged ();
+
+			document.Workspace.Invalidate ();
+		}
+
+		/// <summary>
+		/// Set the current user layer to the index specified.
+		/// </summary>
+		public void SetCurrentUserLayer (int i)
+		{
+			// Ensure that the current tool's modifications are finalized before
+			// switching layers.
+			PintaCore.Tools.CurrentTool.DoCommit ();
+
+			CurrentUserLayerIndex = i;
+			PintaCore.Layers.OnSelectedLayerChanged ();
+		}
+
+		/// <summary>
+		/// Set the current user layer to the layer specified.
+		/// </summary>
+		public void SetCurrentUserLayer (UserLayer layer)
+		{
+			SetCurrentUserLayer (user_layers.IndexOf (layer));
+		}
+	}
+}

--- a/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
@@ -71,7 +71,7 @@ namespace Pinta.Core
 		public void StartSnapshotOfImage ()
 		{
 			snapshots = new List<ImageSurface> ();
-			foreach (UserLayer item in PintaCore.Workspace.ActiveDocument.UserLayers) {
+			foreach (UserLayer item in PintaCore.Workspace.ActiveDocument.Layers.UserLayers) {
 				snapshots.Add (item.Surface.Clone ());
 			}
 		}

--- a/Pinta.Core/HistoryItems/InvertHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/InvertHistoryItem.cs
@@ -107,11 +107,11 @@ namespace Pinta.Core
 					PintaCore.Layers.RotateImageCW ();
 					break;
 				case InvertType.FlipLayerHorizontal:
-					PintaCore.Workspace.ActiveDocument.UserLayers[layer_index].FlipHorizontal ();
+					PintaCore.Workspace.ActiveDocument.Layers.UserLayers[layer_index].FlipHorizontal ();
 					PintaCore.Workspace.Invalidate ();
 					break;
 				case InvertType.FlipLayerVertical:
-					PintaCore.Workspace.ActiveDocument.UserLayers[layer_index].FlipVertical ();
+					PintaCore.Workspace.ActiveDocument.Layers.UserLayers[layer_index].FlipVertical ();
 					PintaCore.Workspace.Invalidate ();
 					break;
 			}
@@ -139,11 +139,11 @@ namespace Pinta.Core
 					PintaCore.Layers.RotateImageCCW ();
 					break;
 				case InvertType.FlipLayerHorizontal:
-					PintaCore.Workspace.ActiveDocument.UserLayers[layer_index].FlipHorizontal ();
+					PintaCore.Workspace.ActiveDocument.Layers.UserLayers[layer_index].FlipHorizontal ();
 					PintaCore.Workspace.Invalidate ();
 					break;
 				case InvertType.FlipLayerVertical:
-					PintaCore.Workspace.ActiveDocument.UserLayers[layer_index].FlipVertical ();
+					PintaCore.Workspace.ActiveDocument.Layers.UserLayers[layer_index].FlipVertical ();
 					PintaCore.Workspace.Invalidate ();
 					break;
 			}

--- a/Pinta.Core/HistoryItems/MovePixelsHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/MovePixelsHistoryItem.cs
@@ -89,7 +89,7 @@ namespace Pinta.Core
 				old_surface = surf;
 
 				is_lifted = !is_lifted;
-				doc.ShowSelectionLayer = is_lifted;
+				doc.Layers.ShowSelectionLayer = is_lifted;
 			}
 
 			PintaCore.Workspace.Invalidate ();
@@ -101,8 +101,8 @@ namespace Pinta.Core
 			is_lifted = true;
 
 			if (lift) {
-				layer_index = doc.CurrentUserLayerIndex;
-				old_surface = doc.CurrentUserLayer.Surface.Clone ();
+				layer_index = doc.Layers.CurrentUserLayerIndex;
+				old_surface = doc.Layers.CurrentUserLayer.Surface.Clone ();
 			}
 				
 			old_selection = PintaCore.Workspace.ActiveDocument.Selection.Clone ();

--- a/Pinta.Core/HistoryItems/PasteHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/PasteHistoryItem.cs
@@ -51,10 +51,10 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			// Copy the paste to the temp layer
-			doc.CreateSelectionLayer ();
-			doc.ShowSelectionLayer = true;
+			doc.Layers.CreateSelectionLayer ();
+			doc.Layers.ShowSelectionLayer = true;
 
-			using (Cairo.Context g = new Cairo.Context (doc.SelectionLayer.Surface)) {
+			using (Cairo.Context g = new Cairo.Context (doc.Layers.SelectionLayer.Surface)) {
 				g.DrawPixbuf (paste_image, new Cairo.Point (0, 0));
 			}
 

--- a/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
@@ -62,10 +62,10 @@ namespace Pinta.Core
 		{
 			var doc = PintaCore.Workspace.ActiveDocument;
 			DocumentSelection swap_selection = doc.Selection;
-			bool swap_hide_tool_layer = doc.ToolLayer.Hidden;
+			bool swap_hide_tool_layer = doc.Layers.ToolLayer.Hidden;
 
 			doc.Selection = old_selection!; // NRT - Set in TakeSnapshot
-			doc.ToolLayer.Hidden = hide_tool_layer;
+			doc.Layers.ToolLayer.Hidden = hide_tool_layer;
 
 			old_selection = swap_selection;
 			hide_tool_layer = swap_hide_tool_layer;
@@ -82,7 +82,7 @@ namespace Pinta.Core
 			var doc = PintaCore.Workspace.ActiveDocument;
 			old_selection = doc.Selection.Clone ();
             old_previous_selection = doc.PreviousSelection.Clone ();
-			hide_tool_layer = doc.ToolLayer.Hidden;
+			hide_tool_layer = doc.Layers.ToolLayer.Hidden;
 		}
 	}
 }

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -60,7 +60,7 @@ namespace Pinta.Core
 			doc.ImageSize = imagesize;
 			doc.Workspace.CanvasSize = imagesize;
 
-			Layer layer = doc.AddNewLayer (Path.GetFileName (fileName));
+			Layer layer = doc.Layers.AddNewLayer (Path.GetFileName (fileName));
 
 			using (Cairo.Context g = new Cairo.Context (layer.Surface)) {
 				CairoHelper.SetSourcePixbuf (g, bg, 0, 0);

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -94,8 +94,8 @@ namespace Pinta.Core
 						}
 					}
 
-					UserLayer layer = doc.CreateLayer(name);
-					doc.Insert (layer, 0);
+					UserLayer layer = doc.Layers.CreateLayer (name);
+					doc.Layers.Insert (layer, 0);
 
 					layer.Opacity = double.Parse (GetAttribute (layerElement, "opacity", "1"), GetFormat ());
 					layer.BlendMode = StandardToBlendMode (GetAttribute (layerElement, "composite-op", "svg:src-over"));
@@ -158,7 +158,7 @@ namespace Pinta.Core
 				return new Size ((int) ((double)width / height * ThumbMaxSize), ThumbMaxSize);
 		}
 
-		private byte[] GetLayerXmlData(List<UserLayer> layers)
+		private byte[] GetLayerXmlData(IReadOnlyList<UserLayer> layers)
 		{
 			MemoryStream ms = new MemoryStream ();
 			XmlTextWriter writer = new XmlTextWriter (ms, System.Text.Encoding.UTF8);
@@ -199,8 +199,8 @@ namespace Pinta.Core
 			byte[] databytes = System.Text.Encoding.ASCII.GetBytes ("image/openraster");
 			stream.Write (databytes, 0, databytes.Length);
 
-			for (int i = 0; i < document.UserLayers.Count; i++) {
-				Pixbuf pb = document.UserLayers[i].Surface.ToPixbuf ();
+			for (int i = 0; i < document.Layers.UserLayers.Count; i++) {
+				Pixbuf pb = document.Layers.UserLayers[i].Surface.ToPixbuf ();
 				byte[] buf = pb.SaveToBuffer ("png");
 				(pb as IDisposable).Dispose ();
 
@@ -209,7 +209,7 @@ namespace Pinta.Core
 			}
 
 			stream.PutNextEntry (new ZipEntry ("stack.xml"));
-			databytes = GetLayerXmlData (document.UserLayers);
+			databytes = GetLayerXmlData (document.Layers.UserLayers);
 			stream.Write (databytes, 0, databytes.Length);
 
 			ImageSurface flattened = document.GetFlattenedImage ();

--- a/Pinta.Core/Managers/LayerManager.cs
+++ b/Pinta.Core/Managers/LayerManager.cs
@@ -38,55 +38,50 @@ namespace Pinta.Core
 		#region Public Properties
 		public UserLayer this[int index]
 		{
-			get { return PintaCore.Workspace.ActiveDocument.UserLayers[index]; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.UserLayers[index]; }
 		}
 
 		public UserLayer CurrentLayer
 		{
-			get { return PintaCore.Workspace.ActiveDocument.CurrentUserLayer; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer; }
 		}
 
 		public int Count {
-			get { return PintaCore.Workspace.ActiveDocument.UserLayers.Count; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.UserLayers.Count; }
 		}
 
 		public Layer ToolLayer {
-			get { return PintaCore.Workspace.ActiveDocument.ToolLayer; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.ToolLayer; }
 		}
 
 		public Layer SelectionLayer {
-			get { return PintaCore.Workspace.ActiveDocument.SelectionLayer; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.SelectionLayer; }
 		}
 
 		public int CurrentLayerIndex {
-			get { return PintaCore.Workspace.ActiveDocument.CurrentUserLayerIndex; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayerIndex; }
 		}
 		
 		public bool ShowSelectionLayer {
-			get { return PintaCore.Workspace.ActiveDocument.ShowSelectionLayer; }
-			set { PintaCore.Workspace.ActiveDocument.ShowSelectionLayer = value; }
+			get { return PintaCore.Workspace.ActiveDocument.Layers.ShowSelectionLayer; }
+			set { PintaCore.Workspace.ActiveDocument.Layers.ShowSelectionLayer = value; }
 		}
 		#endregion
 
 		#region Public Methods
-		public void Clear ()
-		{
-			PintaCore.Workspace.ActiveDocument.Clear ();
-		}
-
 		public List<Layer> GetLayersToPaint ()
 		{
-			return PintaCore.Workspace.ActiveDocument.GetLayersToPaint ();
+			return PintaCore.Workspace.ActiveDocument.Layers.GetLayersToPaint ();
 		}
 
 		public void SetCurrentLayer (int i)
 		{
-			PintaCore.Workspace.ActiveDocument.SetCurrentUserLayer (i);
+			PintaCore.Workspace.ActiveDocument.Layers.SetCurrentUserLayer (i);
 		}
 
 		public void SetCurrentLayer(UserLayer layer)
 		{
-			PintaCore.Workspace.ActiveDocument.SetCurrentUserLayer (layer);
+			PintaCore.Workspace.ActiveDocument.Layers.SetCurrentUserLayer (layer);
 		}
 
 		public void FinishSelection ()
@@ -97,54 +92,54 @@ namespace Pinta.Core
 		// Adds a new layer above the current one
 		public UserLayer AddNewLayer(string name)
 		{
-			return PintaCore.Workspace.ActiveDocument.AddNewLayer (name);
+			return PintaCore.Workspace.ActiveDocument.Layers.AddNewLayer (name);
 		}
 		
 		// Adds a new layer above the current one
 		public void Insert(UserLayer layer, int index)
 		{
-			PintaCore.Workspace.ActiveDocument.Insert (layer, index);
+			PintaCore.Workspace.ActiveDocument.Layers.Insert (layer, index);
 		}
 
 		public int IndexOf(UserLayer layer)
 		{
-			return PintaCore.Workspace.ActiveDocument.IndexOf (layer);
+			return PintaCore.Workspace.ActiveDocument.Layers.IndexOf (layer);
 		}
 
 		// Delete the current layer
 		public void DeleteCurrentLayer ()
 		{
-			PintaCore.Workspace.ActiveDocument.DeleteCurrentLayer ();
+			PintaCore.Workspace.ActiveDocument.Layers.DeleteCurrentLayer ();
 		}
 
 		// Delete the layer
 		public void DeleteLayer (int index, bool dispose)
 		{
-			PintaCore.Workspace.ActiveDocument.DeleteLayer (index, dispose);
+			PintaCore.Workspace.ActiveDocument.Layers.DeleteLayer (index, dispose);
 		}
 
 		// Duplicate current layer
 		public Layer DuplicateCurrentLayer ()
 		{
-			return PintaCore.Workspace.ActiveDocument.DuplicateCurrentLayer ();
+			return PintaCore.Workspace.ActiveDocument.Layers.DuplicateCurrentLayer ();
 		}
 
 		// Flatten current layer
 		public void MergeCurrentLayerDown ()
 		{
-			PintaCore.Workspace.ActiveDocument.MergeCurrentLayerDown ();
+			PintaCore.Workspace.ActiveDocument.Layers.MergeCurrentLayerDown ();
 		}
 
 		// Move current layer up
 		public void MoveCurrentLayerUp ()
 		{
-			PintaCore.Workspace.ActiveDocument.MoveCurrentLayerUp ();
+			PintaCore.Workspace.ActiveDocument.Layers.MoveCurrentLayerUp ();
 		}
 
 		// Move current layer down
 		public void MoveCurrentLayerDown ()
 		{
-			PintaCore.Workspace.ActiveDocument.MoveCurrentLayerDown ();
+			PintaCore.Workspace.ActiveDocument.Layers.MoveCurrentLayerDown ();
 		}
 
 		// Flip image horizontally
@@ -178,27 +173,22 @@ namespace Pinta.Core
 		// Flatten image
 		public void FlattenImage ()
 		{
-			PintaCore.Workspace.ActiveDocument.FlattenImage ();
+			PintaCore.Workspace.ActiveDocument.Layers.FlattenLayers ();
 		}
 		
 		public void CreateSelectionLayer ()
 		{
-			PintaCore.Workspace.ActiveDocument.CreateSelectionLayer ();
+			PintaCore.Workspace.ActiveDocument.Layers.CreateSelectionLayer ();
 		}
 		
 		public void DestroySelectionLayer ()
 		{
-			PintaCore.Workspace.ActiveDocument.DestroySelectionLayer ();
+			PintaCore.Workspace.ActiveDocument.Layers.DestroySelectionLayer ();
 		}
 
 		public void ResetSelectionPath ()
 		{
 			PintaCore.Workspace.ActiveDocument.ResetSelectionPaths ();
-		}
-
-		public ImageSurface GetClippedLayer (int index)
-		{
-			return PintaCore.Workspace.ActiveDocument.GetClippedLayer (index);
 		}
 		#endregion
 
@@ -225,12 +215,12 @@ namespace Pinta.Core
 		#region Private Methods
 		public Layer CreateLayer ()
 		{
-			return PintaCore.Workspace.ActiveDocument.CreateLayer ();
+			return PintaCore.Workspace.ActiveDocument.Layers.CreateLayer ();
 		}
 
 		public Layer CreateLayer (string name, int width, int height)
 		{
-			return PintaCore.Workspace.ActiveDocument.CreateLayer (name, width, height);
+			return PintaCore.Workspace.ActiveDocument.Layers.CreateLayer (name, width, height);
 		}
 		
 		internal void RaiseLayerPropertyChangedEvent (object? sender, PropertyChangedEventArgs e)

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -153,7 +153,7 @@ namespace Pinta.Core
 			doc.Workspace.CanvasSize = imageSize;
 
 			// Start with an empty white layer
-			Layer background = doc.AddNewLayer (Translations.GetString ("Background"));
+			Layer background = doc.Layers.AddNewLayer (Translations.GetString ("Background"));
 
 			if (backgroundColor.A != 0) {
 				using (Cairo.Context g = new Cairo.Context (background.Surface)) {

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -140,7 +140,7 @@ namespace Pinta.Gui.Widgets
             g.Translate (x, y);
 
             // Render all the layers to a surface
-            var layers = document.GetLayersToPaint ();
+            var layers = document.Layers.GetLayersToPaint ();
 
             if (layers.Count == 0)
                 canvas.Clear ();

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListWidget.cs
@@ -228,17 +228,17 @@ namespace Pinta.Gui.Widgets
 
 			var doc = PintaCore.Workspace.ActiveDocument;
 				
-			foreach (var layer in (doc.UserLayers as IEnumerable<Layer>).Reverse ()) {
+			foreach (var layer in (doc.Layers.UserLayers as IEnumerable<Layer>).Reverse ()) {
 				var surf = layer.Surface;
 
 				// Draw the selection layer on top of the active layer.
-				if (layer == doc.CurrentUserLayer && doc.ShowSelectionLayer) {
+				if (layer == doc.Layers.CurrentUserLayer && doc.Layers.ShowSelectionLayer) {
 					active_layer_surface = new Cairo.ImageSurface (Cairo.Format.Argb32, thumbnail_width,
 					                                               thumbnail_height);
 					canvas_renderer.Initialize (doc.ImageSize,
 					                            new Gdk.Size (thumbnail_width, thumbnail_height));
 
-					var layers = new List<Layer> { layer, doc.SelectionLayer };
+					var layers = new List<Layer> { layer, doc.Layers.SelectionLayer };
 					canvas_renderer.Render (layers, active_layer_surface, Gdk.Point.Zero);
 
 					surf = active_layer_surface;

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -531,7 +531,7 @@ namespace Pinta.Tools
 						//Create a new ShapesHistoryItem so that the deletion of a shape can be undone.
 						doc.History.PushNewItem(
 							new ShapesHistoryItem(this, owner.Icon, ShapeName + " " + Translations.GetString("Deleted"),
-								doc.CurrentUserLayer.Surface.Clone(), doc.CurrentUserLayer, SelectedPointIndex, SelectedShapeIndex, false));
+								doc.Layers.CurrentUserLayer.Surface.Clone(), doc.Layers.CurrentUserLayer, SelectedPointIndex, SelectedShapeIndex, false));
 
 
 						//Since the shape itself will be deleted, remove its ReEditableLayer from the drawing loop.
@@ -916,7 +916,7 @@ namespace Pinta.Tools
 
 					//Create a new ShapesHistoryItem so that the creation of a new shape can be undone.
 					doc.History.PushNewItem(new ShapesHistoryItem(this, owner.Icon, ShapeName + " " + Translations.GetString("Added"),
-						doc.CurrentUserLayer.Surface.Clone(), doc.CurrentUserLayer, SelectedPointIndex, SelectedShapeIndex, false));
+						doc.Layers.CurrentUserLayer.Surface.Clone(), doc.Layers.CurrentUserLayer, SelectedPointIndex, SelectedShapeIndex, false));
 
 					//Create the shape, add its starting points, and add it to SEngines.
 					SEngines.Add(CreateShape(ctrlKey, clickedOnControlPoint, prevSelPoint));
@@ -1182,7 +1182,7 @@ namespace Pinta.Tools
 		private void BeforeDraw()
 		{
 			//Clear the ToolLayer if it was used previously (e.g. for hover points when there was no active shape).
-			PintaCore.Workspace.ActiveDocument.ToolLayer.Clear();
+			PintaCore.Workspace.ActiveDocument.Layers.ToolLayer.Clear();
 
 			//Invalidate the old hover point bounds, if any.
 			if (last_hover != null)
@@ -1210,7 +1210,7 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			//Since there is no active ShapeEngine, the ToolLayer's surface will be used to draw the hover point on.
-			using (Context g = new Context(doc.ToolLayer.Surface))
+			using (Context g = new Context(doc.Layers.ToolLayer.Surface))
 			{
 				g.AppendPath(doc.Selection.SelectionPath);
 				g.FillRule = FillRule.EvenOdd;
@@ -1222,7 +1222,7 @@ namespace Pinta.Tools
 				DrawHoverPoint(g);
 			}
 
-			doc.ToolLayer.Hidden = false;
+			doc.Layers.ToolLayer.Hidden = false;
 		}
 
 		/// <summary>
@@ -1244,12 +1244,12 @@ namespace Pinta.Tools
 				//We only need to create a history item if there was a previous shape.
 				if (engine.ControlPoints.Count > 0)
 				{
-					undoSurface = doc.CurrentUserLayer.Surface.Clone();
+					undoSurface = doc.Layers.CurrentUserLayer.Surface.Clone();
 				}
 			}
 
 			//Draw the finalized shape.
-			Rectangle dirty = DrawShape(engine, doc.CurrentUserLayer, false, false);
+			Rectangle dirty = DrawShape(engine, doc.Layers.CurrentUserLayer, false, false);
 
 			if (createHistoryItem)
 			{
@@ -1258,7 +1258,7 @@ namespace Pinta.Tools
 				{
 					//Create a new ShapesHistoryItem so that the finalization of the shape can be undone.
 					doc.History.PushNewItem(new ShapesHistoryItem(this, owner.Icon, ShapeName + " " + Translations.GetString("Finalized"),
-						undoSurface, doc.CurrentUserLayer, SelectedPointIndex, SelectedShapeIndex, false));
+						undoSurface, doc.Layers.CurrentUserLayer, SelectedPointIndex, SelectedShapeIndex, false));
 				}
 			}
 
@@ -1633,7 +1633,7 @@ namespace Pinta.Tools
 
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			ImageSurface undoSurface = doc.CurrentUserLayer.Surface.Clone();
+			ImageSurface undoSurface = doc.Layers.CurrentUserLayer.Surface.Clone();
 			
 			int previousSelectedPointIndex = SelectedPointIndex;
 
@@ -1669,7 +1669,7 @@ namespace Pinta.Tools
 			{
 				//Create a new ShapesHistoryItem so that the finalization of the shapes can be undone.
 				doc.History.PushNewItem(new ShapesHistoryItem(this, owner.Icon, Translations.GetString("Finalized"),
-					undoSurface, doc.CurrentUserLayer, previousSelectedPointIndex, prev_selected_shape_index, true));
+					undoSurface, doc.Layers.CurrentUserLayer, previousSelectedPointIndex, prev_selected_shape_index, true));
 			}
 
 			if (dirty.HasValue)
@@ -1678,7 +1678,7 @@ namespace Pinta.Tools
 			}
 
             // Ensure the ToolLayer gets hidden now that we're done with it
-            doc.ToolLayer.Hidden = true;
+            doc.Layers.ToolLayer.Hidden = true;
 
 			//Clear out all of the data.
 			ResetShapes();

--- a/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			ShapeEngine newEngine = new EllipseEngine(doc.CurrentUserLayer, null, owner.UseAntialiasing,
+			ShapeEngine newEngine = new EllipseEngine(doc.Layers.CurrentUserLayer, null, owner.UseAntialiasing,
 				BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
 
 			AddRectanglePoints(ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);

--- a/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
@@ -52,7 +52,7 @@ namespace Pinta.Tools
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			LineCurveSeriesEngine newEngine = new LineCurveSeriesEngine(doc.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.OpenLineCurveSeries,
+			LineCurveSeriesEngine newEngine = new LineCurveSeriesEngine(doc.Layers.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.OpenLineCurveSeries,
 				owner.UseAntialiasing, false, BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
 
 			AddLinePoints(ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);

--- a/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
@@ -52,7 +52,7 @@ namespace Pinta.Tools
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			ShapeEngine newEngine = new LineCurveSeriesEngine(doc.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.ClosedLineCurveSeries,
+			ShapeEngine newEngine = new LineCurveSeriesEngine(doc.Layers.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.ClosedLineCurveSeries,
 				owner.UseAntialiasing, true, BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
 
 			AddRectanglePoints(ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);

--- a/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
@@ -181,7 +181,7 @@ namespace Pinta.Tools
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			ShapeEngine newEngine = new RoundedLineEngine(doc.CurrentUserLayer, null, Radius, owner.UseAntialiasing,
+			ShapeEngine newEngine = new RoundedLineEngine(doc.Layers.CurrentUserLayer, null, Radius, owner.UseAntialiasing,
 				BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
 
 			AddRectanglePoints(ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -118,7 +118,7 @@ namespace Pinta.Tools
 
 			if (undo_surface != null) {
 				if (surface_modified)
-					doc.History.PushNewItem (new SimpleHistoryItem (Icon, Name, undo_surface, doc.CurrentUserLayerIndex));
+					doc.History.PushNewItem (new SimpleHistoryItem (Icon, Name, undo_surface, doc.Layers.CurrentUserLayerIndex));
 				else if (undo_surface != null)
 					(undo_surface as IDisposable).Dispose ();
 			}
@@ -137,7 +137,7 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			surface_modified = false;
-			undo_surface = doc.CurrentUserLayer.Surface.Clone ();
+			undo_surface = doc.Layers.CurrentUserLayer.Surface.Clone ();
 			mouse_button = args.Event.Button;
 			
 			OnMouseMove (canvas, null, point);

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -86,11 +86,11 @@ namespace Pinta.Tools
 				if (offset.IsNotSet ())
 					offset = new Point ((int)point.X - origin.X, (int)point.Y - origin.Y);
 
-				doc.ToolLayer.Clear ();
-				doc.ToolLayer.Hidden = false;
+				doc.Layers.ToolLayer.Clear ();
+				doc.Layers.ToolLayer.Hidden = false;
 
 				surface_modified = false;
-				undo_surface = doc.CurrentUserLayer.Surface.Clone ();
+				undo_surface = doc.Layers.CurrentUserLayer.Surface.Clone ();
 			} else {
 				origin = point.ToGdkPoint ();
 			}
@@ -117,7 +117,7 @@ namespace Pinta.Tools
 				g.MoveTo (last_point.X, last_point.Y);
 				g.LineTo (x, y);
 
-				g.SetSource (doc.CurrentUserLayer.Surface, offset.X, offset.Y);
+				g.SetSource (doc.Layers.CurrentUserLayer.Surface, offset.X, offset.Y);
 				g.LineWidth = BrushWidth;
 				g.LineCap = Cairo.LineCap.Round;
 
@@ -137,8 +137,8 @@ namespace Pinta.Tools
 
 			painting = false;
 
-			using (Cairo.Context g = new Cairo.Context (doc.CurrentUserLayer.Surface)) {
-				g.SetSource (doc.ToolLayer.Surface);
+			using (Cairo.Context g = new Cairo.Context (doc.Layers.CurrentUserLayer.Surface)) {
+				g.SetSource (doc.Layers.ToolLayer.Surface);
 				g.Paint ();
 			}
 			
@@ -147,8 +147,8 @@ namespace Pinta.Tools
 			offset = new Point (int.MinValue, int.MinValue);
 			last_point = new Point (int.MinValue, int.MinValue);
 
-			doc.ToolLayer.Clear ();
-			doc.ToolLayer.Hidden = true;
+			doc.Layers.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Hidden = true;
 			doc.Workspace.Invalidate ();
 		}
 

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -235,7 +235,7 @@ namespace Pinta.Tools
 		private ColorBgra GetPixel (int x, int y)
 		{
 			if (SampleLayerOnly)
-				return PintaCore.Workspace.ActiveDocument.CurrentUserLayer.Surface.GetColorBgraUnchecked (x, y);
+				return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.Surface.GetColorBgraUnchecked (x, y);
 			else
 				return PintaCore.Workspace.ActiveDocument.GetComputedPixel (x, y);
 		}

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -238,7 +238,7 @@ namespace Pinta.Tools
             if (doc.Workspace.PointInCanvas (new_pointd))
                 surface_modified = true;
 
-            var surf = doc.CurrentUserLayer.Surface;
+            var surf = doc.Layers.CurrentUserLayer.Surface;
             using (Context g = new Context (surf)) {
 
                 g.AppendPath (doc.Selection.SelectionPath);

--- a/Pinta.Tools/Tools/FloodTool.cs
+++ b/Pinta.Tools/Tools/FloodTool.cs
@@ -119,7 +119,7 @@ namespace Pinta.Tools
 				if (!currentRegion.ContainsPoint(pos.X, pos.Y) && limitToSelection)
 					return;
 
-				ImageSurface surface = doc.CurrentUserLayer.Surface;
+				ImageSurface surface = doc.Layers.CurrentUserLayer.Surface;
 				var stencilBuffer = new BitMask ((int) surface.Width, (int) surface.Height);
 				int tol = (int)(Tolerance * Tolerance * 256);
 				Rectangle boundingBox;

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -106,11 +106,11 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			surface_modified = false;
-			undo_surface = doc.CurrentUserLayer.Surface.Clone ();
+			undo_surface = doc.Layers.CurrentUserLayer.Surface.Clone ();
 			path = null;
 
-			doc.ToolLayer.Clear ();
-			doc.ToolLayer.Hidden = false;
+			doc.Layers.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Hidden = false;
 		}
 
 		protected override void OnMouseMove (object o, Gtk.MotionNotifyEventArgs? args, Cairo.PointD point)
@@ -139,8 +139,8 @@ namespace Pinta.Tools
 			if (doc.Workspace.PointInCanvas (point))
 				surface_modified = true;
 
-			doc.ToolLayer.Clear ();
-			ImageSurface surf = doc.ToolLayer.Surface;
+			doc.Layers.ToolLayer.Clear ();
+			ImageSurface surf = doc.Layers.ToolLayer.Surface;
 
 			using (Context g = new Context (surf)) {
 				doc.Selection.Clip(g);
@@ -188,10 +188,10 @@ namespace Pinta.Tools
 		protected override void OnMouseUp (Gtk.DrawingArea canvas, Gtk.ButtonReleaseEventArgs args, Cairo.PointD point)
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
-            doc.ToolLayer.Clear ();
-			doc.ToolLayer.Hidden = true;
+            doc.Layers.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Hidden = true;
 
-			ImageSurface surf = doc.CurrentUserLayer.Surface;
+			ImageSurface surf = doc.Layers.CurrentUserLayer.Surface;
 			using (Context g = new Context (surf)) {
 				g.AppendPath (doc.Selection.SelectionPath);
 				g.FillRule = FillRule.EvenOdd;
@@ -228,7 +228,7 @@ namespace Pinta.Tools
 			}
 
 			if (surface_modified)
-				PintaCore.Workspace.ActiveDocument.History.PushNewItem (new SimpleHistoryItem (Icon, Name, undo_surface!, doc.CurrentUserLayerIndex)); // NRT - Guarded by surface_modified
+				PintaCore.Workspace.ActiveDocument.History.PushNewItem (new SimpleHistoryItem (Icon, Name, undo_surface!, doc.Layers.CurrentUserLayerIndex)); // NRT - Guarded by surface_modified
 			else if (undo_surface != null)
 				(undo_surface as IDisposable).Dispose ();
 

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -67,7 +67,7 @@ namespace Pinta.Tools
 
 			tracking = true;
 			button = args.Event.Button;
-			undo_surface = doc.CurrentUserLayer.Surface.Clone ();
+			undo_surface = doc.Layers.CurrentUserLayer.Surface.Clone ();
 		}
 
 		protected override void OnMouseUp (Gtk.DrawingArea canvas, Gtk.ButtonReleaseEventArgs args, Cairo.PointD point)
@@ -80,7 +80,7 @@ namespace Pinta.Tools
 			tracking = false;
 
 			if (undo_surface != null)
-				doc.History.PushNewItem (new SimpleHistoryItem (Icon, Name, undo_surface, doc.CurrentUserLayerIndex));
+				doc.History.PushNewItem (new SimpleHistoryItem (Icon, Name, undo_surface, doc.Layers.CurrentUserLayerIndex));
 		}
 
 		protected override void OnMouseMove (object o, Gtk.MotionNotifyEventArgs? args, Cairo.PointD point)
@@ -105,7 +105,7 @@ namespace Pinta.Tools
 				gr.BeforeRender ();
 
 				Gdk.Rectangle selection_bounds = doc.GetSelectedBounds (true);
-				ImageSurface scratch_layer = doc.ToolLayer.Surface;
+				ImageSurface scratch_layer = doc.Layers.ToolLayer.Surface;
 
 				gr.Render (scratch_layer, new Gdk.Rectangle[] { selection_bounds });
 
@@ -114,7 +114,7 @@ namespace Pinta.Tools
 					g.Paint ();
 				}
 
-				doc.ToolLayer.Clear ();
+				doc.Layers.ToolLayer.Clear ();
 
 				selection_bounds.Inflate (5, 5);
 				doc.Workspace.Invalidate (selection_bounds);

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -92,7 +92,7 @@ namespace Pinta.Tools
 
 			doc.Selection.Visible = true;
 
-			ImageSurface surf = doc.SelectionLayer.Surface;
+			ImageSurface surf = doc.Layers.SelectionLayer.Surface;
 
 			using (Context g = new Context (surf)) {
 				g.Antialias = Antialias.Subpixel;
@@ -123,7 +123,7 @@ namespace Pinta.Tools
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			ImageSurface surf = doc.SelectionLayer.Surface;
+			ImageSurface surf = doc.Layers.SelectionLayer.Surface;
 
 			using (Context g = new Context (surf)) {
 				if (path != null) {

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -73,29 +73,29 @@ namespace Pinta.Tools
 			}
 
 			original_selection = doc.Selection.Clone ();
-			original_transform.InitMatrix (doc.SelectionLayer.Transform);
+			original_transform.InitMatrix (doc.Layers.SelectionLayer.Transform);
 
 			hist = new MovePixelsHistoryItem (Icon, Name, doc);
-			hist.TakeSnapshot (!doc.ShowSelectionLayer);
+			hist.TakeSnapshot (!doc.Layers.ShowSelectionLayer);
 
-			if (!doc.ShowSelectionLayer) {
+			if (!doc.Layers.ShowSelectionLayer) {
 				// Copy the selection to the temp layer
-				doc.CreateSelectionLayer ();
-				doc.ShowSelectionLayer = true;
+				doc.Layers.CreateSelectionLayer ();
+				doc.Layers.ShowSelectionLayer = true;
 				//Use same BlendMode, Opacity and Visibility for SelectionLayer
-				doc.SelectionLayer.BlendMode = doc.CurrentUserLayer.BlendMode;
-				doc.SelectionLayer.Opacity = doc.CurrentUserLayer.Opacity;
-				doc.SelectionLayer.Hidden = doc.CurrentUserLayer.Hidden;					
+				doc.Layers.SelectionLayer.BlendMode = doc.Layers.CurrentUserLayer.BlendMode;
+				doc.Layers.SelectionLayer.Opacity = doc.Layers.CurrentUserLayer.Opacity;
+				doc.Layers.SelectionLayer.Hidden = doc.Layers.CurrentUserLayer.Hidden;					
 
-				using (Cairo.Context g = new Cairo.Context (doc.SelectionLayer.Surface)) {
+				using (Cairo.Context g = new Cairo.Context (doc.Layers.SelectionLayer.Surface)) {
 					g.AppendPath (doc.Selection.SelectionPath);
 					g.FillRule = FillRule.EvenOdd;
-					g.SetSource (doc.CurrentUserLayer.Surface);
+					g.SetSource (doc.Layers.CurrentUserLayer.Surface);
 					g.Clip ();
 					g.Paint ();
 				}
 
-				Cairo.ImageSurface surf = doc.CurrentUserLayer.Surface;
+				Cairo.ImageSurface surf = doc.Layers.CurrentUserLayer.Surface;
 				
 				using (Cairo.Context g = new Cairo.Context (surf)) {
 					g.AppendPath (doc.Selection.SelectionPath);
@@ -117,8 +117,8 @@ namespace Pinta.Tools
 			doc.Selection = original_selection!.Transform (transform); // NRT - Set in OnStartTransform
 			doc.Selection.Visible = true;
 
-			doc.SelectionLayer.Transform.InitMatrix (original_transform);
-			doc.SelectionLayer.Transform.Multiply (transform);
+			doc.Layers.SelectionLayer.Transform.InitMatrix (original_transform);
+			doc.Layers.SelectionLayer.Transform.Multiply (transform);
 
 			PintaCore.Workspace.Invalidate ();
 		}

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -170,7 +170,7 @@ namespace Pinta.Tools
 			if (doc.Workspace.PointInCanvas (point))
 				surface_modified = true;
 
-			var surf = doc.CurrentUserLayer.Surface;
+			var surf = doc.Layers.CurrentUserLayer.Surface;
 			var invalidate_rect = Gdk.Rectangle.Zero;
 			var brush_width = BrushWidth;
 

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -64,16 +64,16 @@ namespace Pinta.Tools
 		protected unsafe override void OnFillRegionComputed (BitMask stencil)
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
-			ImageSurface surf = doc.ToolLayer.Surface;
+			ImageSurface surf = doc.Layers.ToolLayer.Surface;
 
 			using (var g = new Context (surf)) {
 				g.Operator = Operator.Source;
-				g.SetSource (doc.CurrentUserLayer.Surface);
+				g.SetSource (doc.Layers.CurrentUserLayer.Surface);
 				g.Paint ();
 			}
 
 			SimpleHistoryItem hist = new SimpleHistoryItem (Icon, Name);
-			hist.TakeSnapshotOfLayer (doc.CurrentUserLayer);
+			hist.TakeSnapshotOfLayer (doc.Layers.CurrentUserLayer);
 
 			ColorBgra color = fill_color.ToColorBgra ().ToPremultipliedAlpha ();
 			ColorBgra* dstPtr = (ColorBgra*)surf.DataPtr;
@@ -102,7 +102,7 @@ namespace Pinta.Tools
 				g.Paint ();
 			}
 
-			doc.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Clear ();
 
 			doc.History.PushNewItem (hist); 
 			doc.Workspace.Invalidate ();

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -62,7 +62,7 @@ namespace Pinta.Tools
                 return;
 
 			surface_modified = false;
-			undo_surface = PintaCore.Workspace.ActiveDocument.CurrentUserLayer.Surface.Clone ();
+			undo_surface = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.Surface.Clone ();
             mouse_button = args.Event.Button;
 			Color tool_color;
 
@@ -121,7 +121,7 @@ namespace Pinta.Tools
 			if (doc.Workspace.PointInCanvas (point))
 				surface_modified = true;
 
-			ImageSurface surf = doc.CurrentUserLayer.Surface;
+			ImageSurface surf = doc.Layers.CurrentUserLayer.Surface;
 			
 			using (Context g = new Context (surf)) {
 				g.AppendPath (doc.Selection.SelectionPath);
@@ -165,7 +165,7 @@ namespace Pinta.Tools
             if (undo_surface != null)
             {
                 if (surface_modified)
-                    doc.History.PushNewItem(new SimpleHistoryItem(Icon, Name, undo_surface, doc.CurrentUserLayerIndex));
+                    doc.History.PushNewItem(new SimpleHistoryItem(Icon, Name, undo_surface, doc.Layers.CurrentUserLayerIndex));
                 else if (undo_surface != null)
                     (undo_surface as IDisposable).Dispose();
             }

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -93,7 +93,7 @@ namespace Pinta.Tools
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
-			doc.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Clear ();
 			stencil = new bool[doc.ImageSize.Width, doc.ImageSize.Height];
 
 			base.OnMouseDown (canvas, args, point);
@@ -126,8 +126,8 @@ namespace Pinta.Tools
 			if (doc.Workspace.PointInCanvas (point))
 				surface_modified = true;
 
-			ImageSurface surf = doc.CurrentUserLayer.Surface;
-			ImageSurface tmp_layer = doc.ToolLayer.Surface;
+			ImageSurface surf = doc.Layers.CurrentUserLayer.Surface;
+			ImageSurface tmp_layer = doc.Layers.ToolLayer.Surface;
 
 			Gdk.Rectangle roi = GetRectangleFromPoints (last_point, new Point (x, y));
 

--- a/Pinta.Tools/Tools/SelectShapeTool.cs
+++ b/Pinta.Tools/Tools/SelectShapeTool.cs
@@ -169,11 +169,11 @@ namespace Pinta.Tools
 				fill_color = PintaCore.Palette.PrimaryColor;
 			}
 
-			doc.ToolLayer.Clear ();
-			doc.ToolLayer.Hidden = false;
+			doc.Layers.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Hidden = false;
 
 			surface_modified = false;
-			undo_surface = doc.CurrentUserLayer.Surface.Clone ();
+			undo_surface = doc.Layers.CurrentUserLayer.Surface.Clone ();
 		}
 
 		protected override void OnMouseUp (Gtk.DrawingArea canvas, Gtk.ButtonReleaseEventArgs args, Cairo.PointD point)
@@ -184,9 +184,9 @@ namespace Pinta.Tools
 			double y = point.Y;
 
 			current_point = point;
-			doc.ToolLayer.Hidden = true;
+			doc.Layers.ToolLayer.Hidden = true;
 
-			DrawShape (Utility.PointsToRectangle (shape_origin, new PointD (x, y), args.Event.IsShiftPressed ()), doc.CurrentUserLayer);
+			DrawShape (Utility.PointsToRectangle (shape_origin, new PointD (x, y), args.Event.IsShiftPressed ()), doc.Layers.CurrentUserLayer);
 			
 			doc.Workspace.Invalidate (last_dirty.ToGdkRectangle ());
 			
@@ -211,9 +211,9 @@ namespace Pinta.Tools
 			double x = point.X;
 			double y = point.Y;
 
-			doc.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Clear ();
 
-			Rectangle dirty = DrawShape (Utility.PointsToRectangle (shape_origin, new PointD (x, y), args.IsShiftPressed()), doc.ToolLayer);
+			Rectangle dirty = DrawShape (Utility.PointsToRectangle (shape_origin, new PointD (x, y), args.IsShiftPressed()), doc.Layers.ToolLayer);
 
 			// Increase the size of the dirty rect to account for antialiasing.
 			if (UseAntialiasing) {
@@ -241,7 +241,7 @@ namespace Pinta.Tools
 		protected virtual BaseHistoryItem CreateHistoryItem ()
 		{
 			// NRT - Assumed not-null
-			return new SimpleHistoryItem (Icon, Name, undo_surface!, PintaCore.Workspace.ActiveDocument.CurrentUserLayerIndex);
+			return new SimpleHistoryItem (Icon, Name, undo_surface!, PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayerIndex);
 		}
 		#endregion
 

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -116,7 +116,7 @@ namespace Pinta.Tools
 				PintaCore.Actions.Edit.Deselect.Activate ();
 
 			} else {
-                ClearHandles (doc.ToolLayer);
+                ClearHandles (doc.Layers.ToolLayer);
 				ReDraw(args.Event.State);
 				if (doc.Selection != null)
 				{
@@ -160,7 +160,7 @@ namespace Pinta.Tools
 			base.OnDeactivated (newTool);
 			if (PintaCore.Workspace.HasOpenDocuments) {
 				Document doc = PintaCore.Workspace.ActiveDocument;
-				doc.ToolLayer.Clear ();
+				doc.Layers.ToolLayer.Clear ();
 			}
 		}
 
@@ -178,7 +178,7 @@ namespace Pinta.Tools
             double y = Utility.Clamp(point.Y, 0, doc.ImageSize.Height - 1);
             controls[active_control!.Value].HandleMouseMove (x, y, args.Event.State); // NRT - Set by OnMouseDown
 
-            ClearHandles (doc.ToolLayer);
+            ClearHandles (doc.Layers.ToolLayer);
             RefreshHandler ();
             ReDraw (args.Event.State);
 			
@@ -206,7 +206,7 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			doc.Selection.Visible = true;
-			doc.ToolLayer.Hidden = false;
+			doc.Layers.ToolLayer.Hidden = false;
 			bool constraint = (state & Gdk.ModifierType.ShiftMask) == Gdk.ModifierType.ShiftMask;
 			if (constraint) {
 				double dx = Math.Abs (shape_end.X - shape_origin.X);
@@ -224,9 +224,9 @@ namespace Pinta.Tools
 			}
 
 			Cairo.Rectangle rect = Utility.PointsToRectangle (shape_origin, shape_end, constraint);
-			Cairo.Rectangle dirty = DrawShape (rect, doc.SelectionLayer);
+			Cairo.Rectangle dirty = DrawShape (rect, doc.Layers.SelectionLayer);
 
-            DrawHandler (doc.ToolLayer);
+            DrawHandler (doc.Layers.ToolLayer);
 
 			last_dirty = dirty;
 		}
@@ -361,7 +361,7 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
             if (PintaCore.Tools.CurrentTool == this)
-                doc.ToolLayer.Hidden = false;
+                doc.Layers.ToolLayer.Hidden = false;
 
 			shape_origin = doc.Selection.Origin;
 			shape_end = doc.Selection.End;
@@ -375,7 +375,7 @@ namespace Pinta.Tools
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
             if (PintaCore.Tools.CurrentTool == this)
-                doc.ToolLayer.Hidden = false;
+                doc.Layers.ToolLayer.Hidden = false;
 
 			shape_origin = doc.Selection.Origin;
 			shape_end = doc.Selection.End;
@@ -402,9 +402,9 @@ namespace Pinta.Tools
 		{
 			var doc = PintaCore.Workspace.ActiveDocument;
 
-		    ClearHandles (doc.ToolLayer);
+		    ClearHandles (doc.Layers.ToolLayer);
 			RefreshHandler();
-            DrawHandler (doc.ToolLayer);
+            DrawHandler (doc.Layers.ToolLayer);
 			PintaCore.Workspace.Invalidate();
 		}
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -44,14 +44,14 @@ namespace Pinta.Tools
 		{
 			get
 			{
-				return PintaCore.Workspace.ActiveDocument.CurrentUserLayer.textBounds;
+				return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.textBounds;
 			}
 
 			set
 			{
-				PintaCore.Workspace.ActiveDocument.CurrentUserLayer.previousTextBounds = PintaCore.Workspace.ActiveDocument.CurrentUserLayer.textBounds;
+				PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.previousTextBounds = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.textBounds;
 
-				PintaCore.Workspace.ActiveDocument.CurrentUserLayer.textBounds = value;
+				PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.textBounds = value;
 			}
 		}
 
@@ -62,7 +62,7 @@ namespace Pinta.Tools
 				if (!PintaCore.Workspace.HasOpenDocuments)
 					throw new InvalidOperationException ("Attempting to get CurrentTextEngine when there are no open documents");
 
-				return PintaCore.Workspace.ActiveDocument.CurrentUserLayer.tEngine;
+				return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.tEngine;
 			}
 		}
 
@@ -566,7 +566,7 @@ namespace Pinta.Tools
 				if (ctrlKey)
 				{
 					//Go through every UserLayer.
-					foreach (UserLayer ul in PintaCore.Workspace.ActiveDocument.UserLayers)
+					foreach (UserLayer ul in PintaCore.Workspace.ActiveDocument.Layers.UserLayers)
 					{
 						//Check each UserLayer's editable text boundaries to see if they contain the mouse position.
 						if (ul.textBounds.ContainsCorrect(pt))
@@ -574,7 +574,7 @@ namespace Pinta.Tools
 							//The mouse clicked on editable text.
 
 							//Change the current UserLayer to the Layer that contains the text that was clicked on.
-							PintaCore.Workspace.ActiveDocument.SetCurrentUserLayer(ul);
+							PintaCore.Workspace.ActiveDocument.Layers.SetCurrentUserLayer (ul);
 
 							//The user is editing text now.
 							is_editing = true;
@@ -658,7 +658,7 @@ namespace Pinta.Tools
 			if (ctrlKey && PintaCore.Workspace.HasOpenDocuments)
 			{
 				//Go through every UserLayer.
-				foreach (UserLayer ul in PintaCore.Workspace.ActiveDocument.UserLayers)
+				foreach (UserLayer ul in PintaCore.Workspace.ActiveDocument.Layers.UserLayers)
 				{
 					//Check each UserLayer's editable text boundaries to see if they contain the mouse position.
 					if (ul.textBounds.ContainsCorrect(lastMousePosition))
@@ -908,8 +908,8 @@ namespace Pinta.Tools
 			ignoreCloneFinalizations = true;
 
 			//Store the previous state of the current UserLayer's and TextLayer's ImageSurfaces.
-			user_undo_surface = PintaCore.Workspace.ActiveDocument.CurrentUserLayer.Surface.Clone();
-			text_undo_surface = PintaCore.Workspace.ActiveDocument.CurrentUserLayer.TextLayer.Layer.Surface.Clone();
+			user_undo_surface = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.Surface.Clone();
+			text_undo_surface = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextLayer.Layer.Surface.Clone();
 
 			//Store the previous state of the Text Engine.
 			undo_engine = CurrentTextEngine.Clone();
@@ -943,7 +943,7 @@ namespace Pinta.Tools
 				//Create a new TextHistoryItem so that the committing of text can be undone.
 				doc.History.PushNewItem(new TextHistoryItem(Icon, Name,
 							text_undo_surface.Clone(), user_undo_surface.Clone(),
-							undo_engine!.Clone(), doc.CurrentUserLayer)); // NRT - Set in StartEditing
+							undo_engine!.Clone(), doc.Layers.CurrentUserLayer)); // NRT - Set in StartEditing
 
 				//Stop ignoring any Surface.Clone calls from this point on.
 				ignoreCloneFinalizations = false;
@@ -968,10 +968,10 @@ namespace Pinta.Tools
 		private void ClearTextLayer()
 		{
 			//Clear the TextLayer.
-			PintaCore.Workspace.ActiveDocument.CurrentUserLayer.TextLayer.Layer.Surface.Clear();
+			PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextLayer.Layer.Surface.Clear();
 
 			//Redraw the previous text boundary.
-			InflateAndInvalidate(PintaCore.Workspace.ActiveDocument.CurrentUserLayer.previousTextBounds);
+			InflateAndInvalidate(PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.previousTextBounds);
 		}
 
 		/// <summary>
@@ -993,12 +993,12 @@ namespace Pinta.Tools
 			if (!useTextLayer)
 			{
 				//Draw text on the current UserLayer's surface as finalized text.
-				surf = PintaCore.Workspace.ActiveDocument.CurrentUserLayer.Surface;
+				surf = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.Surface;
 			}
 			else
 			{
 				//Draw text on the current UserLayer's TextLayer's surface as re-editable text.
-				surf = PintaCore.Workspace.ActiveDocument.CurrentUserLayer.TextLayer.Layer.Surface;
+				surf = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextLayer.Layer.Surface;
 
 				ClearTextLayer();
 			}
@@ -1091,7 +1091,7 @@ namespace Pinta.Tools
 				}
 			}
 
-			InflateAndInvalidate(PintaCore.Workspace.ActiveDocument.CurrentUserLayer.previousTextBounds);
+			InflateAndInvalidate(PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.previousTextBounds);
 			PintaCore.Workspace.Invalidate(old_cursor_bounds);
 			InflateAndInvalidate (r);
 			PintaCore.Workspace.Invalidate(cursorBounds);
@@ -1115,15 +1115,15 @@ namespace Pinta.Tools
 					Document doc = PintaCore.Workspace.ActiveDocument;
 
 					//Create a backup of everything before redrawing the text and etc.
-					Cairo.ImageSurface oldTextSurface = doc.CurrentUserLayer.TextLayer.Layer.Surface.Clone();
-					Cairo.ImageSurface oldUserSurface = doc.CurrentUserLayer.Surface.Clone();
+					Cairo.ImageSurface oldTextSurface = doc.Layers.CurrentUserLayer.TextLayer.Layer.Surface.Clone();
+					Cairo.ImageSurface oldUserSurface = doc.Layers.CurrentUserLayer.Surface.Clone();
 					TextEngine oldTextEngine = CurrentTextEngine.Clone();
 
 					//Draw the text onto the UserLayer (without the cursor) rather than the TextLayer.
 					RedrawText(false, false);
 
 					//Clear the TextLayer.
-					doc.CurrentUserLayer.TextLayer.Layer.Clear();
+					doc.Layers.CurrentUserLayer.TextLayer.Layer.Clear();
 
 					//Clear the text and its boundaries.
 					CurrentTextEngine.Clear();
@@ -1132,7 +1132,7 @@ namespace Pinta.Tools
 					//Create a new TextHistoryItem so that the finalization of the text can be undone. Construct
 					//it on the spot so that it is more memory efficient if the changes are small.
 					TextHistoryItem hist = new TextHistoryItem(Icon, FinalizeName, oldTextSurface, oldUserSurface,
-							oldTextEngine, doc.CurrentUserLayer);
+							oldTextEngine, doc.Layers.CurrentUserLayer);
 
 					//Add the new TextHistoryItem.
 					doc.History.PushNewItem(hist);

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -78,10 +78,10 @@ namespace Pinta.Tools
 			Rectangle r = PointsToRectangle (shape_origin, point);
 			Rectangle dirty;
 
-			doc.ToolLayer.Clear ();
-			doc.ToolLayer.Hidden = false;
+			doc.Layers.ToolLayer.Clear ();
+			doc.Layers.ToolLayer.Hidden = false;
 
-			using (Context g = new Context (doc.ToolLayer.Surface)) {
+			using (Context g = new Context (doc.Layers.ToolLayer.Surface)) {
 				g.Antialias = Antialias.Subpixel;
 
 				dirty = g.FillStrokedRectangle (r, new Color (0, 0.4, 0.8, 0.1), new Color (0, 0, 0.9), 1);
@@ -142,7 +142,7 @@ namespace Pinta.Tools
 
 			double x = point.X;
 			double y = point.Y;
-			doc.ToolLayer.Hidden = true;
+			doc.Layers.ToolLayer.Hidden = true;
 			
 			if (mouseDown == 1 || mouseDown == 3) {	//left or right
 				if (args.Event.Button == 1) {	//left

--- a/Pinta/Actions/File/NewScreenshotAction.cs
+++ b/Pinta/Actions/File/NewScreenshotAction.cs
@@ -62,7 +62,7 @@ namespace Pinta.Actions
 					Document doc = PintaCore.Workspace.NewDocument (new Size (root_window.Width, root_window.Height), new Cairo.Color (1, 1, 1));
 
 					using (var pb = new Pixbuf (screen.RootWindow, 0, 0, root_window.Width, root_window.Height)) {
-						using (Cairo.Context g = new Cairo.Context (doc.UserLayers[0].Surface)) {
+						using (Cairo.Context g = new Cairo.Context (doc.Layers.UserLayers[0].Surface)) {
 							CairoHelper.SetSourcePixbuf (g, pb, 0, 0);
 							g.Paint ();
 						}

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -70,8 +70,8 @@ namespace Pinta.Actions
 
 			} else {
 
-				var layer = PintaCore.Workspace.ActiveDocument.CurrentUserLayer;
-				var selectionLayer = PintaCore.Workspace.ActiveDocument.SelectionLayer;
+				var layer = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer;
+				var selectionLayer = PintaCore.Workspace.ActiveDocument.Layers.SelectionLayer;
 				var initial = dialog.InitialLayerProperties;
 				initial.SetProperties (layer);
 				if (selectionLayer != null)

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -59,7 +59,7 @@ namespace Pinta.Actions
 				dialog.EffectDataChanged += (o, args) => {
 					var xform = ComputeMatrix (data);
 					var doc = PintaCore.Workspace.ActiveDocument;
-					doc.CurrentUserLayer.Transform.InitMatrix (xform);
+					doc.Layers.CurrentUserLayer.Transform.InitMatrix (xform);
 					PintaCore.Workspace.Invalidate ();
 				};
 
@@ -73,7 +73,7 @@ namespace Pinta.Actions
 
 		private static void ClearLivePreview ()
 		{
-			PintaCore.Workspace.ActiveDocument.CurrentUserLayer.Transform.InitIdentity ();
+			PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.Transform.InitIdentity ();
 			PintaCore.Workspace.Invalidate ();
 		}
 
@@ -97,14 +97,14 @@ namespace Pinta.Actions
 			var doc = PintaCore.Workspace.ActiveDocument;
 			PintaCore.Tools.Commit ();
 
-			var old_surf = doc.CurrentUserLayer.Surface.Clone ();
+			var old_surf = doc.Layers.CurrentUserLayer.Surface.Clone ();
 
 			var xform = ComputeMatrix (data);
-			doc.CurrentUserLayer.ApplyTransform (xform, PintaCore.Workspace.ImageSize);
+			doc.Layers.CurrentUserLayer.ApplyTransform (xform, PintaCore.Workspace.ImageSize);
 			doc.Workspace.Invalidate ();
 
 			doc.History.PushNewItem (new SimpleHistoryItem (Resources.Icons.LayerRotateZoom,
-			    Translations.GetString ("Rotate / Zoom Layer"), old_surf, doc.CurrentUserLayerIndex));
+			    Translations.GetString ("Rotate / Zoom Layer"), old_surf, doc.Layers.CurrentUserLayerIndex));
 		}
 
 		private class RotateZoomData : EffectData


### PR DESCRIPTION
I apologize that this couldn't be broken down into smaller pieces. 🙁 

Simplifies `Document` class by moving all layer functionality into a separate `DocumentLayers` class, like `DocumentHistory` and `DocumentSelection`.

Updates callers to point to new `Document.Layers` property.