### PR TITLE
Implement Paste Into New Image without extra history items.

### DIFF
--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -160,6 +160,16 @@ namespace Pinta.Core
 			document.IsDirty = false;
 		}
 
+		/// <summary>
+		/// Mark the document history as being dirty. No matter where we are in the history
+		/// stack the user will be prompted to Save if the document is closed.
+		/// </summary>
+		public void SetDirty ()
+		{
+			clean_pointer = -1;
+			document.IsDirty = true;
+		}
+
 		public void Clear ()
 		{
 			history.ForEach (delegate (BaseHistoryItem item) { item.Dispose (); });

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -174,6 +174,24 @@ namespace Pinta.Core
 			return doc;
 		}
 
+		/// <summary>
+		/// Creates a new Document with a specified image as content.
+		/// Primarily used for Paste Into New Image.
+		/// </summary>
+		public Document NewDocumentFromImage (Gdk.Pixbuf image)
+		{
+			var doc = NewDocument (new Gdk.Size (image.Width, image.Height), new Color (0, 0, 0, 0));
+
+			using (var g = new Context (doc.Layers[0].Surface))
+				g.DrawPixbuf (image, new Point (0, 0));
+
+			// A normal document considers the "New Image" history to not be dirty, as it's just a
+			// blank background. We put an image there, so we should try to save if the user closes it.
+			doc.Workspace.History.SetDirty ();
+
+			return doc;
+		}
+
 		// TODO: Standardize add to recent files
 		public bool OpenFile (string file, Window? parent = null)
 		{

--- a/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
@@ -43,11 +43,7 @@ namespace Pinta.Actions
 			if (cb.WaitIsImageAvailable ()) {
 				using (var image = cb.WaitForImage ()) {
 					if (image != null) {
-						var size = new Gdk.Size (image.Width, image.Height);
-
-						PintaCore.Workspace.NewDocument (size, new Cairo.Color (0, 0, 0, 0));
-						PintaCore.Actions.Edit.Paste.Activate ();
-						PintaCore.Actions.Edit.Deselect.Activate ();
+						PintaCore.Workspace.NewDocumentFromImage (image);
 						return;
 					}
 				}


### PR DESCRIPTION
Today `Paste Into New Image` is implemented as: create new document, activate the paste action, activate the deselect action.  This leaves the user starting with the following history items:

* New Image
* Paste
* Finish Pixels
* Deselect

This doesn't really feel like what the user asked for, as well as several of the history items maintain an `old_surface` which takes up unneeded memory.

Instead, this creates a new document and then copies the clipboard image to the document surface.  The only history item is `New Image`, which seems more like what the user would expect.  The only tricky part is we need to mark the document as dirty, since we should prompt the user to save the pasted image, even if they make no changes to it.