### PR TITLE
Store Primary/Secondary colors in settings.

### DIFF
--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -49,11 +49,17 @@ namespace Pinta.Core
 
         public const int SizeOf = 4;
 
-        public static ColorBgra ParseHexString(string hexString)
-        {
-            uint value = Convert.ToUInt32(hexString, 16);
-            return ColorBgra.FromUInt32(value);
-        }
+		public static bool TryParseHexString (string hexString, out ColorBgra color)
+		{
+			try {
+				var value = Convert.ToUInt32 (hexString, 16);
+				color = FromUInt32 (value);
+				return true;
+			} catch (Exception) {
+				color = Zero;
+				return false;
+			}
+		}
 
         public string ToHexString()
         {

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -79,8 +79,10 @@ namespace Pinta.Gui.Widgets
 					break;
 				case WidgetElement.SwapColors:
 					var temp = PintaCore.Palette.PrimaryColor;
-					PintaCore.Palette.PrimaryColor = PintaCore.Palette.SecondaryColor;
-					PintaCore.Palette.SecondaryColor = temp;
+
+					// Swapping should not trigger adding colors to recently used palette
+					PintaCore.Palette.SetColor (true, PintaCore.Palette.SecondaryColor, false);
+					PintaCore.Palette.SetColor (false, temp, false);
 
 					break;
 				case WidgetElement.ResetColors:


### PR DESCRIPTION
Persists the Primary/Secondary colors in settings between application starts.

Also makes it so clicking the "swap colors" icon does not alter the most recently used colors palette.