### PR TITLE
Move remaining GTK obsolete API calls to ObsoleteExtensions.

### DIFF
--- a/Pinta.Core/Extensions/ObsoleteExtensions.cs
+++ b/Pinta.Core/Extensions/ObsoleteExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Gdk;
+using Gtk;
+using Pango;
+
+namespace Pinta.Core
+{
+	// TODO-GTK3: These are known obsolete GTK methods that we should replace, but haven't yet.
+	// Moving them here so that they don't drown out other warnings.
+	public static class ObsoleteExtensions
+	{
+#pragma warning disable CS0612
+		public static void AddToIconFactory (IconFactory factory, string stock_id, IconSet icon_set)
+			=> factory.Add (stock_id, icon_set);
+
+		public static void AddDefaultToIconFactory (IconFactory factory)
+			=> factory.AddDefault ();
+
+		// https://github.com/GtkSharp/GtkSharp/issues/131
+		public static Gdk.Window GetWindowPointer (Gdk.Window window, out int x, out int y, out ModifierType mask)
+			=> window.GetPointer (out x, out y, out mask);
+
+		public static void GetWidgetPointer (Widget widget, out int x, out int y)
+			=> widget.GetPointer (out x, out y);
+
+		public static FontDescription GetStyleContextFont (StyleContext context, StateFlags flags)
+			=> context.GetFont (flags);
+	}
+}

