### PR TITLE
Fix exception in TextTool caused by NRT changes.

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -419,7 +419,7 @@ namespace Pinta.Tools
 
 		private void UpdateFont ()
 		{
-			if (CurrentTextEngine != null) {
+			if (PintaCore.Workspace.HasOpenDocuments) {
 				CurrentTextEngine.Alignment = Alignment;
 				CurrentTextEngine.SetFont (Font, FontSize, bold_btn.Active, italic_btn.Active, underscore_btn.Active);
 			}


### PR DESCRIPTION
#158 changed `TextTool.CurrentTextEngine` to throw an exception rather than return `null` when there is not an `ActiveDocument`.  However there is a place where it is checked for `null` to avoid performing action if there is no ActiveDocument. 

Thus if you click the Text Tool while there is no document open, it throws an exception.  This guards against that by checking if there are any open documents instead of checking if `CurrentTextEngine` is `null`.