--- a/Pinta.Core/Managers/EffectsManager.cs
+++ b/Pinta.Core/Managers/EffectsManager.cs
@@ -53,8 +53,8 @@ namespace Pinta.Core
 		{
 			// Add icon to IconFactory
 			Gtk.IconFactory fact = new Gtk.IconFactory ();
-			fact.Add (adjustment.Icon, new Gtk.IconSet (PintaCore.Resources.GetIcon (adjustment.Icon)));
-			fact.AddDefault ();
+			ObsoleteExtensions.AddToIconFactory (fact, adjustment.Icon, new Gtk.IconSet (PintaCore.Resources.GetIcon (adjustment.Icon)));
+			ObsoleteExtensions.AddDefaultToIconFactory (fact);
 
 			// Create a gtk action for each adjustment
 			var act = new Command (adjustment.GetType ().Name, adjustment.Name + (adjustment.IsConfigurable ? Translations.GetString ("...") : ""), string.Empty, adjustment.Icon);
@@ -84,8 +84,8 @@ namespace Pinta.Core
 		{
 			// Add icon to IconFactory
 			Gtk.IconFactory fact = new Gtk.IconFactory ();
-			fact.Add (effect.Icon, new Gtk.IconSet (PintaCore.Resources.GetIcon (effect.Icon)));
-			fact.AddDefault ();
+			ObsoleteExtensions.AddToIconFactory (fact, effect.Icon, new Gtk.IconSet (PintaCore.Resources.GetIcon (effect.Icon)));
+			ObsoleteExtensions.AddDefaultToIconFactory (fact);
 
 			// Create a gtk action and menu item for each effect
 			var act = new Command (effect.GetType ().Name, effect.Name + (effect.IsConfigurable ? Translations.GetString ("...") : ""), string.Empty, effect.Icon);

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -200,8 +200,7 @@ namespace Pinta.Effects
 		{	
 			int x, y;
 			Gdk.ModifierType mask;
-			drawing.Window.GetPointer (out x, out y, out mask); 
-			
+			ObsoleteExtensions.GetWindowPointer (drawing.Window, out x, out y, out mask); 			
 			
 			if (x < 0 || x >= size || y < 0 || y >=size)
 				return;
@@ -225,7 +224,7 @@ namespace Pinta.Effects
 		{
 			int x, y;
 			Gdk.ModifierType mask;
-			drawing.Window.GetPointer (out x, out y, out mask); 
+			ObsoleteExtensions.GetWindowPointer (drawing.Window, out x, out y, out mask); 
 			
 			if (args.Event.Button == 1) {
 				AddControlPoint (x, y);
@@ -266,7 +265,7 @@ namespace Pinta.Effects
 		{
 			int x, y;
 			Gdk.ModifierType mask;
-			drawing.Window.GetPointer (out x, out y, out mask); 
+			ObsoleteExtensions.GetWindowPointer (drawing.Window, out x, out y, out mask); 
 			
 			if (x >= 0 && x < size && y >= 0 && y < size) {
 				g.LineWidth = 0.5;
@@ -331,7 +330,7 @@ namespace Pinta.Effects
 		{
 			int x, y;
 			Gdk.ModifierType mask;
-			drawing.Window.GetPointer (out x, out y, out mask); 
+			ObsoleteExtensions.GetWindowPointer (drawing.Window, out x, out y, out mask); 
 			
 			var infos = GetDrawingInfos ();
 			

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasWindow.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasWindow.cs
@@ -113,8 +113,7 @@ namespace Pinta
 
                 // Get the position of the mouse pointer relative
                 // to canvas scrolled window top-left corner
-                scrolled_window.GetPointer (out x, out y);
-
+                ObsoleteExtensions.GetWidgetPointer (scrolled_window, out x, out y);
                 // Check if the pointer is on the canvas
                 return (x > 0) && (x < scrolled_window.Allocation.Width) &&
                     (y > 0) && (y < scrolled_window.Allocation.Height);

--- a/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
@@ -176,7 +176,7 @@ namespace Pinta.Gui.Widgets
 		{
 			int px, py;
 			Gdk.ModifierType mask;
-			Window.GetPointer (out px, out py, out mask);
+			ObsoleteExtensions.GetWindowPointer (Window, out px, out py, out mask);
 
 			int index = FindValueIndex (py);
 			py = (int) NormalizeY (index, py);
@@ -208,7 +208,7 @@ namespace Pinta.Gui.Widgets
 		{
 			int px, py;
 			Gdk.ModifierType mask;
-			Window.GetPointer (out px, out py, out mask);
+			ObsoleteExtensions.GetWindowPointer (Window, out px, out py, out mask);
 
 			int index = FindValueIndex ((int) py);
 
@@ -239,7 +239,7 @@ namespace Pinta.Gui.Widgets
 		{
 			int px, py;
 			Gdk.ModifierType mask;
-			Window.GetPointer (out px, out py, out mask);
+			ObsoleteExtensions.GetWindowPointer (Window, out px, out py, out mask);
 
 			Rectangle rect = GradientRectangle;
 			Rectangle all = Allocation.ToCairoRectangle ();

--- a/Pinta.Gui.Widgets/Widgets/Ruler.cs
+++ b/Pinta.Gui.Widgets/Widgets/Ruler.cs
@@ -110,7 +110,7 @@ namespace Pinta.Gui.Widgets
         private Requisition GetSizeRequest()
         {
             var border = StyleContext.GetBorder(StateFlags);
-            var font = StyleContext.GetFont(StateFlags);
+            var font = ObsoleteExtensions.GetStyleContextFont (StyleContext, StateFlags);
             int font_size = GetFontSize(font);
 
             int size = 2 + font_size * 2;
@@ -201,7 +201,7 @@ namespace Pinta.Gui.Widgets
             double max_size = scaled_upper - scaled_lower;
 
             // There must be enough space between the large ticks for the text labels.
-            var font = StyleContext.GetFont(StateFlags);
+            var font = ObsoleteExtensions.GetStyleContextFont (StyleContext, StateFlags);
             int font_size = GetFontSize(font);
             var max_digits = ((int)-Math.Abs(max_size)).ToString().Length;
             int min_separation = max_digits * font_size * 2;

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -492,7 +492,6 @@ namespace Mono.Options
 			get {return this.option;}
 		}
 
-		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData (info, context);


### PR DESCRIPTION
Not sure if this is desired or not, but it moves the remaining `[Obsolete]` GTK usage we have into an `ObsoleteExtensions` class and ignores the obsolete warnings from there.

This makes the build warning-free, which should help make it easier to ensure no new warnings are committed, as they won't be drowned out by obsolete warnings.