### PR TITLE
Tidy up Pinta.Gui.Widgets.

### DIFF
--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -544,8 +544,8 @@ namespace Pinta.Effects
 			spinOutHigh = new SpinButton (2, 255, 1) { Value = 255 };
 			spinOutGamma = new SpinButton (0, 100, 0.1) { Value = 1 };
 
-			gradientInput = new ColorGradientWidget () { WidthRequest = 40, Count = 2 };
-			gradientOutput = new ColorGradientWidget () { WidthRequest = 40, Count = 3 };
+			gradientInput = new ColorGradientWidget (2) { WidthRequest = 40 };
+			gradientOutput = new ColorGradientWidget (3) { WidthRequest = 40 };
 
 			colorpanelInHigh = new ColorPanelWidget () { HeightRequest = 24 };
 			colorpanelInLow = new ColorPanelWidget () { HeightRequest = 24 };

--- a/Pinta.Gui.Widgets/DialogAttributes.cs
+++ b/Pinta.Gui.Widgets/DialogAttributes.cs
@@ -12,7 +12,6 @@
 // Code licensed under the MIT X11 license
 
 using System;
-using System.Collections.Generic;
 
 namespace Pinta.Gui.Widgets
 {
@@ -24,78 +23,56 @@ namespace Pinta.Gui.Widgets
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
 	public class CaptionAttribute : Attribute
 	{
-		public CaptionAttribute (string caption)
-		{
-			Caption = caption;
-		}
+		public CaptionAttribute (string caption) => Caption = caption;
 
-		public string Caption;
+		public string Caption { get; set; }
 	}
 
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
-    public class DigitsValueAttribute : Attribute
-    {
-        public DigitsValueAttribute(int value)
-        {
-            Value = value;
-        }
+	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
+	public class DigitsValueAttribute : Attribute
+	{
+		public DigitsValueAttribute (int value) => Value = value;
 
-        public int Value;
-    }
+		public int Value { get; set; }
+	}
 
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
-    public class IncrementValueAttribute : Attribute
-    {
-        public IncrementValueAttribute(double value)
-        {
-            Value = value;
-        }
+	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
+	public class IncrementValueAttribute : Attribute
+	{
+		public IncrementValueAttribute (double value) => Value = value;
 
-        public double Value;
-    }
+		public double Value { get; set; }
+	}
 
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
 	public class MinimumValueAttribute : Attribute
 	{
-		public MinimumValueAttribute (int value)
-		{
-			Value = value;
-		}
+		public MinimumValueAttribute (int value) => Value = value;
 
-		public int Value;
+		public int Value { get; set; }
 	}
 
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
 	public class MaximumValueAttribute : Attribute
 	{
-		public MaximumValueAttribute (int value)
-		{
-			Value = value;
-		}
+		public MaximumValueAttribute (int value) => Value = value;
 
-		public int Value;
+		public int Value { get; set; }
 	}
-	
+
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
 	public class HintAttribute : Attribute
 	{
-		public HintAttribute (string caption)
-		{
-			Hint = caption;
-		}
+		public HintAttribute (string caption) => Hint = caption;
 
-		public string Hint;
+		public string Hint { get; set; }
 	}
 
-	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
+	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
 	public class StaticListAttribute : Attribute
 	{
-		public StaticListAttribute (string dict)
-		{
-			this.dictionaryName = dict;
-		}
+		public StaticListAttribute (string dict) => DictionaryName = dict;
 
-		public string dictionaryName;
+		public string DictionaryName { get; set; }
 	}
-	
 }

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -39,7 +39,7 @@ namespace Pinta.Gui.Widgets
 	public class SimpleEffectDialog : Gtk.Dialog
 	{
 		[ThreadStatic]
-		Random random = new Random ();
+		readonly Random random = new Random ();
 
 		const uint event_delay_millis = 100;
 		uint event_delay_timeout_id;
@@ -48,10 +48,8 @@ namespace Pinta.Gui.Widgets
 		/// Since this dialog is used by add-ins, the IAddinLocalizer allows for translations to be
 		/// fetched from the appropriate place.
 		/// </param>
-		public SimpleEffectDialog (string title, Gdk.Pixbuf icon, object effectData,
-		                           IAddinLocalizer localizer)
-			: base (title, Pinta.Core.PintaCore.Chrome.MainWindow, Gtk.DialogFlags.Modal,
-				Core.GtkExtensions.DialogButtonsCancelOk())
+		public SimpleEffectDialog (string title, Gdk.Pixbuf icon, object effectData, IAddinLocalizer localizer)
+			: base (title, Core.PintaCore.Chrome.MainWindow, Gtk.DialogFlags.Modal, Core.GtkExtensions.DialogButtonsCancelOk ())
 		{
 			Icon = icon;
 			EffectData = effectData;
@@ -86,25 +84,25 @@ namespace Pinta.Gui.Widgets
 			var members = EffectData.GetType ().GetMembers ();
 
 			foreach (var mi in members) {
-				Type? mType = GetTypeForMember (mi);
+				var mType = GetTypeForMember (mi);
 
 				if (mType == null)
 					continue;
 
 				string? caption = null;
 				string? hint = null;
-				bool skip = false;
-				bool combo = false;
+				var skip = false;
+				var combo = false;
 
-				object[] attrs = mi.GetCustomAttributes (false);
+				var attrs = mi.GetCustomAttributes (false);
 
 				foreach (var attr in attrs) {
 					if (attr is SkipAttribute)
 						skip = true;
 					else if (attr is CaptionAttribute)
-						caption = ((CaptionAttribute)attr).Caption;
+						caption = ((CaptionAttribute) attr).Caption;
 					else if (attr is HintAttribute)
-						hint = ((HintAttribute)attr).Hint;
+						hint = ((HintAttribute) attr).Hint;
 					else if (attr is StaticListAttribute)
 						combo = true;
 
@@ -143,69 +141,71 @@ namespace Pinta.Gui.Widgets
 		private void AddWidget (Gtk.Widget widget)
 		{
 			widget.Show ();
-			this.ContentArea.Add (widget);
+			ContentArea.Add (widget);
 		}
 		#endregion
 
 		#region Control Builders
-		private ComboBoxWidget CreateEnumComboBox (string caption, object o, System.Reflection.MemberInfo member, System.Object[] attributes)
+		private ComboBoxWidget CreateEnumComboBox (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			Type myType = GetTypeForMember (member)!; // NRT - We're looping through members we got from reflection
+			var myType = GetTypeForMember (member)!; // NRT - We're looping through members we got from reflection
 
-			string[] member_names = Enum.GetNames (myType);
+			var member_names = Enum.GetNames (myType);
 			var labels = new List<string> ();
 			var label_to_member = new Dictionary<string, string> ();
 
-			foreach (var member_name in member_names)
-			{
+			foreach (var member_name in member_names) {
 				var members = myType.GetMember (member_name);
 
 				// Look for a Caption attribute that provides a (translated) description.
 				string label;
-				var attrs = members [0].GetCustomAttributes (typeof (CaptionAttribute), false);
-				if (attrs.Length > 0)
-					label = Pinta.Core.Translations.GetString (((CaptionAttribute)attrs [0]).Caption);
-				else
-					label = Pinta.Core.Translations.GetString (member_name);
+				var attrs = members[0].GetCustomAttributes (typeof (CaptionAttribute), false);
 
-				label_to_member [label] = member_name;
+				if (attrs.Length > 0)
+					label = Core.Translations.GetString (((CaptionAttribute) attrs[0]).Caption);
+				else
+					label = Core.Translations.GetString (member_name);
+
+				label_to_member[label] = member_name;
 				labels.Add (label);
 			}
 
-			ComboBoxWidget widget = new ComboBoxWidget (labels.ToArray ());
+			var widget = new ComboBoxWidget (labels.ToArray ()) {
+				Label = caption
+			};
 
-			widget.Label = caption;
-			widget.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
+			widget.AddEvents ((int) Gdk.EventMask.ButtonPressMask);
 
 			if (GetValue (member, o) is object obj)
-				widget.Active = ((IList)member_names).IndexOf (obj.ToString ());
+				widget.Active = ((IList) member_names).IndexOf (obj.ToString ());
 
 			widget.Changed += delegate (object? sender, EventArgs e) {
-				SetValue (member, o, Enum.Parse (myType, label_to_member [widget.ActiveText]));
+				SetValue (member, o, Enum.Parse (myType, label_to_member[widget.ActiveText]));
 			};
 
 			return widget;
 		}
 
-		private ComboBoxWidget CreateComboBox (string caption, object o, System.Reflection.MemberInfo member, System.Object [] attributes)
+		private ComboBoxWidget CreateComboBox (string caption, object o, MemberInfo member, object[] attributes)
 		{
 			Dictionary<string, object>? dict = null;
 
 			foreach (var attr in attributes) {
-				if (attr is StaticListAttribute && GetValue (((StaticListAttribute) attr).dictionaryName, o) is Dictionary<string, object> d)
+				if (attr is StaticListAttribute attribute && GetValue (attribute.DictionaryName, o) is Dictionary<string, object> d)
 					dict = d;
 			}
 
-			List<string> entries = new List<string> ();
+			var entries = new List<string> ();
 
 			if (dict != null)
-				foreach (string str in dict.Keys)
+				foreach (var str in dict.Keys)
 					entries.Add (str);
 
-			ComboBoxWidget widget = new ComboBoxWidget (entries.ToArray ());
+			var widget = new ComboBoxWidget (entries.ToArray ()) {
+				Label = caption
+			};
 
-			widget.Label = caption;
-			widget.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
+			widget.AddEvents ((int) Gdk.EventMask.ButtonPressMask);
 
 			if (GetValue (member, o) is string s)
 				widget.Active = entries.IndexOf (s);
@@ -217,37 +217,37 @@ namespace Pinta.Gui.Widgets
 			return widget;
 		}
 
-		private HScaleSpinButtonWidget CreateDoubleSlider (string caption, object o, MemberInfo member, object [] attributes)
+		private HScaleSpinButtonWidget CreateDoubleSlider (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			HScaleSpinButtonWidget widget = new HScaleSpinButtonWidget ();
-
-			int min_value = -100;
-			int max_value = 100;
-			double inc_value = 0.01;
-			int digits_value = 2;
+			var min_value = -100;
+			var max_value = 100;
+			var inc_value = 0.01;
+			var digits_value = 2;
 
 			foreach (var attr in attributes) {
-				if (attr is MinimumValueAttribute)
-					min_value = ((MinimumValueAttribute)attr).Value;
-				else if (attr is MaximumValueAttribute)
-					max_value = ((MaximumValueAttribute)attr).Value;
-				else if (attr is IncrementValueAttribute)
-					inc_value = ((IncrementValueAttribute)attr).Value;
-				else if (attr is DigitsValueAttribute)
-					digits_value = ((DigitsValueAttribute)attr).Value;
+				if (attr is MinimumValueAttribute min)
+					min_value = min.Value;
+				else if (attr is MaximumValueAttribute max)
+					max_value = max.Value;
+				else if (attr is IncrementValueAttribute inc)
+					inc_value = inc.Value;
+				else if (attr is DigitsValueAttribute digits)
+					digits_value = digits.Value;
 			}
 
-			widget.Label = caption;
-			widget.MinimumValue = min_value;
-			widget.MaximumValue = max_value;
-			widget.IncrementValue = inc_value;
-			widget.DigitsValue = digits_value;
+			var widget = new HScaleSpinButtonWidget {
+				Label = caption,
+				MinimumValue = min_value,
+				MaximumValue = max_value,
+				IncrementValue = inc_value,
+				DigitsValue = digits_value
+			};
 
 			if (GetValue (member, o) is double d)
 				widget.DefaultValue = d;
 
 			widget.ValueChanged += delegate (object? sender, EventArgs e) {
-				DelayedUpdate( () => {
+				DelayedUpdate (() => {
 					SetValue (member, o, widget.Value);
 					return false;
 				});
@@ -256,37 +256,37 @@ namespace Pinta.Gui.Widgets
 			return widget;
 		}
 
-		private HScaleSpinButtonWidget CreateSlider (string caption, object o, MemberInfo member, object [] attributes)
+		private HScaleSpinButtonWidget CreateSlider (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			HScaleSpinButtonWidget widget = new HScaleSpinButtonWidget ();
-
-			int min_value = -100;
-			int max_value = 100;
-			double inc_value = 1.0;
-			int digits_value = 0;
+			var min_value = -100;
+			var max_value = 100;
+			var inc_value = 1.0;
+			var digits_value = 0;
 
 			foreach (var attr in attributes) {
-				if (attr is MinimumValueAttribute)
-					min_value = ((MinimumValueAttribute)attr).Value;
-				else if (attr is MaximumValueAttribute)
-					max_value = ((MaximumValueAttribute)attr).Value;
-				else if (attr is IncrementValueAttribute)
-					inc_value = ((IncrementValueAttribute)attr).Value;
-				else if (attr is DigitsValueAttribute)
-					digits_value = ((DigitsValueAttribute)attr).Value;
+				if (attr is MinimumValueAttribute min)
+					min_value = min.Value;
+				else if (attr is MaximumValueAttribute max)
+					max_value = max.Value;
+				else if (attr is IncrementValueAttribute inc)
+					inc_value = inc.Value;
+				else if (attr is DigitsValueAttribute digits)
+					digits_value = digits.Value;
 			}
 
-			widget.Label = caption;
-			widget.MinimumValue = min_value;
-			widget.MaximumValue = max_value;
-			widget.IncrementValue = inc_value;
-			widget.DigitsValue = digits_value;
+			var widget = new HScaleSpinButtonWidget {
+				Label = caption,
+				MinimumValue = min_value,
+				MaximumValue = max_value,
+				IncrementValue = inc_value,
+				DigitsValue = digits_value
+			};
 
 			if (GetValue (member, o) is int i)
 				widget.DefaultValue = i;
 
 			widget.ValueChanged += delegate (object? sender, EventArgs e) {
-				DelayedUpdate( () => {
+				DelayedUpdate (() => {
 					SetValue (member, o, widget.ValueAsInt);
 					return false;
 				});
@@ -295,11 +295,11 @@ namespace Pinta.Gui.Widgets
 			return widget;
 		}
 
-		private Gtk.CheckButton CreateCheckBox (string caption, object o, MemberInfo member, object [] attributes)
+		private Gtk.CheckButton CreateCheckBox (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			Gtk.CheckButton widget = new Gtk.CheckButton ();
-
-			widget.Label = caption;
+			var widget = new Gtk.CheckButton {
+				Label = caption
+			};
 
 			if (GetValue (member, o) is bool b)
 				widget.Active = b;
@@ -311,11 +311,11 @@ namespace Pinta.Gui.Widgets
 			return widget;
 		}
 
-		private PointPickerWidget CreateOffsetPicker (string caption, object o, MemberInfo member, object [] attributes)
+		private PointPickerWidget CreateOffsetPicker (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			PointPickerWidget widget = new PointPickerWidget ();
-
-			widget.Label = caption;
+			var widget = new PointPickerWidget {
+				Label = caption
+			};
 
 			if (GetValue (member, o) is Cairo.PointD p)
 				widget.DefaultOffset = p;
@@ -327,11 +327,11 @@ namespace Pinta.Gui.Widgets
 			return widget;
 		}
 
-		private PointPickerWidget CreatePointPicker (string caption, object o, MemberInfo member, object [] attributes)
+		private PointPickerWidget CreatePointPicker (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			PointPickerWidget widget = new PointPickerWidget ();
-
-			widget.Label = caption;
+			var widget = new PointPickerWidget {
+				Label = caption
+			};
 
 			if (GetValue (member, o) is Gdk.Point p)
 				widget.DefaultPoint = p;
@@ -343,17 +343,17 @@ namespace Pinta.Gui.Widgets
 			return widget;
 		}
 
-		private AnglePickerWidget CreateAnglePicker (string caption, object o, MemberInfo member, object [] attributes)
+		private AnglePickerWidget CreateAnglePicker (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			AnglePickerWidget widget = new AnglePickerWidget ();
-
-			widget.Label = caption;
+			var widget = new AnglePickerWidget {
+				Label = caption
+			};
 
 			if (GetValue (member, o) is double d)
 				widget.DefaultValue = d;
 
 			widget.ValueChanged += delegate (object? sender, EventArgs e) {
-				DelayedUpdate( () => {
+				DelayedUpdate (() => {
 					SetValue (member, o, widget.Value);
 					return false;
 				});
@@ -364,15 +364,16 @@ namespace Pinta.Gui.Widgets
 
 		private Gtk.Label CreateHintLabel (string hint)
 		{
-			Gtk.Label label = new Gtk.Label (hint);
-			label.LineWrap = true;
+			var label = new Gtk.Label (hint) {
+				LineWrap = true
+			};
 
 			return label;
 		}
 
-		private ReseedButtonWidget CreateSeed (string caption, object o, MemberInfo member, object [] attributes)
+		private ReseedButtonWidget CreateSeed (string caption, object o, MemberInfo member, object[] attributes)
 		{
-			ReseedButtonWidget widget = new ReseedButtonWidget ();
+			var widget = new ReseedButtonWidget ();
 
 			widget.Clicked += delegate (object? sender, EventArgs e) {
 				SetValue (member, o, random.Next ());
@@ -385,40 +386,36 @@ namespace Pinta.Gui.Widgets
 		#region Static Reflection Methods
 		private static object? GetValue (MemberInfo mi, object o)
 		{
-			var fi = mi as FieldInfo;
-			if (fi != null)
+			if (mi is FieldInfo fi)
 				return fi.GetValue (o);
+
 			var pi = mi as PropertyInfo;
 
-			return pi?.GetGetMethod ()?.Invoke (o, new object[0]);
+			return pi?.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
 		}
 
 		private void SetValue (MemberInfo mi, object o, object val)
 		{
-			var fi = mi as FieldInfo;
-			var pi = mi as PropertyInfo;
 			string? fieldName = null;
 
-			if (fi != null) {
+			if (mi is FieldInfo fi) {
 				fi.SetValue (o, val);
 				fieldName = fi.Name;
-			} else if (pi != null) {
-				var setMethod = pi.GetSetMethod ();
-				setMethod?.Invoke (o, new object [] { val });
+			} else if (mi is PropertyInfo pi) {
+				pi.GetSetMethod ()?.Invoke (o, new object[] { val });
 				fieldName = pi.Name;
 			}
 
-			if (EffectDataChanged != null)
-				EffectDataChanged (this, new PropertyChangedEventArgs (fieldName));
+			EffectDataChanged?.Invoke (this, new PropertyChangedEventArgs (fieldName));
 		}
 
 		// Returns the type for fields and properties and null for everything else
 		private static Type? GetTypeForMember (MemberInfo mi)
 		{
-			if (mi is FieldInfo)
-				return ((FieldInfo)mi).FieldType;
-			else if (mi is PropertyInfo)
-				return ((PropertyInfo)mi).PropertyType;
+			if (mi is FieldInfo fi)
+				return fi.FieldType;
+			else if (mi is PropertyInfo pi)
+				return pi.PropertyType;
 
 			return null;
 		}
@@ -426,11 +423,11 @@ namespace Pinta.Gui.Widgets
 		private static string MakeCaption (string name)
 		{
 			var sb = new StringBuilder (name.Length);
-			bool nextUp = true;
+			var nextUp = true;
 
-			foreach (char c in name) {
+			foreach (var c in name) {
 				if (nextUp) {
-					sb.Append (Char.ToUpper (c));
+					sb.Append (char.ToUpper (c));
 					nextUp = false;
 				} else {
 					if (c == '_') {
@@ -438,7 +435,7 @@ namespace Pinta.Gui.Widgets
 						nextUp = true;
 						continue;
 					}
-					if (Char.IsUpper (c))
+					if (char.IsUpper (c))
 						sb.Append (' ');
 					sb.Append (c);
 				}
@@ -449,20 +446,18 @@ namespace Pinta.Gui.Widgets
 
 		private object? GetValue (string name, object o)
 		{
-			var fi = o.GetType ().GetField (name);
-			if (fi != null)
+			if (o.GetType ().GetField (name) is FieldInfo fi)
 				return fi.GetValue (o);
-			var pi = o.GetType ().GetProperty (name);
-			if (pi == null)
-				return null;
-			var getMethod = pi.GetGetMethod ();
-			return getMethod?.Invoke (o, new object [0]);
+
+			if (o.GetType ().GetProperty (name) is PropertyInfo pi)
+				return pi.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
+
+			return null;
 		}
 
-        private void DelayedUpdate (GLib.TimeoutHandler handler)
-        {
-            if (event_delay_timeout_id != 0)
-			{
+		private void DelayedUpdate (GLib.TimeoutHandler handler)
+		{
+			if (event_delay_timeout_id != 0) {
 				GLib.Source.Remove (event_delay_timeout_id);
 				if (handler != timeout_func)
 					timeout_func?.Invoke ();
@@ -475,16 +470,16 @@ namespace Pinta.Gui.Widgets
 				timeout_func = null;
 				return false;
 			});
-        }
-        #endregion
-    }
+		}
+		#endregion
+	}
 
 	// TODO-GTK3 (addins)
 	// This is a temporary replacement for IAddinLocalizer from Mono.Addins.
 	public interface IAddinLocalizer
-    {
-		string GetString(string msgid);
-    }
+	{
+		string GetString (string msgid);
+	}
 
 	/// <summary>
 	/// Wrapper around Pinta's translation template.

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
@@ -14,41 +14,39 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem (true)]
 	public class AnglePickerGraphic : Gtk.DrawingArea
 	{
 		private bool tracking = false;
-		private Gdk.Point lastMouseXY;
-		private double angleValue;
+		private Gdk.Point last_mouse_xy;
+		private double angle_value;
 
 		public AnglePickerGraphic ()
 		{
-			Events = ((Gdk.EventMask)(16134));
-			
+			Events = ((EventMask) (16134));
+
 			ButtonPressEvent += HandleHandleButtonPressEvent;
 			ButtonReleaseEvent += HandleHandleButtonReleaseEvent;
 			MotionNotifyEvent += HandleHandleMotionNotifyEvent;
 		}
 
-		#region Public Properties
 		public int Value {
-			get { return (int)angleValue; }
+			get => (int) angle_value;
 			set {
-				double v = value % 360;
-				if (angleValue != v) {
-					angleValue = v;
+				var v = value % 360;
+				if (angle_value != v) {
+					angle_value = v;
 					OnValueChanged ();
-					this.Window.Invalidate ();
+					Window.Invalidate ();
 				}
 			}
 		}
 
 		public double ValueDouble {
-			get { return angleValue; }
+			get => angle_value;
 			set {
 				//double v = Math.IEEERemainder (value, 360.0);
-				if (angleValue != value) {
-					angleValue = value;
+				if (angle_value != value) {
+					angle_value = value;
 					OnValueChanged ();
 
 					if (Window != null)
@@ -56,12 +54,10 @@ namespace Pinta.Gui.Widgets
 				}
 			}
 		}
-		#endregion
 
-		#region Mouse Handlers
 		private void HandleHandleMotionNotifyEvent (object o, Gtk.MotionNotifyEventArgs args)
 		{
-			ProcessMouseEvent (new Gdk.Point ((int)args.Event.X, (int)args.Event.Y), (args.Event.State & ModifierType.ShiftMask) == ModifierType.ShiftMask);
+			ProcessMouseEvent (new Gdk.Point ((int) args.Event.X, (int) args.Event.Y), (args.Event.State & ModifierType.ShiftMask) == ModifierType.ShiftMask);
 		}
 
 		private void HandleHandleButtonReleaseEvent (object o, Gtk.ButtonReleaseEventArgs args)
@@ -73,110 +69,99 @@ namespace Pinta.Gui.Widgets
 		{
 			tracking = true;
 
-			ProcessMouseEvent (new Gdk.Point ((int)args.Event.X, (int)args.Event.Y), args.Event.IsShiftPressed ());
+			ProcessMouseEvent (new Gdk.Point ((int) args.Event.X, (int) args.Event.Y), args.Event.IsShiftPressed ());
 		}
-		
+
 		private void ProcessMouseEvent (Gdk.Point pt, bool constrainAngle)
 		{
-			lastMouseXY = pt;
+			last_mouse_xy = pt;
 
 			if (tracking) {
-                Gdk.Rectangle ourRect = Gdk.Rectangle.Inflate (Window.GetBounds (), -2, -2);
-				int diameter = Math.Min (ourRect.Width, ourRect.Height);
-                Gdk.Point center = new Gdk.Point (ourRect.X + (diameter / 2), ourRect.Y + (diameter / 2));
+				var ourRect = Gdk.Rectangle.Inflate (Window.GetBounds (), -2, -2);
+				var diameter = Math.Min (ourRect.Width, ourRect.Height);
+				var center = new Gdk.Point (ourRect.X + (diameter / 2), ourRect.Y + (diameter / 2));
 
-				int dx = lastMouseXY.X - center.X;
-				int dy = lastMouseXY.Y - center.Y;
-				double theta = Math.Atan2 (-dy, dx);
+				var dx = last_mouse_xy.X - center.X;
+				var dy = last_mouse_xy.Y - center.Y;
+				var theta = Math.Atan2 (-dy, dx);
 
-				double newAngle = (theta * 360) / (2 * Math.PI);
+				var newAngle = (theta * 360) / (2 * Math.PI);
 
 				if (newAngle < 0)
-					newAngle = newAngle + 360;
+					newAngle += 360;
 
 				if (constrainAngle) {
 					const double constraintAngle = 15.0;
 
-					double multiple = newAngle / constraintAngle;
-					double top = Math.Floor (multiple);
-					double topDelta = Math.Abs (top - multiple);
-					double bottom = Math.Ceiling (multiple);
-					double bottomDelta = Math.Abs (bottom - multiple);
+					var multiple = newAngle / constraintAngle;
+					var top = Math.Floor (multiple);
+					var topDelta = Math.Abs (top - multiple);
+					var bottom = Math.Ceiling (multiple);
+					var bottomDelta = Math.Abs (bottom - multiple);
 
 					double bestMultiple;
-					if (bottomDelta < topDelta) {
+
+					if (bottomDelta < topDelta)
 						bestMultiple = bottom;
-					} else {
+					else
 						bestMultiple = top;
-					}
 
 					newAngle = bestMultiple * constraintAngle;
 				}
 
-				this.ValueDouble = newAngle;
+				ValueDouble = newAngle;
 
 				Window.Invalidate ();
 			}
 		}
-        #endregion
 
-        #region Drawing Code
-        protected override bool OnDrawn(Context g)
-        {
-            base.OnDrawn(g);
+		protected override bool OnDrawn (Context g)
+		{
+			base.OnDrawn (g);
 
-            Cairo.Rectangle ourRect = Gdk.Rectangle.Inflate(Window.GetBounds(), -1, -1).ToCairoRectangle();
-            double diameter = Math.Min(ourRect.Width, ourRect.Height);
+			var ourRect = Gdk.Rectangle.Inflate (Window.GetBounds (), -1, -1).ToCairoRectangle ();
 
-            double radius = (diameter / 2.0);
+			var diameter = Math.Min (ourRect.Width, ourRect.Height);
+			var radius = (diameter / 2.0);
 
-            Cairo.PointD center = new Cairo.PointD(
-                (float)(ourRect.X + radius),
-                (float)(ourRect.Y + radius));
+			var center = new PointD (
+			    (float) (ourRect.X + radius),
+			    (float) (ourRect.Y + radius));
 
-            double theta = (this.angleValue * 2.0 * Math.PI) / 360.0;
+			var theta = (angle_value * 2.0 * Math.PI) / 360.0;
 
-            Cairo.Rectangle ellipseRect = new Cairo.Rectangle(ourRect.Location(), diameter, diameter);
-            Cairo.Rectangle ellipseOutlineRect = ellipseRect;
+			var ellipseRect = new Cairo.Rectangle (ourRect.Location (), diameter, diameter);
+			var ellipseOutlineRect = ellipseRect;
 
-            g.DrawEllipse(ellipseOutlineRect, new Cairo.Color(.1, .1, .1), 1);
+			g.DrawEllipse (ellipseOutlineRect, new Cairo.Color (.1, .1, .1), 1);
 
-            double endPointRadius = radius - 2;
+			var endPointRadius = radius - 2;
 
-            Cairo.PointD endPoint = new Cairo.PointD(
-                (float)(center.X + (endPointRadius * Math.Cos(theta))),
-                (float)(center.Y - (endPointRadius * Math.Sin(theta))));
+			var endPoint = new PointD (
+			    (float) (center.X + (endPointRadius * Math.Cos (theta))),
+			    (float) (center.Y - (endPointRadius * Math.Sin (theta))));
 
-            float gripSize = 2.5f;
-            Cairo.Rectangle gripEllipseRect = new Cairo.Rectangle(center.X - gripSize, center.Y - gripSize, gripSize * 2, gripSize * 2);
+			var gripSize = 2.5f;
+			var gripEllipseRect = new Cairo.Rectangle (center.X - gripSize, center.Y - gripSize, gripSize * 2, gripSize * 2);
 
-            g.FillEllipse(gripEllipseRect, new Cairo.Color(.1, .1, .1));
-            g.DrawLine(center, endPoint, new Cairo.Color(.1, .1, .1), 1);
+			g.FillEllipse (gripEllipseRect, new Cairo.Color (.1, .1, .1));
+			g.DrawLine (center, endPoint, new Cairo.Color (.1, .1, .1), 1);
 
+			return true;
+		}
 
-            return true;
-        }
-
-        protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
-        {
+		protected override void OnGetPreferredHeight (out int minimum_height, out int natural_height)
+		{
 			minimum_height = natural_height = 50;
 		}
 
-        protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
-        {
-			minimum_width = natural_width = 50;
-        }
-        #endregion
-
-        #region Public Events
-        public event EventHandler? ValueChanged;
-		
-		protected virtual void OnValueChanged ()
+		protected override void OnGetPreferredWidth (out int minimum_width, out int natural_width)
 		{
-			if (ValueChanged != null) {
-				ValueChanged (this, EventArgs.Empty);
-			}
+			minimum_width = natural_width = 50;
 		}
-#endregion
+
+		public event EventHandler? ValueChanged;
+
+		protected virtual void OnValueChanged () => ValueChanged?.Invoke (this, EventArgs.Empty);
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
@@ -14,17 +14,16 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem (true)]
 	public class AnglePickerWidget : FilledAreaBin
-    {
-        private AnglePickerGraphic anglepickergraphic1;
-        private SpinButton spin;
-        private Button button;
-        private Label label;
+	{
+		private AnglePickerGraphic anglepickergraphic1;
+		private SpinButton spin;
+		private Button button;
+		private Label label;
 
 		public AnglePickerWidget ()
 		{
-            Build ();
+			Build ();
 
 			anglepickergraphic1.ValueChanged += HandleAnglePickerValueChanged;
 			spin.ValueChanged += HandleSpinValueChanged;
@@ -33,16 +32,15 @@ namespace Pinta.Gui.Widgets
 			spin.ActivatesDefault = true;
 		}
 
-		#region Public Properties
 		public double DefaultValue { get; set; }
 
 		public string Label {
-			get { return label.Text; }
-			set { label.Text = value; }
+			get => label.Text;
+			set => label.Text = value;
 		}
 
 		public double Value {
-			get { return anglepickergraphic1.ValueDouble; }
+			get => anglepickergraphic1.ValueDouble;
 			set {
 				if (anglepickergraphic1.ValueDouble != value) {
 					anglepickergraphic1.ValueDouble = value;
@@ -50,9 +48,7 @@ namespace Pinta.Gui.Widgets
 				}
 			}
 		}
-		#endregion
 
-		#region Event Handlers
 		protected override void OnShown ()
 		{
 			base.OnShown ();
@@ -80,70 +76,67 @@ namespace Pinta.Gui.Widgets
 		{
 			Value = DefaultValue;
 		}
-		#endregion
 
-		#region Protected Methods
-		protected void OnValueChanged ()
-		{
-			if (ValueChanged != null)
-				ValueChanged (this, EventArgs.Empty);
-		}
-		#endregion
+		protected void OnValueChanged () => ValueChanged?.Invoke (this, EventArgs.Empty);
 
-		#region Public Events
 		public event EventHandler? ValueChanged;
-		#endregion
 
-	[MemberNotNull(nameof(anglepickergraphic1), nameof (spin), nameof (button), nameof (label))]
-        private void Build ()
-        {
-            // Section label + line
-            var hbox1 = new HBox (false, 6);
+		[MemberNotNull (nameof (anglepickergraphic1), nameof (spin), nameof (button), nameof (label))]
+		private void Build ()
+		{
+			// Section label + line
+			var hbox1 = new HBox (false, 6);
 
-            label = new Label ();
-            hbox1.PackStart (label, false, false, 0);
-            hbox1.PackStart (new HSeparator (), true, true, 0);
+			label = new Label ();
+			hbox1.PackStart (label, false, false, 0);
+			hbox1.PackStart (new HSeparator (), true, true, 0);
 
-            // Angle graphic + spinner + reset button
-            var hbox2 = new HBox (false, 6);
+			// Angle graphic + spinner + reset button
+			var hbox2 = new HBox (false, 6);
 
-            anglepickergraphic1 = new AnglePickerGraphic ();
-            hbox2.PackStart (anglepickergraphic1, true, false, 0);
+			anglepickergraphic1 = new AnglePickerGraphic ();
+			hbox2.PackStart (anglepickergraphic1, true, false, 0);
 
-            spin = new SpinButton (0, 360, 1);
-            spin.CanFocus = true;
-            spin.Adjustment.PageIncrement = 10;
-            spin.ClimbRate = 1;
-            spin.Numeric = true;
+			spin = new SpinButton (0, 360, 1) {
+				CanFocus = true,
+				ClimbRate = 1,
+				Numeric = true
+			};
 
-            var alignment = new Alignment (0.5F, 0F, 1F, 0F);
-            alignment.Add (spin);
-            hbox2.PackStart (alignment, false, false, 0);
+			spin.Adjustment.PageIncrement = 10;
 
-            // Reset button
-            button = new Button ();
-            button.WidthRequest = 28;
-            button.HeightRequest = 24;
-            button.CanFocus = true;
-            button.UseUnderline = true;
+			var alignment = new Alignment (0.5F, 0F, 1F, 0F) {
+				spin
+			};
 
-            var button_image = new Image (Gtk.IconTheme.Default.LoadIcon(Resources.StandardIcons.GoPrevious, 16));
-            button.Add (button_image);
+			hbox2.PackStart (alignment, false, false, 0);
 
-            var alignment2 = new Alignment (0.5F, 0F, 1F, 0F);
-            alignment2.Add (button);
+			// Reset button
+			button = new Button {
+				WidthRequest = 28,
+				HeightRequest = 24,
+				CanFocus = true,
+				UseUnderline = true
+			};
 
-            hbox2.PackStart (alignment2, false, false, 0);
+			var button_image = new Image (IconTheme.Default.LoadIcon (Resources.StandardIcons.GoPrevious, 16));
+			button.Add (button_image);
 
-            // Main layout
-            var vbox = new VBox (false, 6);
+			var alignment2 = new Alignment (0.5F, 0F, 1F, 0F) {
+				button
+			};
 
-            vbox.Add (hbox1);
-            vbox.Add (hbox2);
+			hbox2.PackStart (alignment2, false, false, 0);
 
-            Add (vbox);
+			// Main layout
+			var vbox = new VBox (false, 6) {
+				hbox1,
+				hbox2
+			};
 
-            vbox.ShowAll ();
-        }
-    }
+			Add (vbox);
+
+			vbox.ShowAll ();
+		}
+	}
 }

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -16,19 +16,19 @@ namespace Pinta.Gui.Widgets
 {
 	class CanvasRenderer
 	{
-        private static Cairo.Pattern tranparent_pattern;
+		private static Cairo.Pattern tranparent_pattern;
+
+		private readonly bool enable_pixel_grid;
 
 		private Size source_size;
 		private Size destination_size;
 		private Layer? offset_layer;
-		private bool enable_pixel_grid;
-
 		private ScaleFactor scale_factor;
-		private bool generated;
-		private int[] d2sLookupX = null!; // NRT - Guarded by EnsureLookupTablesCreated
-		private int[] d2sLookupY = null!;
-		private int[] s2dLookupX = null!;
-		private int[] s2dLookupY = null!;
+
+		private int[]? d2sLookupX;
+		private int[]? d2sLookupY;
+		private int[]? s2dLookupX;
+		private int[]? s2dLookupY;
 
 		public CanvasRenderer (bool enable_pixel_grid)
 		{
@@ -44,59 +44,62 @@ namespace Pinta.Gui.Widgets
 		{
 			if (sourceSize == source_size && destinationSize == destination_size)
 				return;
-				
+
 			source_size = sourceSize;
 			destination_size = destinationSize;
-			
+
 			scale_factor = new ScaleFactor (source_size.Width, destination_size.Width);
-			generated = false;
+
+			d2sLookupX = null;
+			d2sLookupY = null;
+			s2dLookupX = null;
+			s2dLookupY = null;
 		}
 
-		public void Render (List<Layer> layers, Cairo.ImageSurface dst, Gdk.Point offset)
+		public void Render (List<Layer> layers, Cairo.ImageSurface dst, Point offset)
 		{
 			dst.Flush ();
 
-            // Our rectangle of interest
-            var r = new Gdk.Rectangle (offset, dst.GetBounds ().Size).ToCairoRectangle ();
+			// Our rectangle of interest
+			var r = new Rectangle (offset, dst.GetBounds ().Size).ToCairoRectangle ();
 			var doc = PintaCore.Workspace.ActiveDocument;
 
+			using (var g = new Cairo.Context (dst)) {
+				// Create the transparent checkerboard background
+				g.Translate (-offset.X, -offset.Y);
+				g.FillRectangle (r, tranparent_pattern, new Cairo.PointD (offset.X, offset.Y));
 
-            using (var g = new Cairo.Context (dst)) {
-                // Create the transparent checkerboard background
-                g.Translate (-offset.X, -offset.Y);
-                g.FillRectangle (r, tranparent_pattern, new Cairo.PointD (offset.X, offset.Y));
+				for (var i = 0; i < layers.Count; i++) {
+					var layer = layers[i];
 
-                for (var i = 0; i < layers.Count; i++) {
-                    var layer = layers[i];
+					// If we're in LivePreview, substitute current layer with the preview layer
+					if (layer == doc.Layers.CurrentUserLayer && PintaCore.LivePreview.IsEnabled)
+						layer = CreateLivePreviewLayer (layer);
 
-                    // If we're in LivePreview, substitute current layer with the preview layer
-                    if (layer == doc.Layers.CurrentUserLayer && PintaCore.LivePreview.IsEnabled)
-                        layer = CreateLivePreviewLayer (layer);
+					// If the layer is offset, handle it here
+					if (!layer.Transform.IsIdentity ())
+						layer = CreateOffsetLayer (layer);
 
-                    // If the layer is offset, handle it here
-                    if (!layer.Transform.IsIdentity ())
-                        layer = CreateOffsetLayer (layer);
+					// No need to resize the surface if we're at 100% zoom
+					if (scale_factor.Ratio == 1)
+						layer.Draw (g, layer.Surface, layer.Opacity, false);
+					else {
+						using (var scaled = new Cairo.ImageSurface (Cairo.Format.Argb32, dst.Width, dst.Height)) {
+							g.Save ();
+							// Have to undo the translate set above
+							g.Translate (offset.X, offset.Y);
+							CopyScaled (layer.Surface, scaled, r.ToGdkRectangle ());
+							layer.Draw (g, scaled, layer.Opacity, false);
+							g.Restore ();
+						}
+					}
+				}
+			}
 
-                    // No need to resize the surface if we're at 100% zoom
-                    if (scale_factor.Ratio == 1)
-                        layer.Draw (g, layer.Surface, layer.Opacity, false);
-                    else {
-                        using (var scaled = new Cairo.ImageSurface (Cairo.Format.Argb32, dst.Width, dst.Height)) {
-                            g.Save ();
-                            // Have to undo the translate set above
-                            g.Translate (offset.X, offset.Y);
-                            CopyScaled (layer.Surface, scaled, r.ToGdkRectangle ());
-                            layer.Draw (g, scaled, layer.Opacity, false);
-                            g.Restore ();
-                        }
-                    }
-                }
-            }
+			// If we are at least 200% and grid is requested, draw it
+			if (enable_pixel_grid && PintaCore.Actions.View.PixelGrid.Value && scale_factor.Ratio <= 0.5d)
+				RenderPixelGrid (dst, offset);
 
-            // If we are at least 200% and grid is requested, draw it
-            if (enable_pixel_grid && PintaCore.Actions.View.PixelGrid.Value && scale_factor.Ratio <= 0.5d)
-                RenderPixelGrid (dst, offset);
-			
 			dst.MarkDirty ();
 		}
 
@@ -118,12 +121,13 @@ namespace Pinta.Gui.Widgets
 
 		private Layer CreateLivePreviewLayer (Layer original)
 		{
-			var preview_layer = new Layer (PintaCore.LivePreview.LivePreviewSurface);
+			var preview_layer = new Layer (PintaCore.LivePreview.LivePreviewSurface) {
+				BlendMode = original.BlendMode,
+				Opacity = original.Opacity,
+				Hidden = original.Hidden
+			};
 
-			preview_layer.BlendMode = original.BlendMode;
 			preview_layer.Transform.InitMatrix (original.Transform);
-			preview_layer.Opacity = original.Opacity;
-			preview_layer.Hidden = original.Hidden;
 
 			return preview_layer;
 		}
@@ -143,139 +147,141 @@ namespace Pinta.Gui.Widgets
 			return offset;
 		}
 
+		// Lazily create and cache these
+		private int[] D2SLookupX => d2sLookupX ??= CreateLookupX (source_size.Width, destination_size.Width, scale_factor);
+		private int[] D2SLookupY => d2sLookupY ??= CreateLookupY (source_size.Height, destination_size.Height, scale_factor);
+		private int[] S2DLookupX => s2dLookupX ??= CreateS2DLookupX (source_size.Width, destination_size.Width, scale_factor);
+		private int[] S2DLookupY => s2dLookupY ??= CreateS2DLookupY (source_size.Height, destination_size.Height, scale_factor);
+
 		#region Algorithms ported from PDN
-        private void CopyScaled (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
-        {
-            if (scale_factor.Ratio < 1)
-                CopyScaledZoomIn (src, dst, roi);
-            else
-                CopyScaledZoomOut (src, dst, roi);
-        }
-
-        private unsafe void CopyScaledZoomIn (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
-        {
-            // Tell Cairo we need the latest raw data
-            dst.Flush ();
-
-            EnsureLookupTablesCreated ();
-
-            // Cache pointers to surface raw data
-            var src_ptr = (ColorBgra*)src.DataPtr;
-            var dst_ptr = (ColorBgra*)dst.DataPtr;
-
-            // Cache surface sizes
-            var src_width = src.Width;
-            var dst_width = dst.Width;
-            var dst_height = dst.Height;
-
-            for (var dst_row = 0; dst_row < dst_height; ++dst_row) {
-                // For each dest row, look up the src row to copy from
-                var nnY = dst_row + roi.Y;
-                var srcY = d2sLookupY[nnY];
-
-                // Get pointers to src and dest rows
-                var dst_row_ptr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dst_row);
-                var src_row_ptr = src.GetRowAddressUnchecked (src_ptr, src_width, srcY);
-
-                for (var dstCol = 0; dstCol < dst_width; ++dstCol) {
-                    // Look up the src column to copy from
-                    var nnX = dstCol + roi.X;
-                    var srcX = d2sLookupX[nnX];
-
-                    // Copy source to destination
-                    *dst_row_ptr++ = *(src_row_ptr + srcX);
-                }
-            }
-
-            // Tell Cairo we changed the raw data
-            dst.MarkDirty ();
-        }
-
-        private unsafe void CopyScaledZoomOut (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
-        {
-            // Tell Cairo we need the latest raw data
-            dst.Flush ();
-
-            const int fpShift = 12;
-            const int fpFactor = (1 << fpShift);
-
-            var source_size = src.GetBounds ().Size;
-
-            // Find destination bounds
-            var dst_left = (int)(((long)roi.X * fpFactor * (long)source_size.Width) / (long)destination_size.Width);
-            var dst_top = (int)(((long)roi.Y * fpFactor * (long)source_size.Height) / (long)destination_size.Height);
-            var dst_right = (int)(((long)(roi.X + dst.Width) * fpFactor * (long)source_size.Width) / (long)destination_size.Width);
-            var dst_bottom = (int)(((long)(roi.Y + dst.Height) * fpFactor * (long)source_size.Height) / (long)destination_size.Height);
-            var dx = (dst_right - dst_left) / dst.Width;
-            var dy = (dst_bottom - dst_top) / dst.Height;
-
-            // Cache pointers to surface raw data and sizes
-            var src_ptr = (ColorBgra*)src.DataPtr;
-            var dst_ptr = (ColorBgra*)dst.DataPtr;
-            var src_width = src.Width;
-            var dst_width = dst.Width;
-            var dst_height = dst.Height;
-
-            for (int dstRow = 0, fDstY = dst_top; dstRow < dst_height && fDstY < dst_bottom; ++dstRow, fDstY += dy) {
-                var srcY1 = fDstY >> fpShift;                            // y
-                var srcY2 = (fDstY + (dy >> 2)) >> fpShift;              // y + 0.25
-                var srcY3 = (fDstY + (dy >> 1)) >> fpShift;              // y + 0.50
-                var srcY4 = (fDstY + (dy >> 1) + (dy >> 2)) >> fpShift;  // y + 0.75
-
-                var src1 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY1);
-                var src2 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY2);
-                var src3 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY3);
-                var src4 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY4);
-                var dstPtr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dstRow);
-
-                var checkerY = dstRow + roi.Y;
-                var checkerX = roi.X;
-                var maxCheckerX = checkerX + dst.Width;
-
-                for (var fDstX = dst_left; checkerX < maxCheckerX && fDstX < dst_right; ++checkerX, fDstX += dx) {
-                    var srcX1 = (fDstX + (dx >> 2)) >> fpShift;             // x + 0.25
-                    var srcX2 = (fDstX + (dx >> 1) + (dx >> 2)) >> fpShift; // x + 0.75
-                    var srcX3 = fDstX >> fpShift;                           // x
-                    var srcX4 = (fDstX + (dx >> 1)) >> fpShift;             // x + 0.50
-
-                    var p1 = src1 + srcX1;
-                    var p2 = src2 + srcX2;
-                    var p3 = src3 + srcX3;
-                    var p4 = src4 + srcX4;
-
-                    var r = (2 + p1->R + p2->R + p3->R + p4->R) >> 2;
-                    var g = (2 + p1->G + p2->G + p3->G + p4->G) >> 2;
-                    var b = (2 + p1->B + p2->B + p3->B + p4->B) >> 2;
-                    var a = (2 + p1->A + p2->A + p3->A + p4->A) >> 2;
-
-                    // Copy color to destination
-                    *dstPtr++ = ColorBgra.FromUInt32 ((uint)b + ((uint)g << 8) + ((uint)r << 16) + ((uint)a << 24));
-                }
-            }
-
-            // Tell Cairo we changed the raw data
-            dst.MarkDirty ();
-        }
-
-		private unsafe void RenderPixelGrid (Cairo.ImageSurface dst, Gdk.Point offset)
+		private void CopyScaled (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
 		{
-            EnsureLookupTablesCreated ();
-            
-            // Draw horizontal lines
-			var dst_ptr = (ColorBgra*)dst.DataPtr; 
-			int dstHeight = dst.Height;
-			int dstWidth = dst.Width;
-			int dstStride = dst.Stride;
-			int sTop = d2sLookupY[offset.Y];
-			int sBottom = d2sLookupY[offset.Y + dstHeight];
+			if (scale_factor.Ratio < 1)
+				CopyScaledZoomIn (src, dst, roi);
+			else
+				CopyScaledZoomOut (src, dst, roi);
+		}
 
-			for (int srcY = sTop; srcY <= sBottom; ++srcY) {
-				int dstY = s2dLookupY[srcY];
-				int dstRow = dstY - offset.Y;
+		private unsafe void CopyScaledZoomIn (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
+		{
+			// Tell Cairo we need the latest raw data
+			dst.Flush ();
+
+			// Cache pointers to surface raw data
+			var src_ptr = (ColorBgra*) src.DataPtr;
+			var dst_ptr = (ColorBgra*) dst.DataPtr;
+
+			// Cache surface sizes
+			var src_width = src.Width;
+			var dst_width = dst.Width;
+			var dst_height = dst.Height;
+
+			for (var dst_row = 0; dst_row < dst_height; ++dst_row) {
+				// For each dest row, look up the src row to copy from
+				var nnY = dst_row + roi.Y;
+				var srcY = D2SLookupY[nnY];
+
+				// Get pointers to src and dest rows
+				var dst_row_ptr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dst_row);
+				var src_row_ptr = src.GetRowAddressUnchecked (src_ptr, src_width, srcY);
+
+				for (var dstCol = 0; dstCol < dst_width; ++dstCol) {
+					// Look up the src column to copy from
+					var nnX = dstCol + roi.X;
+					var srcX = D2SLookupX[nnX];
+
+					// Copy source to destination
+					*dst_row_ptr++ = *(src_row_ptr + srcX);
+				}
+			}
+
+			// Tell Cairo we changed the raw data
+			dst.MarkDirty ();
+		}
+
+		private unsafe void CopyScaledZoomOut (Cairo.ImageSurface src, Cairo.ImageSurface dst, Rectangle roi)
+		{
+			// Tell Cairo we need the latest raw data
+			dst.Flush ();
+
+			const int fpShift = 12;
+			const int fpFactor = (1 << fpShift);
+
+			var source_size = src.GetBounds ().Size;
+
+			// Find destination bounds
+			var dst_left = (int) (((long) roi.X * fpFactor * (long) source_size.Width) / (long) destination_size.Width);
+			var dst_top = (int) (((long) roi.Y * fpFactor * (long) source_size.Height) / (long) destination_size.Height);
+			var dst_right = (int) (((long) (roi.X + dst.Width) * fpFactor * (long) source_size.Width) / (long) destination_size.Width);
+			var dst_bottom = (int) (((long) (roi.Y + dst.Height) * fpFactor * (long) source_size.Height) / (long) destination_size.Height);
+			var dx = (dst_right - dst_left) / dst.Width;
+			var dy = (dst_bottom - dst_top) / dst.Height;
+
+			// Cache pointers to surface raw data and sizes
+			var src_ptr = (ColorBgra*) src.DataPtr;
+			var dst_ptr = (ColorBgra*) dst.DataPtr;
+			var src_width = src.Width;
+			var dst_width = dst.Width;
+			var dst_height = dst.Height;
+
+			for (int dstRow = 0, fDstY = dst_top; dstRow < dst_height && fDstY < dst_bottom; ++dstRow, fDstY += dy) {
+				var srcY1 = fDstY >> fpShift;                            // y
+				var srcY2 = (fDstY + (dy >> 2)) >> fpShift;              // y + 0.25
+				var srcY3 = (fDstY + (dy >> 1)) >> fpShift;              // y + 0.50
+				var srcY4 = (fDstY + (dy >> 1) + (dy >> 2)) >> fpShift;  // y + 0.75
+
+				var src1 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY1);
+				var src2 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY2);
+				var src3 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY3);
+				var src4 = src.GetRowAddressUnchecked (src_ptr, src_width, srcY4);
+				var dstPtr = dst.GetRowAddressUnchecked (dst_ptr, dst_width, dstRow);
+
+				var checkerY = dstRow + roi.Y;
+				var checkerX = roi.X;
+				var maxCheckerX = checkerX + dst.Width;
+
+				for (var fDstX = dst_left; checkerX < maxCheckerX && fDstX < dst_right; ++checkerX, fDstX += dx) {
+					var srcX1 = (fDstX + (dx >> 2)) >> fpShift;             // x + 0.25
+					var srcX2 = (fDstX + (dx >> 1) + (dx >> 2)) >> fpShift; // x + 0.75
+					var srcX3 = fDstX >> fpShift;                           // x
+					var srcX4 = (fDstX + (dx >> 1)) >> fpShift;             // x + 0.50
+
+					var p1 = src1 + srcX1;
+					var p2 = src2 + srcX2;
+					var p3 = src3 + srcX3;
+					var p4 = src4 + srcX4;
+
+					var r = (2 + p1->R + p2->R + p3->R + p4->R) >> 2;
+					var g = (2 + p1->G + p2->G + p3->G + p4->G) >> 2;
+					var b = (2 + p1->B + p2->B + p3->B + p4->B) >> 2;
+					var a = (2 + p1->A + p2->A + p3->A + p4->A) >> 2;
+
+					// Copy color to destination
+					*dstPtr++ = ColorBgra.FromUInt32 ((uint) b + ((uint) g << 8) + ((uint) r << 16) + ((uint) a << 24));
+				}
+			}
+
+			// Tell Cairo we changed the raw data
+			dst.MarkDirty ();
+		}
+
+		private unsafe void RenderPixelGrid (Cairo.ImageSurface dst, Point offset)
+		{
+			// Draw horizontal lines
+			var dst_ptr = (ColorBgra*) dst.DataPtr;
+			var dstHeight = dst.Height;
+			var dstWidth = dst.Width;
+			var dstStride = dst.Stride;
+			var sTop = D2SLookupY[offset.Y];
+			var sBottom = D2SLookupY[offset.Y + dstHeight];
+
+			for (var srcY = sTop; srcY <= sBottom; ++srcY) {
+				var dstY = S2DLookupY[srcY];
+				var dstRow = dstY - offset.Y;
 
 				if (dstRow >= 0 && dstRow < dstHeight) {
-					ColorBgra* dstRowPtr = dst.GetRowAddressUnchecked (dst_ptr, dstWidth, dstRow);
-					ColorBgra* dstRowEndPtr = dstRowPtr + dstWidth;
+					var dstRowPtr = dst.GetRowAddressUnchecked (dst_ptr, dstWidth, dstRow);
+					var dstRowEndPtr = dstRowPtr + dstWidth;
 
 					dstRowPtr += offset.X & 1;
 
@@ -287,46 +293,34 @@ namespace Pinta.Gui.Widgets
 			}
 
 			// Draw vertical lines
-			int sLeft = d2sLookupX[offset.X];
-			int sRight = d2sLookupX[offset.X + dstWidth];
+			var sLeft = D2SLookupX[offset.X];
+			var sRight = D2SLookupX[offset.X + dstWidth];
 
-			for (int srcX = sLeft; srcX <= sRight; ++srcX) {
-				int dstX = s2dLookupX[srcX];
-				int dstCol = dstX - offset.X;
+			for (var srcX = sLeft; srcX <= sRight; ++srcX) {
+				var dstX = S2DLookupX[srcX];
+				var dstCol = dstX - offset.X;
 
 				if (dstCol >= 0 && dstCol < dstWidth) {
-					byte* dstColPtr = (byte*)dst.GetPointAddress (dstCol, 0);
-					byte* dstColEndPtr = dstColPtr + dstStride * dstHeight;
+					var dstColPtr = (byte*) dst.GetPointAddress (dstCol, 0);
+					var dstColEndPtr = dstColPtr + dstStride * dstHeight;
 
 					dstColPtr += (offset.Y & 1) * dstStride;
 
 					while (dstColPtr < dstColEndPtr) {
-						*((ColorBgra*)dstColPtr) = ColorBgra.Black;
+						*((ColorBgra*) dstColPtr) = ColorBgra.Black;
 						dstColPtr += 2 * dstStride;
 					}
 				}
 			}
 		}
 
-        private void EnsureLookupTablesCreated ()
-        {
-            if (!generated) {
-                d2sLookupX = CreateLookupX (source_size.Width, destination_size.Width, scale_factor);
-                d2sLookupY = CreateLookupY (source_size.Height, destination_size.Height, scale_factor);
-                s2dLookupX = CreateS2DLookupX (source_size.Width, destination_size.Width, scale_factor);
-                s2dLookupY = CreateS2DLookupY (source_size.Height, destination_size.Height, scale_factor);
-
-                generated = true;
-            }
-        }
-
 		private int[] CreateLookupX (int srcWidth, int dstWidth, ScaleFactor scaleFactor)
 		{
 			var lookup = new int[dstWidth + 1];
 
-			for (int x = 0; x < lookup.Length; ++x) {
-				Gdk.Point pt = new Gdk.Point (x, 0);
-				Gdk.Point clientPt = scaleFactor.ScalePoint (pt);
+			for (var x = 0; x < lookup.Length; ++x) {
+				var pt = new Point (x, 0);
+				var clientPt = scaleFactor.ScalePoint (pt);
 
 				// Sometimes the scale factor is slightly different on one axis than
 				// on another, simply due to accuracy. So we have to clamp this value to
@@ -341,9 +335,9 @@ namespace Pinta.Gui.Widgets
 		{
 			var lookup = new int[dstHeight + 1];
 
-			for (int y = 0; y < lookup.Length; ++y) {
-				Gdk.Point pt = new Gdk.Point (0, y);
-				Gdk.Point clientPt = scaleFactor.ScalePoint (pt);
+			for (var y = 0; y < lookup.Length; ++y) {
+				var pt = new Point (0, y);
+				var clientPt = scaleFactor.ScalePoint (pt);
 
 				// Sometimes the scale factor is slightly different on one axis than
 				// on another, simply due to accuracy. So we have to clamp this value to
@@ -353,14 +347,14 @@ namespace Pinta.Gui.Widgets
 
 			return lookup;
 		}
-		
-		private int[] CreateS2DLookupX(int srcWidth, int dstWidth, ScaleFactor scaleFactor)
+
+		private int[] CreateS2DLookupX (int srcWidth, int dstWidth, ScaleFactor scaleFactor)
 		{
 			var lookup = new int[srcWidth + 1];
 
-			for (int x = 0; x < lookup.Length; ++x) {
-				Gdk.Point pt = new Gdk.Point (x, 0);
-				Gdk.Point clientPt = scaleFactor.UnscalePoint (pt);
+			for (var x = 0; x < lookup.Length; ++x) {
+				var pt = new Gdk.Point (x, 0);
+				var clientPt = scaleFactor.UnscalePoint (pt);
 
 				// Sometimes the scale factor is slightly different on one axis than
 				// on another, simply due to accuracy. So we have to clamp this value to
@@ -375,9 +369,9 @@ namespace Pinta.Gui.Widgets
 		{
 			var lookup = new int[srcHeight + 1];
 
-			for (int y = 0; y < lookup.Length; ++y) {
-				Gdk.Point pt = new Gdk.Point (0, y);
-				Gdk.Point clientPt = scaleFactor.UnscalePoint (pt);
+			for (var y = 0; y < lookup.Length; ++y) {
+				var pt = new Gdk.Point (0, y);
+				var clientPt = scaleFactor.UnscalePoint (pt);
 
 				// Sometimes the scale factor is slightly different on one axis than
 				// on another, simply due to accuracy. So we have to clamp this value to

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // PintaCanvas.cs
 //  
 // Author:
@@ -31,14 +31,13 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem (true)]
 	public class PintaCanvas : DrawingArea
 	{
-		Cairo.ImageSurface? canvas;
-		CanvasRenderer cr;
+		private readonly CanvasRenderer cr;
+		private readonly Document document;
 
-		private Document document;
-		private int hScrollAmount = 92;
+		private Cairo.ImageSurface? canvas;
+		private int h_scroll_amount = 92;
 
 		public CanvasWindow CanvasWindow { get; private set; }
 
@@ -91,27 +90,27 @@ namespace Pinta.Gui.Widgets
 					PintaCore.Chrome.LastCanvasCursorPoint = point.ToGdkPoint ();
 
 				if (PintaCore.Tools.CurrentTool != null)
-					PintaCore.Tools.CurrentTool.DoMouseMove ((DrawingArea)sender, e, point);
+					PintaCore.Tools.CurrentTool.DoMouseMove ((DrawingArea) sender, e, point);
 			};
 		}
 
-        #region Protected Methods
-        protected override bool OnDrawn(Cairo.Context context)
-        {
-			base.OnDrawn(context);
-				
+		protected override bool OnDrawn (Cairo.Context context)
+		{
+			base.OnDrawn (context);
+
 			var scale = document.Workspace.Scale;
 
-			var x = (int)document.Workspace.Offset.X;
-			var y = (int)document.Workspace.Offset.Y;
+			var x = (int) document.Workspace.Offset.X;
+			var y = (int) document.Workspace.Offset.Y;
 
 			// Translate our expose area for the whole drawingarea to just our canvas
-            var canvas_bounds = new Gdk.Rectangle (x, y, document.Workspace.CanvasSize.Width, document.Workspace.CanvasSize.Height);
-			Gdk.Rectangle expose_rect;
-			if (Gdk.CairoHelper.GetClipRectangle(context, out expose_rect))
-                canvas_bounds.Intersect(expose_rect);
+			var canvas_bounds = new Rectangle (x, y, document.Workspace.CanvasSize.Width, document.Workspace.CanvasSize.Height);
+			Rectangle expose_rect;
 
-            if (canvas_bounds.IsEmpty)
+			if (Gdk.CairoHelper.GetClipRectangle (context, out expose_rect))
+				canvas_bounds.Intersect (expose_rect);
+
+			if (canvas_bounds.IsEmpty)
 				return true;
 
 			canvas_bounds.X -= x;
@@ -119,44 +118,42 @@ namespace Pinta.Gui.Widgets
 
 			// Resize our offscreen surface to a surface the size of our drawing area
 			if (canvas == null || canvas.Width != canvas_bounds.Width || canvas.Height != canvas_bounds.Height) {
-				if (canvas != null)
-					(canvas as IDisposable).Dispose ();
-
+				canvas?.Dispose ();
 				canvas = new Cairo.ImageSurface (Cairo.Format.Argb32, canvas_bounds.Width, canvas_bounds.Height);
 			}
 
 			cr.Initialize (document.ImageSize, document.Workspace.CanvasSize);
 
 			var g = context;
-            // Draw our canvas drop shadow
-            g.DrawRectangle (new Cairo.Rectangle (x - 1, y - 1, document.Workspace.CanvasSize.Width + 2, document.Workspace.CanvasSize.Height + 2), new Cairo.Color (.5, .5, .5), 1);
-            g.DrawRectangle (new Cairo.Rectangle (x - 2, y - 2, document.Workspace.CanvasSize.Width + 4, document.Workspace.CanvasSize.Height + 4), new Cairo.Color (.8, .8, .8), 1);
-            g.DrawRectangle (new Cairo.Rectangle (x - 3, y - 3, document.Workspace.CanvasSize.Width + 6, document.Workspace.CanvasSize.Height + 6), new Cairo.Color (.9, .9, .9), 1);
 
-            // Set up our clip rectangle
-            g.Rectangle (new Cairo.Rectangle (x, y, document.Workspace.CanvasSize.Width, document.Workspace.CanvasSize.Height));
-            g.Clip ();
+			// Draw our canvas drop shadow
+			g.DrawRectangle (new Cairo.Rectangle (x - 1, y - 1, document.Workspace.CanvasSize.Width + 2, document.Workspace.CanvasSize.Height + 2), new Cairo.Color (.5, .5, .5), 1);
+			g.DrawRectangle (new Cairo.Rectangle (x - 2, y - 2, document.Workspace.CanvasSize.Width + 4, document.Workspace.CanvasSize.Height + 4), new Cairo.Color (.8, .8, .8), 1);
+			g.DrawRectangle (new Cairo.Rectangle (x - 3, y - 3, document.Workspace.CanvasSize.Width + 6, document.Workspace.CanvasSize.Height + 6), new Cairo.Color (.9, .9, .9), 1);
 
-            g.Translate (x, y);
+			// Set up our clip rectangle
+			g.Rectangle (new Cairo.Rectangle (x, y, document.Workspace.CanvasSize.Width, document.Workspace.CanvasSize.Height));
+			g.Clip ();
 
-            // Render all the layers to a surface
-            var layers = document.Layers.GetLayersToPaint ();
+			g.Translate (x, y);
 
-            if (layers.Count == 0)
-                canvas.Clear ();
+			// Render all the layers to a surface
+			var layers = document.Layers.GetLayersToPaint ();
 
-            cr.Render (layers, canvas, canvas_bounds.Location);
+			if (layers.Count == 0)
+				canvas.Clear ();
 
-            // Paint the surface to our canvas
-            g.SetSourceSurface (canvas, canvas_bounds.X + (int)(0 * scale), canvas_bounds.Y + (int)(0 * scale));
-            g.Paint ();
+			cr.Render (layers, canvas, canvas_bounds.Location);
 
-            // Selection outline
-            if (document.Selection.Visible) {
-                                bool fillSelection = PintaCore.Tools.CurrentTool.Name.Contains ("Select") &&
-                    !PintaCore.Tools.CurrentTool.Name.Contains ("Selected");
-                                document.Selection.Draw (g, scale, fillSelection);
-            }
+			// Paint the surface to our canvas
+			g.SetSourceSurface (canvas, canvas_bounds.X + (int) (0 * scale), canvas_bounds.Y + (int) (0 * scale));
+			g.Paint ();
+
+			// Selection outline
+			if (document.Selection.Visible) {
+				var fillSelection = PintaCore.Tools.CurrentTool.Name.Contains ("Select") && !PintaCore.Tools.CurrentTool.Name.Contains ("Selected");
+				document.Selection.Draw (g, scale, fillSelection);
+			}
 
 			return true;
 		}
@@ -182,20 +179,18 @@ namespace Pinta.Gui.Widgets
 				switch (evnt.Direction) {
 					case ScrollDirection.Down:
 					case ScrollDirection.Right:
-						document.Workspace.ScrollCanvas (hScrollAmount, 0);
+						document.Workspace.ScrollCanvas (h_scroll_amount, 0);
 						return true;
 					case ScrollDirection.Up:
 					case ScrollDirection.Left:
-						document.Workspace.ScrollCanvas (-hScrollAmount, 0);
+						document.Workspace.ScrollCanvas (-h_scroll_amount, 0);
 						return true;
 				}
 			}
 
 			return base.OnScrollEvent (evnt);
 		}
-#endregion
 
-#region Private Methods
 		private void SetRequisition (Size size)
 		{
 			WidthRequest = size.Width;
@@ -215,6 +210,5 @@ namespace Pinta.Gui.Widgets
 			PintaCore.Tools.CurrentTool.DoKeyRelease (this, e);
 			PintaCore.Palette.DoKeyRelease (this, e);
 		}
-#endregion
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
@@ -25,7 +25,6 @@
 // THE SOFTWARE.
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Cairo;
@@ -34,54 +33,20 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[ToolboxItem (true)]
 	public class ColorGradientWidget : FilledAreaBin
 	{
 		private EventBox eventbox;
+		
+		private const double xpad = 0.15;       // gradient horizontal padding							
+		private const double ypad = 0.03;       // gradient vertical padding
 
-		//gradient horizontal padding
-		private const double xpad = 0.15;
-		//gradient vertical padding
-		private const double ypad = 0.03;
+		private double[] vals;
 
-		private double[] vals = null!; // Set by Count
-
-		private Rectangle GradientRectangle {
-			get {
-				var rect = new Rectangle (0, 0, AllocatedWidth, AllocatedHeight);
-				double x = rect.X + xpad * rect.Width;
-				double y = rect.Y + ypad * rect.Height;
-				double width = (1 - 2 * xpad) * rect.Width;
-				double height = (1 - 2 * ypad) * rect.Height;
-
-				return new Rectangle (x, y, width, height);
-			}
-		}
-
-		[Category ("Custom Properties")]
-		public int Count {
-			get { return vals.Length; }
-			set {
-				if (value < 2 || value > 3) {
-					throw new ArgumentOutOfRangeException ("value", value, "Count must be 2 or 3");
-				}
-
-				vals = new double[value];
-				double step = 256 / (value - 1);
-
-				for (int i = 0; i < value; i++) {
-					vals[i] = i * step - ((i != 0) ? 1 : 0);
-				}
-			}
-		}
-
-		public Color MaxColor { get; set; }
-
-		public int ValueIndex { get; private set; }
-
-		public ColorGradientWidget ()
+		public ColorGradientWidget (int count)
 		{
 			Build ();
+			Count = count;
+
 			ValueIndex = -1;
 
 			eventbox.MotionNotifyEvent += HandleMotionNotifyEvent;
@@ -89,6 +54,38 @@ namespace Pinta.Gui.Widgets
 			eventbox.ButtonPressEvent += HandleButtonPressEvent;
 			eventbox.ButtonReleaseEvent += HandleButtonReleaseEvent;
 		}
+
+		private Rectangle GradientRectangle {
+			get {
+				var rect = new Rectangle (0, 0, AllocatedWidth, AllocatedHeight);
+				var x = rect.X + xpad * rect.Width;
+				var y = rect.Y + ypad * rect.Height;
+				var width = (1 - 2 * xpad) * rect.Width;
+				var height = (1 - 2 * ypad) * rect.Height;
+
+				return new Rectangle (x, y, width, height);
+			}
+		}
+
+		public int Count {
+			get => vals.Length;
+			[MemberNotNull (nameof (vals))]
+			set {
+				if (value < 2 || value > 3) 
+					throw new ArgumentOutOfRangeException ("value", value, "Count must be 2 or 3");
+
+				vals = new double[value];
+
+				var step = 256 / (value - 1);
+
+				for (var i = 0; i < value; i++)
+					vals[i] = i * step - ((i != 0) ? 1 : 0);
+			}
+		}
+
+		public Color MaxColor { get; set; }
+
+		public int ValueIndex { get; private set; }
 
 		public int GetValue (int i)
 		{
@@ -105,33 +102,32 @@ namespace Pinta.Gui.Widgets
 
 		private double GetYFromValue (double val)
 		{
-			Rectangle rect = GradientRectangle;
-			Rectangle all = Allocation.ToCairoRectangle ();
+			var rect = GradientRectangle;
+			var all = Allocation.ToCairoRectangle ();
 
 			return all.Y + ypad * all.Height + rect.Height * (255 - val) / 255;
 		}
 
 		private double NormalizeY (int index, double py)
 		{
-			Rectangle rect = GradientRectangle;
+			var rect = GradientRectangle;
 			var yvals = (from val in vals select GetYFromValue (val)).Concat (
 				      new double[] { rect.Y, rect.Y + rect.Height }).OrderByDescending (
 				      v => v).ToArray ();
 			index++;
 
-			if (py >= yvals[index - 1]) {
+			if (py >= yvals[index - 1])
 				py = yvals[index - 1];
-			} else if (py < yvals[index + 1]) {
+			else if (py < yvals[index + 1])
 				py = yvals[index + 1];
-			}
 
 			return py;
 		}
 
 		private int GetValueFromY (double py)
 		{
-			Rectangle rect = GradientRectangle;
-			Rectangle all = Allocation.ToCairoRectangle ();
+			var rect = GradientRectangle;
+			var all = Allocation.ToCairoRectangle ();
 
 			py -= all.Y + ypad * all.Height;
 			return ((int) (255 * (rect.Height - py) / rect.Height));
@@ -141,12 +137,12 @@ namespace Pinta.Gui.Widgets
 		{
 			if (ValueIndex == -1) {
 				var yvals = (from val in vals select GetYFromValue (val)).ToArray ();
-				int count = Count - 1;
+				var count = Count - 1;
 
-				for (int i = 0; i < count; i++) {
-					double y1 = yvals[i];
-					double y2 = yvals[i + 1];
-					double h = (y1 - y2) / 2;
+				for (var i = 0; i < count; i++) {
+					var y1 = yvals[i];
+					var y2 = yvals[i + 1];
+					var h = (y1 - y2) / 2;
 
 					// pointer is below the lowest value triangle
 					if (i == 0 && y1 < y)
@@ -172,30 +168,28 @@ namespace Pinta.Gui.Widgets
 			}
 		}
 
-		private void HandleMotionNotifyEvent (object o, Gtk.MotionNotifyEventArgs args)
+		private void HandleMotionNotifyEvent (object o, MotionNotifyEventArgs args)
 		{
-			int px, py;
-			Gdk.ModifierType mask;
-			ObsoleteExtensions.GetWindowPointer (Window, out px, out py, out mask);
+			ObsoleteExtensions.GetWindowPointer (Window, out var px, out var py, out var mask);
 
-			int index = FindValueIndex (py);
+			var index = FindValueIndex (py);
 			py = (int) NormalizeY (index, py);
 
 			if (mask == Gdk.ModifierType.Button1Mask) {
 				if (index != -1) {
-					double y = GetValueFromY (py);
+					var y = GetValueFromY (py);
 
 					vals[index] = y;
 					OnValueChanged (index);
 				}
 			}
 
-			//to avoid unnessesary costly redrawing
+			// to avoid unnessesary costly redrawing
 			if (index != -1)
 				Window.Invalidate ();
 		}
 
-		private void HandleLeaveNotifyEvent (object o, Gtk.LeaveNotifyEventArgs args)
+		private void HandleLeaveNotifyEvent (object o, LeaveNotifyEventArgs args)
 		{
 			if (args.Event.State != Gdk.ModifierType.Button1Mask)
 				ValueIndex = -1;
@@ -203,30 +197,26 @@ namespace Pinta.Gui.Widgets
 			Window.Invalidate ();
 		}
 
-
-		void HandleButtonPressEvent (object o, Gtk.ButtonPressEventArgs args)
+		private void HandleButtonPressEvent (object o, ButtonPressEventArgs args)
 		{
-			int px, py;
-			Gdk.ModifierType mask;
-			ObsoleteExtensions.GetWindowPointer (Window, out px, out py, out mask);
+			ObsoleteExtensions.GetWindowPointer (Window, out var px, out var py, out var mask);
 
-			int index = FindValueIndex ((int) py);
+			var index = FindValueIndex ((int) py);
 
 			if (index != -1)
 				ValueIndex = index;
 		}
 
-		void HandleButtonReleaseEvent (object o, Gtk.ButtonReleaseEventArgs args)
+		private void HandleButtonReleaseEvent (object o, ButtonReleaseEventArgs args)
 		{
 			ValueIndex = -1;
 		}
 
 		private void DrawGradient (Context g)
 		{
-			Rectangle rect = GradientRectangle;
+			var rect = GradientRectangle;
 
-			Cairo.Gradient pat = new LinearGradient (rect.X, rect.Y, rect.X,
-							  rect.Y + rect.Height);
+			var pat = new LinearGradient (rect.X, rect.Y, rect.X, rect.Y + rect.Height);
 			pat.AddColorStop (0, MaxColor);
 			pat.AddColorStop (1, new Cairo.Color (0, 0, 0));
 
@@ -237,34 +227,34 @@ namespace Pinta.Gui.Widgets
 
 		private void DrawTriangles (Context g)
 		{
-			int px, py;
-			Gdk.ModifierType mask;
-			ObsoleteExtensions.GetWindowPointer (Window, out px, out py, out mask);
+			ObsoleteExtensions.GetWindowPointer (Window, out var px, out var py, out var mask);
 
-			Rectangle rect = GradientRectangle;
-			Rectangle all = Allocation.ToCairoRectangle ();
+			var rect = GradientRectangle;
+			var all = Allocation.ToCairoRectangle ();
 
-			int index = FindValueIndex (py);
+			var index = FindValueIndex (py);
 
-			for (int i = 0; i < Count; i++) {
+			for (var i = 0; i < Count; i++) {
 
-				double val = vals[i];
-				double y = GetYFromValue (val);
-				bool hoover = ((index == i)) && (all.ContainsPoint (px, py) || ValueIndex != -1);
-				Color color = hoover ? new Color (0.1, 0.1, 0.9) : new Color (0.1, 0.1, 0.1);
+				var val = vals[i];
+				var y = GetYFromValue (val);
+				var hoover = ((index == i)) && (all.ContainsPoint (px, py) || ValueIndex != -1);
+				var color = hoover ? new Color (0.1, 0.1, 0.9) : new Color (0.1, 0.1, 0.1);
 
+				// left triangle
+				var points = new PointD[] { new PointD (rect.X, y),
+							    new PointD (rect.X - xpad * rect.Width, y + ypad * rect.Height),
+							    new PointD (rect.X - xpad * rect.Width, y - ypad * rect.Height)};
 
-				//left triangle
-				PointD[] points = new PointD[] { new PointD (rect.X, y),
-												 new PointD (rect.X - xpad * rect.Width, y + ypad * rect.Height),
-												 new PointD (rect.X - xpad * rect.Width, y - ypad * rect.Height) };
 				g.FillPolygonal (points, color);
 
-				double x = rect.X + rect.Width;
-				//right triangle
-				PointD[] points2 = new PointD[] { new PointD (x , y),
-												  new PointD (x + xpad * rect.Width, y + ypad * rect.Height),
-												  new PointD (x + xpad * rect.Width, y - ypad * rect.Height) };
+				var x = rect.X + rect.Width;
+
+				// right triangle
+				var points2 = new PointD[] { new PointD (x , y),
+							     new PointD (x + xpad * rect.Width, y + ypad * rect.Height),
+							     new PointD (x + xpad * rect.Width, y - ypad * rect.Height)};
+
 				g.FillPolygonal (points2, color);
 			}
 		}
@@ -276,18 +266,9 @@ namespace Pinta.Gui.Widgets
 			return true;
 		}
 
-		#region Protected Methods
-		protected void OnValueChanged (int index)
-		{
-			if (ValueChanged != null) {
-				ValueChanged (this, new IndexEventArgs (index));
-			}
-		}
-		#endregion
+		protected void OnValueChanged (int index) => ValueChanged?.Invoke (this, new IndexEventArgs (index));
 
-		#region Public Events
 		public event EventHandler<IndexEventArgs>? ValueChanged;
-		#endregion
 
 		[MemberNotNull (nameof (eventbox))]
 		private void Build ()
@@ -295,9 +276,11 @@ namespace Pinta.Gui.Widgets
 			CanFocus = true;
 			Events = (Gdk.EventMask) 1534;
 
-			eventbox = new EventBox ();
-			eventbox.Events = (Gdk.EventMask) 790;
-			eventbox.VisibleWindow = false;
+			eventbox = new EventBox {
+				Events = (Gdk.EventMask) 790,
+				VisibleWindow = false
+			};
+
 			Add (eventbox);
 		}
 	}

--- a/Pinta.Gui.Widgets/Widgets/ColorPanelWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPanelWidget.cs
@@ -32,10 +32,9 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem (true)]
 	public class ColorPanelWidget : FilledAreaBin
 	{
-		private EventBox eventbox;
+		private readonly EventBox eventbox;
 
 		public Color CairoColor { get; set; }
 
@@ -53,7 +52,7 @@ namespace Pinta.Gui.Widgets
 
 		protected override bool OnDrawn (Context cr)
 		{
-			cr.FillRoundedRectangle (new Rectangle(0,0, AllocatedWidth, AllocatedHeight), 4, CairoColor);
+			cr.FillRoundedRectangle (new Rectangle (0, 0, AllocatedWidth, AllocatedHeight), 4, CairoColor);
 			return true;
 		}
 	}

--- a/Pinta.Gui.Widgets/Widgets/ComboBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ComboBoxWidget.cs
@@ -30,71 +30,59 @@ using Gtk;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem(true)]
 	public class ComboBoxWidget : FilledAreaBin
 	{
-        private Label label;
-        private ComboBoxText combobox;
+		private Label label;
+		private ComboBoxText combobox;
 
-        public string Label {
-			get { return label.Text; }
-			set { label.Text = value; }
-		}
-		
-		public int Active {
-			get { return combobox.Active; }
-			set { combobox.Active = value; }
-		}
-		
-		public string ActiveText {
-			get { return combobox.ActiveText; }
-		}
-		
 		public ComboBoxWidget (string[] entries)
 		{
-			this.Build ();
-			foreach (string s in entries)
+			Build ();
+
+			foreach (var s in entries)
 				combobox.AppendText (s);
-			
+
 			combobox.Changed += delegate {
-				OnChanged ();
+				Changed?.Invoke (this, EventArgs.Empty);
 			};
 		}
-		
-		#region Protected Methods
-		protected void OnChanged ()
-		{
-			if (Changed != null)
-				Changed (this, EventArgs.Empty);
+
+		public string Label {
+			get => label.Text;
+			set => label.Text = value;
 		}
-		#endregion
 
-		#region Public Events
+		public int Active {
+			get => combobox.Active;
+			set => combobox.Active = value;
+		}
+
+		public string ActiveText => combobox.ActiveText;
+
 		public event EventHandler? Changed;
-		#endregion
 
-	[MemberNotNull (nameof (label), nameof (combobox))]
-        private void Build ()
-        {
-            // Section label + line
-            var hbox1 = new HBox (false, 6);
+		[MemberNotNull (nameof (label), nameof (combobox))]
+		private void Build ()
+		{
+			// Section label + line
+			var hbox1 = new HBox (false, 6);
 
-            label = new Label ();
-            hbox1.PackStart (label, false, false, 0);
-            hbox1.PackStart (new HSeparator (), true, true, 0);
+			label = new Label ();
+			hbox1.PackStart (label, false, false, 0);
+			hbox1.PackStart (new HSeparator (), true, true, 0);
 
 			// Combobox
-			combobox = new ComboBoxText();
+			combobox = new ComboBoxText ();
 
-            // Main layout
-            var vbox = new VBox (false, 6);
+			// Main layout
+			var vbox = new VBox (false, 6) {
+				hbox1,
+				combobox
+			};
 
-            vbox.Add (hbox1);
-            vbox.Add (combobox);
+			Add (vbox);
 
-            Add (vbox);
-
-            vbox.ShowAll ();
-        }
-    }
+			vbox.ShowAll ();
+		}
+	}
 }

--- a/Pinta.Gui.Widgets/Widgets/FilledAreaBin.cs
+++ b/Pinta.Gui.Widgets/Widgets/FilledAreaBin.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // FilledAreaBin.cs
 //  
 // Author:
@@ -30,44 +30,44 @@ using Gtk;
 
 namespace Pinta.Gui.Widgets
 {
-    public class FilledAreaBin : Bin
-    {
-        private Widget? child;
+	public class FilledAreaBin : Bin
+	{
+		private Widget? child;
 
-        protected override void OnAdded (Widget widget)
-        {
-            base.OnAdded (widget);
-            child = widget;
-        }
+		protected override void OnAdded (Widget widget)
+		{
+			base.OnAdded (widget);
+			child = widget;
+		}
 
-        protected override void OnRemoved (Widget widget)
-        {
-            base.OnRemoved (widget);
-            child = null;
-        }
+		protected override void OnRemoved (Widget widget)
+		{
+			base.OnRemoved (widget);
+			child = null;
+		}
 
-        protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
-        {
-            if (child != null)
-                child.GetPreferredHeight(out minimum_height, out natural_height);
-            else
-                base.OnGetPreferredHeight(out minimum_height, out natural_height);
-        }
+		protected override void OnGetPreferredHeight (out int minimum_height, out int natural_height)
+		{
+			if (child != null)
+				child.GetPreferredHeight (out minimum_height, out natural_height);
+			else
+				base.OnGetPreferredHeight (out minimum_height, out natural_height);
+		}
 
-        protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
-        {
-            if (child != null)
-                child.GetPreferredWidth(out minimum_width, out natural_width);
-            else
-                base.OnGetPreferredWidth(out minimum_width, out natural_width);
-        }
+		protected override void OnGetPreferredWidth (out int minimum_width, out int natural_width)
+		{
+			if (child != null)
+				child.GetPreferredWidth (out minimum_width, out natural_width);
+			else
+				base.OnGetPreferredWidth (out minimum_width, out natural_width);
+		}
 
-        protected override void OnSizeAllocated (Rectangle allocation)
-        {
-            base.OnSizeAllocated (allocation);
+		protected override void OnSizeAllocated (Rectangle allocation)
+		{
+			base.OnSizeAllocated (allocation);
 
-            if (child != null)
-                child.SetAllocation(allocation);
-        }
-    }
+			if (child != null)
+				child.SetAllocation (allocation);
+		}
+	}
 }

--- a/Pinta.Gui.Widgets/Widgets/HScaleSpinButtonWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HScaleSpinButtonWidget.cs
@@ -25,35 +25,44 @@
 // THE SOFTWARE.
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem(true)]
 	public class HScaleSpinButtonWidget : FilledAreaBin
 	{
-        private HScale hscale;
-        private SpinButton spin;
-        private Button button;
-        private Label label;
+		private HScale hscale;
+		private SpinButton spin;
+		private Button button;
+		private Label label;
 
-        [Category ("Custom Properties")]
-		public string Label {
-			get { return label.Text; }
-			set { label.Text = value; }
+		private int max_value;
+		private int min_value;
+		private int digits_value;
+		private double inc_value;
+
+		public HScaleSpinButtonWidget ()
+		{
+			Build ();
+
+			hscale.ValueChanged += HandleHscaleValueChanged;
+			spin.ValueChanged += HandleSpinValueChanged;
+			button.Clicked += HandleButtonClicked;
+
+			spin.ActivatesDefault = true;
 		}
 
-		[Category("Custom Properties")]
+		public string Label {
+			get => label.Text;
+			set => label.Text = value;
+		}
+
 		public double DefaultValue { get; set; }
 
-        private int max_value;
-		[Category("Custom Properties")]
-        public int MaximumValue
-        {
-			get { return max_value; }
+		public int MaximumValue {
+			get => max_value;
 			set {
 				max_value = value;
 				hscale.Adjustment.Upper = value;
@@ -61,55 +70,39 @@ namespace Pinta.Gui.Widgets
 			}
 		}
 
-        private int min_value;
-		[Category("Custom Properties")]
 		public int MinimumValue {
-			get { return min_value; }
+			get => min_value;
 			set {
 				min_value = value;
 				hscale.Adjustment.Lower = value;
 				spin.Adjustment.Lower = value;
 			}
 		}
-        private int digits_value;
-        [Category("Custom Properties")]
-        public int DigitsValue
-        {
-            get { return digits_value; }
-            set
-            {
-                if (value > 0)
-                {
-                    
-                    digits_value = value;
-                    hscale.Digits = value;
-                    spin.Digits = Convert.ToUInt32(value);
-                }
-            }
-        }
 
-        private double inc_value;
-        [Category("Custom Properties")]
-        public double IncrementValue
-        {
-            get { return inc_value; }
-            set
-            {
-                inc_value = value;
-                hscale.Adjustment.StepIncrement = value;
-                spin.Adjustment.StepIncrement = value;
-            }
-        }
-        
-        [Category("Custom Properties")]
-        public int ValueAsInt
-        {
-            get { return spin.ValueAsInt; }
-        }
+		public int DigitsValue {
+			get => digits_value;
+			set {
+				if (value > 0) {
+					digits_value = value;
+					hscale.Digits = value;
+					spin.Digits = Convert.ToUInt32 (value);
+				}
+			}
+		}
 
-		[Category("Custom Properties")]
+		public double IncrementValue {
+			get => inc_value;
+			set {
+				inc_value = value;
+				hscale.Adjustment.StepIncrement = value;
+				spin.Adjustment.StepIncrement = value;
+			}
+		}
+
+		public int ValueAsInt => spin.ValueAsInt;
+
 		public double Value {
-			get { return spin.Value; }
+			get => spin.Value;
 			set {
 				if (spin.Value != value) {
 					spin.Value = value;
@@ -118,21 +111,10 @@ namespace Pinta.Gui.Widgets
 			}
 		}
 
-		public HScaleSpinButtonWidget ()
-		{
-			this.Build ();
-			
-			hscale.ValueChanged += HandleHscaleValueChanged;
-			spin.ValueChanged += HandleSpinValueChanged;
-			button.Clicked += HandleButtonClicked;
-
-			spin.ActivatesDefault = true;
-		}
-
 		protected override void OnShown ()
 		{
 			base.OnShown ();
-			
+
 			Value = DefaultValue;
 		}
 
@@ -157,69 +139,67 @@ namespace Pinta.Gui.Widgets
 			Value = DefaultValue;
 		}
 
-		#region Protected Methods
-		protected void OnValueChanged ()
-		{
-			if (ValueChanged != null)
-				ValueChanged (this, EventArgs.Empty);
-		}
-		#endregion
+		protected void OnValueChanged () => ValueChanged?.Invoke (this, EventArgs.Empty);
 
-		#region Public Events
 		public event EventHandler? ValueChanged;
-        #endregion
 
-        [MemberNotNull (nameof (label), nameof (hscale), nameof (spin), nameof (button))]
-	private void Build ()
-        {
-            // Section label + line
-            var hbox1 = new HBox (false, 6);
+		[MemberNotNull (nameof (label), nameof (hscale), nameof (spin), nameof (button))]
+		private void Build ()
+		{
+			// Section label + line
+			var hbox1 = new HBox (false, 6);
 
-            label = new Label ();
-            hbox1.PackStart (label, false, false, 0);
-            hbox1.PackStart (new HSeparator (), true, true, 0);
+			label = new Label ();
+			hbox1.PackStart (label, false, false, 0);
+			hbox1.PackStart (new HSeparator (), true, true, 0);
 
-            // Slider + spinner + reset button
-            var hbox2 = new HBox (false, 6);
+			// Slider + spinner + reset button
+			var hbox2 = new HBox (false, 6);
 
-            hscale = new HScale (2, 64, 1);
-            hscale.CanFocus = true;
-            hscale.DrawValue = false;
-            hscale.Digits = 0;
-            hscale.ValuePos = PositionType.Top;
-            hbox2.PackStart (hscale, true, true, 0);
+			hscale = new HScale (2, 64, 1) {
+				CanFocus = true,
+				DrawValue = false,
+				Digits = 0,
+				ValuePos = PositionType.Top
+			};
 
-            spin = new SpinButton (0, 100, 1);
-            spin.CanFocus = true;
-            spin.Adjustment.PageIncrement = 10;
-            spin.ClimbRate = 1;
-            spin.Numeric = true;
-            hbox2.PackStart (spin, false, false, 0);
+			hbox2.PackStart (hscale, true, true, 0);
 
-            // Reset button
-            button = new Button ();
-            button.WidthRequest = 28;
-            button.HeightRequest = 24;
-            button.CanFocus = true;
-            button.UseUnderline = true;
+			spin = new SpinButton (0, 100, 1) {
+				CanFocus = true,
+				ClimbRate = 1,
+				Numeric = true
+			};
+			spin.Adjustment.PageIncrement = 10;
 
-            var button_image = new Image (Gtk.IconTheme.Default.LoadIcon(Resources.StandardIcons.GoPrevious, 16));
-            button.Add (button_image);
+			hbox2.PackStart (spin, false, false, 0);
 
-            var alignment2 = new Alignment (0.5F, 0F, 1F, 0F);
-            alignment2.Add (button);
+			// Reset button
+			button = new Button {
+				WidthRequest = 28,
+				HeightRequest = 24,
+				CanFocus = true,
+				UseUnderline = true
+			};
 
-            hbox2.PackStart (alignment2, false, false, 0);
+			var button_image = new Image (IconTheme.Default.LoadIcon (Resources.StandardIcons.GoPrevious, 16));
+			button.Add (button_image);
 
-            // Main layout
-            var vbox = new VBox (false, 6);
+			var alignment2 = new Alignment (0.5F, 0F, 1F, 0F) {
+				button
+			};
 
-            vbox.Add (hbox1);
-            vbox.Add (hbox2);
+			hbox2.PackStart (alignment2, false, false, 0);
 
-            Add (vbox);
+			// Main layout
+			var vbox = new VBox (false, 6) {
+				hbox1,
+				hbox2
+			};
 
-            vbox.ShowAll ();
-        }
-    }
+			Add (vbox);
+
+			vbox.ShowAll ();
+		}
+	}
 }

--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -35,32 +35,26 @@
 // THE SOFTWARE.
 
 using System;
-using System.ComponentModel;
 using Cairo;
-
 using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem (true)]
 	public class HistogramWidget : FilledAreaBin
 	{
 		private bool[] selected;
-
-		[Category ("Custom Properties")]
-		public bool FlipHorizontal { get; set; }
-
-		[Category ("Custom Properties")]
-		public bool FlipVertical { get; set; }
-
-		public HistogramRgb Histogram { get; private set; }
-
 
 		public HistogramWidget ()
 		{
 			Histogram = new HistogramRgb ();
 			selected = new bool[] { true, true, true };
 		}
+
+		public bool FlipHorizontal { get; set; }
+
+		public bool FlipVertical { get; set; }
+
+		public HistogramRgb Histogram { get; private set; }
 
 		public void ResetHistogram ()
 		{
@@ -74,48 +68,43 @@ namespace Pinta.Gui.Widgets
 
 		private void CheckPoint (Rectangle rect, PointD point)
 		{
-			if (point.X < rect.X) {
+			if (point.X < rect.X)
 				point.X = rect.X;
-			} else if (point.X > rect.X + rect.Width) {
+			else if (point.X > rect.X + rect.Width)
 				point.X = rect.X + rect.Width;
-			}
 
-			if (point.Y < rect.Y) {
+			if (point.Y < rect.Y)
 				point.Y = rect.Y;
-			} else if (point.Y > rect.Y + rect.Height) {
+			else if (point.Y > rect.Y + rect.Height)
 				point.Y = rect.Y + rect.Height;
-			}
 		}
 
 		private void DrawChannel (Context g, ColorBgra color, int channel, long max, float mean)
 		{
-			Rectangle rect = new Rectangle (0, 0, AllocatedWidth, AllocatedHeight);
-			Histogram histogram = Histogram;
+			var rect = new Rectangle (0, 0, AllocatedWidth, AllocatedHeight);
 
-			int l = (int) rect.X;
-			int t = (int) rect.Y;
-			int r = (int) (rect.X + rect.Width);
-			int b = (int) (rect.Y + rect.Height);
+			var l = (int) rect.X;
+			var t = (int) rect.Y;
+			var r = (int) (rect.X + rect.Width);
+			var b = (int) (rect.Y + rect.Height);
 
-			int entries = histogram.Entries;
-			long[] hist = histogram.HistogramValues[channel];
+			var entries = Histogram.Entries;
+			var hist = Histogram.HistogramValues[channel];
 
 			++max;
 
-			if (FlipHorizontal) {
+			if (FlipHorizontal)
 				Utility.Swap (ref l, ref r);
-			}
 
-			if (!FlipVertical) {
+			if (!FlipVertical)
 				Utility.Swap (ref t, ref b);
-			}
 
-			PointD[] points = new PointD[entries + 2];
+			var points = new PointD[entries + 2];
 
 			points[entries] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (t, b, 20));
 			points[entries + 1] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (b, t, 20));
 
-			for (int i = 0; i < entries; i += entries - 1) {
+			for (var i = 0; i < entries; i += entries - 1) {
 				points[i] = new PointD (
 				    Utility.Lerp (l, r, (float) hist[i] / (float) max),
 				    Utility.Lerp (t, b, (float) i / (float) entries));
@@ -123,9 +112,9 @@ namespace Pinta.Gui.Widgets
 				CheckPoint (rect, points[i]);
 			}
 
-			long sum3 = hist[0] + hist[1];
+			var sum3 = hist[0] + hist[1];
 
-			for (int i = 1; i < entries - 1; ++i) {
+			for (var i = 1; i < entries - 1; ++i) {
 				sum3 += hist[i + 1];
 
 				points[i] = new PointD (
@@ -136,9 +125,10 @@ namespace Pinta.Gui.Widgets
 				sum3 -= hist[i - 1];
 			}
 
-			byte intensity = selected[channel] ? (byte) 96 : (byte) 32;
-			ColorBgra pen_color = ColorBgra.Blend (ColorBgra.Black, color, intensity);
-			ColorBgra brush_color = color;
+			var intensity = selected[channel] ? (byte) 96 : (byte) 32;
+			var pen_color = ColorBgra.Blend (ColorBgra.Black, color, intensity);
+			var brush_color = color;
+
 			brush_color.A = intensity;
 
 			g.LineWidth = 1;
@@ -151,15 +141,13 @@ namespace Pinta.Gui.Widgets
 
 		protected override bool OnDrawn (Context g)
 		{
-			Histogram histogram = Histogram;
-			long max = histogram.GetMax ();
-			float[] mean = histogram.GetMean ();
+			var max = Histogram.GetMax ();
+			var mean = Histogram.GetMean ();
 
-			int channels = histogram.Channels;
+			var channels = Histogram.Channels;
 
-			for (int i = 0; i < channels; ++i) {
-				DrawChannel (g, histogram.GetVisualColor (i), i, max, mean[i]);
-			}
+			for (var i = 0; i < channels; ++i)
+				DrawChannel (g, Histogram.GetVisualColor (i), i, max, mean[i]);
 
 			return true;
 		}

--- a/Pinta.Gui.Widgets/Widgets/PointPickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/PointPickerWidget.cs
@@ -25,90 +25,87 @@
 // THE SOFTWARE.
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem(true)]
 	public class PointPickerWidget : FilledAreaBin
 	{
-        private Label label;
-        private PointPickerGraphic pointpickergraphic1;
-        private Button button1;
-        private Button button2;
-        private SpinButton spinX;
-        private SpinButton spinY;
+		private Label label;
+		private PointPickerGraphic pointpickergraphic1;
+		private Button button1;
+		private Button button2;
+		private SpinButton spin_x;
+		private SpinButton spin_y;
 
-        bool active = true; 
-			
-		[Category("Custom Properties")]
-		public string Label {
-			get { return label.Text; }
-			set { label.Text = value; }
-		}
-
-		[Category("Custom Properties")]
-		public Gdk.Point DefaultPoint { get; set; }
-
-		[Category("Custom Properties")]
-		public Gdk.Point Point {
-			get { return new Gdk.Point (spinX.ValueAsInt, spinY.ValueAsInt); }
-			set {
-				if (value.X != spinX.ValueAsInt || value.Y != spinY.ValueAsInt) {
-					spinX.Value = value.X;
-					spinY.Value = value.Y;
-					OnPointPicked ();
-				}
-			}
-		}
-
-		[Category("Custom Properties")]
-		public Cairo.PointD DefaultOffset { 
-			get { return new Cairo.PointD ( (DefaultPoint.X * 2.0 /PintaCore.Workspace.ImageSize.Width) - 1.0,
-											(DefaultPoint.Y * 2.0 / PintaCore.Workspace.ImageSize.Height) - 1.0);}
-			set {DefaultPoint = new Gdk.Point ( (int) ((value.X + 1.0) * PintaCore.Workspace.ImageSize.Width / 2.0 ),
-				                                (int) ((value.Y + 1.0) * PintaCore.Workspace.ImageSize.Height / 2.0 ) );} 
-		}
-
-		public Cairo.PointD Offset {
-			get { return new Cairo.PointD ((spinX.Value * 2.0 / PintaCore.Workspace.ImageSize.Width) - 1.0, (spinY.Value * 2.0 / PintaCore.Workspace.ImageSize.Height) - 1.0); }
-		}
+		bool active = true;
 
 		public PointPickerWidget ()
 		{
 			Build ();
 
-			spinX.Adjustment.Upper = PintaCore.Workspace.ImageSize.Width;
-			spinY.Adjustment.Upper = PintaCore.Workspace.ImageSize.Height;
-			spinX.Adjustment.Lower = 0;
-			spinY.Adjustment.Lower = 0;
+			spin_x.Adjustment.Upper = PintaCore.Workspace.ImageSize.Width;
+			spin_y.Adjustment.Upper = PintaCore.Workspace.ImageSize.Height;
+			spin_x.Adjustment.Lower = 0;
+			spin_y.Adjustment.Lower = 0;
 
-			spinX.ActivatesDefault = true;
-			spinY.ActivatesDefault = true;
+			spin_x.ActivatesDefault = true;
+			spin_y.ActivatesDefault = true;
 		}
 
-		void HandlePointpickergraphic1PositionChanged (object? sender, EventArgs e)
+		public string Label {
+			get => label.Text;
+			set => label.Text = value;
+		}
+
+		public Gdk.Point DefaultPoint { get; set; }
+
+		public Gdk.Point Point {
+			get => new Gdk.Point (spin_x.ValueAsInt, spin_y.ValueAsInt);
+			set {
+				if (value.X != spin_x.ValueAsInt || value.Y != spin_y.ValueAsInt) {
+					spin_x.Value = value.X;
+					spin_y.Value = value.Y;
+					OnPointPicked ();
+				}
+			}
+		}
+
+		public Cairo.PointD DefaultOffset {
+			get {
+				return new Cairo.PointD ((DefaultPoint.X * 2.0 / PintaCore.Workspace.ImageSize.Width) - 1.0,
+							 (DefaultPoint.Y * 2.0 / PintaCore.Workspace.ImageSize.Height) - 1.0);
+			}
+			set {
+				DefaultPoint = new Gdk.Point ((int) ((value.X + 1.0) * PintaCore.Workspace.ImageSize.Width / 2.0),
+							      (int) ((value.Y + 1.0) * PintaCore.Workspace.ImageSize.Height / 2.0));
+			}
+		}
+
+		public Cairo.PointD Offset
+			=> new Cairo.PointD ((spin_x.Value * 2.0 / PintaCore.Workspace.ImageSize.Width) - 1.0, (spin_y.Value * 2.0 / PintaCore.Workspace.ImageSize.Height) - 1.0);
+
+		private void HandlePointpickergraphic1PositionChanged (object? sender, EventArgs e)
 		{
 			if (Point != pointpickergraphic1.Position) {
 				active = false;
-				spinX.Value = pointpickergraphic1.Position.X;
-				spinY.Value = pointpickergraphic1.Position.Y;
+				spin_x.Value = pointpickergraphic1.Position.X;
+				spin_y.Value = pointpickergraphic1.Position.Y;
 				active = true;
 				OnPointPicked ();
 			}
 		}
-		
+
 		private void HandleSpinXValueChanged (object? sender, EventArgs e)
 		{
 			if (active) {
-				pointpickergraphic1.Position = Point; 
+				pointpickergraphic1.Position = Point;
 				OnPointPicked ();
 			}
 		}
-		
+
 		private void HandleSpinYValueChanged (object? sender, EventArgs e)
 		{
 			if (active) {
@@ -116,132 +113,132 @@ namespace Pinta.Gui.Widgets
 				OnPointPicked ();
 			}
 		}
-		
+
 		protected override void OnShown ()
 		{
 			base.OnShown ();
 			Point = DefaultPoint;
-			
-			spinX.ValueChanged += HandleSpinXValueChanged;
-			spinY.ValueChanged += HandleSpinYValueChanged;
+
+			spin_x.ValueChanged += HandleSpinXValueChanged;
+			spin_y.ValueChanged += HandleSpinYValueChanged;
 			pointpickergraphic1.PositionChanged += HandlePointpickergraphic1PositionChanged;
 			button1.Pressed += HandleButton1Pressed;
 			button2.Pressed += HandleButton2Pressed;
-			
+
 			pointpickergraphic1.Init (DefaultPoint);
 		}
 
-		void HandleButton1Pressed (object? sender, EventArgs e)
+		private void HandleButton1Pressed (object? sender, EventArgs e)
 		{
-			spinX.Value = DefaultPoint.X;
+			spin_x.Value = DefaultPoint.X;
 		}
 
-		void HandleButton2Pressed (object? sender, EventArgs e)
+		private void HandleButton2Pressed (object? sender, EventArgs e)
 		{
-			spinY.Value = DefaultPoint.Y;
+			spin_y.Value = DefaultPoint.Y;
 		}
-		
-		#region Protected Methods
-		protected void OnPointPicked ()
-		{
-			if (PointPicked != null)
-				PointPicked (this, EventArgs.Empty);
-		}
-		#endregion
 
-		#region Public Events
+		protected void OnPointPicked () => PointPicked?.Invoke (this, EventArgs.Empty);
+
 		public event EventHandler? PointPicked;
-        #endregion
 
-        [MemberNotNull (nameof (label), nameof (spinX), nameof (spinY), nameof (button1), nameof (button2), nameof (pointpickergraphic1))]
-        private void Build ()
-        {
-            // Section label + line
-            var hbox1 = new HBox (false, 6);
+		[MemberNotNull (nameof (label), nameof (spin_x), nameof (spin_y), nameof (button1), nameof (button2), nameof (pointpickergraphic1))]
+		private void Build ()
+		{
+			// Section label + line
+			var hbox1 = new HBox (false, 6);
 
-            label = new Label ();
-            hbox1.PackStart (label, false, false, 0);
-            hbox1.PackStart (new HSeparator (), true, true, 0);
+			label = new Label ();
+			hbox1.PackStart (label, false, false, 0);
+			hbox1.PackStart (new HSeparator (), true, true, 0);
 
-            // PointPickerGraphic
-            var hbox2 = new HBox (false, 6);
+			// PointPickerGraphic
+			var hbox2 = new HBox (false, 6);
 
-            pointpickergraphic1 = new PointPickerGraphic ();
-            hbox2.PackStart (pointpickergraphic1, true, false, 0);
+			pointpickergraphic1 = new PointPickerGraphic ();
+			hbox2.PackStart (pointpickergraphic1, true, false, 0);
 
-            // X spinner
-            var label2 = new Label ();
-            label2.LabelProp = "X:";
+			// X spinner
+			var label2 = new Label {
+				LabelProp = "X:"
+			};
 
-            spinX = new SpinButton (0, 100, 1);
-            spinX.CanFocus = true;
-            spinX.Adjustment.PageIncrement = 10;
-            spinX.ClimbRate = 1;
-            spinX.Numeric = true;
+			spin_x = new SpinButton (0, 100, 1) {
+				CanFocus = true,
+				ClimbRate = 1,
+				Numeric = true
+			};
+			spin_x.Adjustment.PageIncrement = 10;
 
-            button1 = new Button ();
-            button1.WidthRequest = 28;
-            button1.HeightRequest = 24;
-            button1.CanFocus = true;
-            button1.UseUnderline = true;
+			button1 = new Button {
+				WidthRequest = 28,
+				HeightRequest = 24,
+				CanFocus = true,
+				UseUnderline = true
+			};
 
-			var button_image = new Image(Gtk.IconTheme.Default.LoadIcon(Resources.StandardIcons.GoPrevious, 16));
-            button1.Add (button_image);
+			var button_image = new Image (IconTheme.Default.LoadIcon (Resources.StandardIcons.GoPrevious, 16));
+			button1.Add (button_image);
 
-            var alignment1 = new Alignment (0.5F, 0.5F, 1F, 0F);
-            alignment1.Add (button1);
+			var alignment1 = new Alignment (0.5F, 0.5F, 1F, 0F) {
+				button1
+			};
 
-            var x_hbox = new HBox (false, 6);
+			var x_hbox = new HBox (false, 6);
 
-            x_hbox.PackStart (label2, false, false, 0);
-            x_hbox.PackStart (spinX, false, false, 0);
-            x_hbox.PackStart (alignment1, false, false, 0);
+			x_hbox.PackStart (label2, false, false, 0);
+			x_hbox.PackStart (spin_x, false, false, 0);
+			x_hbox.PackStart (alignment1, false, false, 0);
 
-            // Y spinner
-            var label3 = new Label ();
-            label3.LabelProp = "Y:";
+			// Y spinner
+			var label3 = new Label {
+				LabelProp = "Y:"
+			};
 
-            spinY = new SpinButton (0, 100, 1);
-            spinY.CanFocus = true;
-            spinY.Adjustment.PageIncrement = 10;
-            spinY.ClimbRate = 1;
-            spinY.Numeric = true;
+			spin_y = new SpinButton (0, 100, 1) {
+				CanFocus = true,
+				ClimbRate = 1,
+				Numeric = true
+			};
+			spin_y.Adjustment.PageIncrement = 10;
 
-            button2 = new Button ();
-            button2.WidthRequest = 28;
-            button2.HeightRequest = 24;
-            button2.CanFocus = true;
-            button2.UseUnderline = true;
+			button2 = new Button {
+				WidthRequest = 28,
+				HeightRequest = 24,
+				CanFocus = true,
+				UseUnderline = true
+			};
 
-            var button_image2 = new Image (Gtk.IconTheme.Default.LoadIcon(Resources.StandardIcons.GoPrevious, 16));
-            button2.Add (button_image2);
+			var button_image2 = new Image (Gtk.IconTheme.Default.LoadIcon (Resources.StandardIcons.GoPrevious, 16));
+			button2.Add (button_image2);
 
-            var alignment2 = new Alignment (0.5F, 0.5F, 1F, 0F);
-            alignment2.Add (button2);
+			var alignment2 = new Alignment (0.5F, 0.5F, 1F, 0F) {
+				button2
+			};
 
-            var y_hbox = new HBox (false, 6);
+			var y_hbox = new HBox (false, 6);
 
-            y_hbox.PackStart (label3, false, false, 0);
-            y_hbox.PackStart (spinY, false, false, 0);
-            y_hbox.PackStart (alignment2, false, false, 0);
+			y_hbox.PackStart (label3, false, false, 0);
+			y_hbox.PackStart (spin_y, false, false, 0);
+			y_hbox.PackStart (alignment2, false, false, 0);
 
-            // Vbox for spinners
-            var spin_vbox = new VBox ();
+			// Vbox for spinners
+			var spin_vbox = new VBox {
+				x_hbox,
+				y_hbox
+			};
 
-            spin_vbox.Add (x_hbox);
-            spin_vbox.Add (y_hbox);
+			hbox2.PackStart (spin_vbox, false, false, 0);
 
-            hbox2.PackStart (spin_vbox, false, false, 0);
+			// Main layout
+			var vbox = new VBox (false, 6) {
+				hbox1,
+				hbox2
+			};
 
-            // Main layout
-            var vbox = new VBox (false, 6);
+			Add (vbox);
 
-            vbox.Add (hbox1);
-            vbox.Add (hbox2);
-
-            Add (vbox);
-
-            vbox.ShowAll ();
-        }
-    }
+			vbox.ShowAll ();
+		}
+	}
 }

--- a/Pinta.Gui.Widgets/Widgets/ReseedButtonWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ReseedButtonWidget.cs
@@ -30,64 +30,54 @@ using Gtk;
 
 namespace Pinta.Gui.Widgets
 {
-	[System.ComponentModel.ToolboxItem(true)]
 	public class ReseedButtonWidget : FilledAreaBin
 	{
-        private Button button1;
+		private Button button;
+
+		public event EventHandler? Clicked;
 
 		public ReseedButtonWidget ()
 		{
 			Build ();
-			
-			button1.Clicked += delegate (object? sender, EventArgs e) {
-				OnClicked ();
-			};
+
+			button.Clicked += (_, _) => Clicked?.Invoke (this, EventArgs.Empty);
 		}
 
-		#region Protected Methods
-		protected void OnClicked ()
+		[MemberNotNull (nameof (button))]
+		private void Build ()
 		{
-			if (Clicked != null)
-				Clicked (this, EventArgs.Empty);
+			// Section label + line
+			var hbox1 = new HBox (false, 6);
+
+			var label = new Label {
+				LabelProp = Pinta.Core.Translations.GetString ("Random Noise")
+			};
+
+			hbox1.PackStart (label, false, false, 0);
+			hbox1.PackStart (new HSeparator (), true, true, 0);
+
+			// Reseed button
+			button = new Button {
+				WidthRequest = 88,
+				CanFocus = true,
+				UseUnderline = true,
+				Label = Pinta.Core.Translations.GetString ("Reseed")
+			};
+
+			var hbox2 = new HBox (false, 6);
+
+			hbox2.PackStart (button, false, false, 0);
+
+			// Main layout
+			var vbox = new VBox (false, 6) {
+				hbox1,
+				hbox2
+			};
+
+			Add (vbox);
+
+			vbox.ShowAll ();
 		}
-		#endregion
-
-		#region Public Events
-		public event EventHandler? Clicked;
-        #endregion
-
-        [MemberNotNull (nameof (button1))]
-        private void Build ()
-        {
-            // Section label + line
-            var hbox1 = new HBox (false, 6);
-
-            var label = new Label ();
-            label.LabelProp = Pinta.Core.Translations.GetString ("Random Noise");
-
-            hbox1.PackStart (label, false, false, 0);
-            hbox1.PackStart (new HSeparator (), true, true, 0);
-
-            // Reseed button
-            button1 = new Button ();
-            button1.WidthRequest = 88;
-            button1.CanFocus = true;
-            button1.UseUnderline = true;
-            button1.Label = Pinta.Core.Translations.GetString ("Reseed");
-
-            var hbox2 = new HBox (false, 6);
-            hbox2.PackStart (button1, false, false, 0);
-
-            // Main layout
-            var vbox = new VBox (false, 6);
-
-            vbox.Add (hbox1);
-            vbox.Add (hbox2);
-
-            Add (vbox);
-
-            vbox.ShowAll ();
-        }
-    }
+	}
 }
 

--- a/Pinta.Gui.Widgets/Widgets/Ruler.cs
+++ b/Pinta.Gui.Widgets/Widgets/Ruler.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Ruler.cs
 //
 // Author:
@@ -23,281 +23,268 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using Cairo;
 using Gtk;
 using Pinta.Core;
 using System;
-using System.Linq;
 
 namespace Pinta.Gui.Widgets
 {
-    public enum MetricType
-    {
-        Pixels,
-        Inches,
-        Centimeters
-    }
+	public enum MetricType
+	{
+		Pixels,
+		Inches,
+		Centimeters
+	}
 
-    /// <summary>
-    /// Replacement for Gtk.Ruler, which was removed in GTK3.
-    /// Based on the original GTK2 widget and Inkscape's ruler widget.
-    /// </summary>
-    public class Ruler : DrawingArea
-    {
-        private double _position = 0;
-        private MetricType _metric = MetricType.Pixels;
+	/// <summary>
+	/// Replacement for Gtk.Ruler, which was removed in GTK3.
+	/// Based on the original GTK2 widget and Inkscape's ruler widget.
+	/// </summary>
+	public class Ruler : DrawingArea
+	{
+		private double _position = 0;
+		private MetricType _metric = MetricType.Pixels;
 
-        /// <summary>
-        /// Whether the ruler is horizontal or vertical.
-        /// </summary>
-        public Orientation Orientation { get; private set; }
+		/// <summary>
+		/// Whether the ruler is horizontal or vertical.
+		/// </summary>
+		public Orientation Orientation { get; private set; }
 
-        /// <summary>
-        /// Metric type used for the ruler.
-        /// </summary>
-        public MetricType Metric
-        {
-            get => _metric;
-            set
-            {
-                _metric = value;
-                QueueDraw();
-            }
-        }
+		/// <summary>
+		/// Metric type used for the ruler.
+		/// </summary>
+		public MetricType Metric {
+			get => _metric;
+			set {
+				_metric = value;
+				QueueDraw ();
+			}
+		}
 
-        /// <summary>
-        /// The position of the mark along the ruler.
-        /// </summary>
-        public double Position
-        {
-            get => _position;
-            set
-            {
-                _position = value;
-                QueueDraw();
-            }
-        }
+		/// <summary>
+		/// The position of the mark along the ruler.
+		/// </summary>
+		public double Position {
+			get => _position;
+			set {
+				_position = value;
+				QueueDraw ();
+			}
+		}
 
-        /// <summary>
-        /// Lower limit of the ruler in pixels.
-        /// </summary>
-        public double Lower { get; private set; } = 0;
+		/// <summary>
+		/// Lower limit of the ruler in pixels.
+		/// </summary>
+		public double Lower { get; private set; } = 0;
 
-        /// <summary>
-        /// Upper limit of the ruler in pixels.
-        /// </summary>
-        public double Upper { get; private set; } = 1;
+		/// <summary>
+		/// Upper limit of the ruler in pixels.
+		/// </summary>
+		public double Upper { get; private set; } = 1;
 
-        public Ruler(Orientation orientation)
-        {
-            Orientation = orientation;
-        }
+		public Ruler (Orientation orientation)
+		{
+			Orientation = orientation;
+		}
 
-        /// <summary>
-        /// Update the ruler's range.
-        /// </summary>
-        public void SetRange(double lower, double upper)
-        {
-            if (lower > upper)
-                throw new ArgumentOutOfRangeException(nameof(lower), "Invalid range");
+		/// <summary>
+		/// Update the ruler's range.
+		/// </summary>
+		public void SetRange (double lower, double upper)
+		{
+			if (lower > upper)
+				throw new ArgumentOutOfRangeException (nameof (lower), "Invalid range");
 
-            Lower = lower;
-            Upper = upper;
+			Lower = lower;
+			Upper = upper;
 
-            QueueDraw();
-        }
+			QueueDraw ();
+		}
 
-        private Requisition GetSizeRequest()
-        {
-            var border = StyleContext.GetBorder(StateFlags);
-            var font = ObsoleteExtensions.GetStyleContextFont (StyleContext, StateFlags);
-            int font_size = GetFontSize(font);
+		private Requisition GetSizeRequest ()
+		{
+			var border = StyleContext.GetBorder (StateFlags);
+			var font = ObsoleteExtensions.GetStyleContextFont (StyleContext, StateFlags);
+			int font_size = GetFontSize (font);
 
-            int size = 2 + font_size * 2;
+			int size = 2 + font_size * 2;
 
-            int width = border.Left + border.Right;
-            int height = border.Top + border.Bottom;
+			int width = border.Left + border.Right;
+			int height = border.Top + border.Bottom;
 
-            switch (Orientation)
-            {
-                case Orientation.Horizontal:
-                    width += 1;
-                    height += size;
-                    break;
-                case Orientation.Vertical:
-                    width += size;
-                    height += 1;
-                    break;
-            }
+			switch (Orientation) {
+				case Orientation.Horizontal:
+					width += 1;
+					height += size;
+					break;
+				case Orientation.Vertical:
+					width += size;
+					height += 1;
+					break;
+			}
 
-            return new Requisition() { Width = width, Height = height };
-        }
+			return new Requisition () { Width = width, Height = height };
+		}
 
-        protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
-        {
-            minimum_height = natural_height = GetSizeRequest().Height;
-        }
+		protected override void OnGetPreferredHeight (out int minimum_height, out int natural_height)
+		{
+			minimum_height = natural_height = GetSizeRequest ().Height;
+		}
 
-        protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
-        {
-            minimum_width = natural_width = GetSizeRequest().Width;
-        }
+		protected override void OnGetPreferredWidth (out int minimum_width, out int natural_width)
+		{
+			minimum_width = natural_width = GetSizeRequest ().Width;
+		}
 
-        protected override bool OnDrawn(Context cr)
-        {
-            var awidth = AllocatedWidth;
-            var aheight = AllocatedHeight;
-            StyleContext.RenderBackground(cr, 0, 0, awidth, aheight);
+		protected override bool OnDrawn (Context cr)
+		{
+			var awidth = AllocatedWidth;
+			var aheight = AllocatedHeight;
+			StyleContext.RenderBackground (cr, 0, 0, awidth, aheight);
 
-            cr.LineWidth = 1.0;
-            Gdk.CairoHelper.SetSourceRgba(cr, StyleContext.GetColor(StateFlags));
+			cr.LineWidth = 1.0;
+			Gdk.CairoHelper.SetSourceRgba (cr, StyleContext.GetColor (StateFlags));
 
-            // Determine the ruler's size.
-            var border = StyleContext.GetBorder(StateFlags);
-            int rwidth = awidth - (border.Left + border.Right);
-            int rheight = aheight - (border.Top + border.Bottom);
+			// Determine the ruler's size.
+			var border = StyleContext.GetBorder (StateFlags);
+			int rwidth = awidth - (border.Left + border.Right);
+			int rheight = aheight - (border.Top + border.Bottom);
 
-            // Draw bottom line of the ruler.
-            switch (Orientation)
-            {
-                case Orientation.Horizontal:
-                    cr.Rectangle(0, aheight - border.Bottom - 1, awidth, 1);
-                    break;
-                case Orientation.Vertical:
-                    cr.Rectangle(awidth - border.Left - 1, 0, 1, aheight);
-                    // Swap so that width is the longer dimension (horizontal).
-                    Utility.Swap(ref awidth, ref aheight);
-                    Utility.Swap(ref rwidth, ref rheight);
-                    break;
-            }
-            cr.Fill();
+			// Draw bottom line of the ruler.
+			switch (Orientation) {
+				case Orientation.Horizontal:
+					cr.Rectangle (0, aheight - border.Bottom - 1, awidth, 1);
+					break;
+				case Orientation.Vertical:
+					cr.Rectangle (awidth - border.Left - 1, 0, 1, aheight);
+					// Swap so that width is the longer dimension (horizontal).
+					Utility.Swap (ref awidth, ref aheight);
+					Utility.Swap (ref rwidth, ref rheight);
+					break;
+			}
+			cr.Fill ();
 
-            double[] ruler_scale = null!; // NRT - Set immediately below
-            int[] subdivide = null!;
-            double pixels_per_unit = 1.0;
-            switch (Metric)
-            {
-                case MetricType.Pixels:
-                    ruler_scale = new double[] { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000 };
-                    subdivide = new int[] { 1, 5, 10, 50, 100 };
-                    pixels_per_unit = 1.0;
-                    break;
-                case MetricType.Inches:
-                    ruler_scale = new double[] { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
-                    subdivide = new int[] { 1, 2, 4, 8, 16 };
-                    pixels_per_unit = 72;
-                    break;
-                case MetricType.Centimeters:
-                default:
-                    ruler_scale = new double[] { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000 };
-                    subdivide = new int[] { 1, 5, 10, 50, 100 };
-                    pixels_per_unit = 28.35;
-                    break;
-            }
+			double[]? ruler_scale;
+			int[]? subdivide;
+			double pixels_per_unit = 1.0;
 
-            // Find our scaled range.
-            double scaled_upper = Upper / pixels_per_unit;
-            double scaled_lower = Lower / pixels_per_unit;
-            double max_size = scaled_upper - scaled_lower;
+			switch (Metric) {
+				case MetricType.Pixels:
+					ruler_scale = new double[] { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000 };
+					subdivide = new int[] { 1, 5, 10, 50, 100 };
+					pixels_per_unit = 1.0;
+					break;
+				case MetricType.Inches:
+					ruler_scale = new double[] { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
+					subdivide = new int[] { 1, 2, 4, 8, 16 };
+					pixels_per_unit = 72;
+					break;
+				case MetricType.Centimeters:
+				default:
+					ruler_scale = new double[] { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000 };
+					subdivide = new int[] { 1, 5, 10, 50, 100 };
+					pixels_per_unit = 28.35;
+					break;
+			}
 
-            // There must be enough space between the large ticks for the text labels.
-            var font = ObsoleteExtensions.GetStyleContextFont (StyleContext, StateFlags);
-            int font_size = GetFontSize(font);
-            var max_digits = ((int)-Math.Abs(max_size)).ToString().Length;
-            int min_separation = max_digits * font_size * 2;
+			// Find our scaled range.
+			double scaled_upper = Upper / pixels_per_unit;
+			double scaled_lower = Lower / pixels_per_unit;
+			double max_size = scaled_upper - scaled_lower;
 
-            double increment = awidth / max_size;
+			// There must be enough space between the large ticks for the text labels.
+			var font = ObsoleteExtensions.GetStyleContextFont (StyleContext, StateFlags);
+			int font_size = GetFontSize (font);
+			var max_digits = ((int) -Math.Abs (max_size)).ToString ().Length;
+			int min_separation = max_digits * font_size * 2;
 
-            // Figure out how to display the ticks.
-            int scale_index;
-            for (scale_index = 0; scale_index < ruler_scale.Length - 1; ++scale_index)
-            {
-                if (ruler_scale[scale_index] * increment > min_separation)
-                    break;
-            }
+			double increment = awidth / max_size;
 
-            int divide_index;
-            for (divide_index = 0; divide_index < subdivide.Length - 1; ++divide_index)
-            {
-                if (ruler_scale[scale_index] * increment < 5 * subdivide[divide_index + 1])
-                    break;
-            }
+			// Figure out how to display the ticks.
+			int scale_index;
+			for (scale_index = 0; scale_index < ruler_scale.Length - 1; ++scale_index) {
+				if (ruler_scale[scale_index] * increment > min_separation)
+					break;
+			}
 
-            double pixels_per_tick = increment * ruler_scale[scale_index] / subdivide[divide_index];
-            double units_per_tick = pixels_per_tick / increment;
-            double ticks_per_unit = 1.0 / units_per_tick;
+			int divide_index;
+			for (divide_index = 0; divide_index < subdivide.Length - 1; ++divide_index) {
+				if (ruler_scale[scale_index] * increment < 5 * subdivide[divide_index + 1])
+					break;
+			}
 
-            int start = (int)Math.Floor(scaled_lower * ticks_per_unit);
-            int end = (int)Math.Ceiling(scaled_upper * ticks_per_unit);
+			double pixels_per_tick = increment * ruler_scale[scale_index] / subdivide[divide_index];
+			double units_per_tick = pixels_per_tick / increment;
+			double ticks_per_unit = 1.0 / units_per_tick;
 
-            for (int i = start; i <= end; ++i)
-            {
-                // Position of tick (add 0.5 to center tick on pixel).
-                double position = Math.Floor(i * pixels_per_tick - scaled_lower * increment) + 0.5;
+			int start = (int) Math.Floor (scaled_lower * ticks_per_unit);
+			int end = (int) Math.Ceiling (scaled_upper * ticks_per_unit);
 
-                // Height of tick
-                int height = rheight;
-                for (int j = divide_index; j > 0; --j)
-                {
-                    if (i % subdivide[j] == 0) break;
-                    height = height / 2 + 1;
-                }
+			for (int i = start; i <= end; ++i) {
+				// Position of tick (add 0.5 to center tick on pixel).
+				double position = Math.Floor (i * pixels_per_tick - scaled_lower * increment) + 0.5;
 
-                // Draw text for major ticks.
-                if (i % subdivide[divide_index] == 0)
-                {
-                    int label_value = (int)Math.Round(i * units_per_tick);
-                    string label = label_value.ToString();
+				// Height of tick
+				int height = rheight;
+				for (int j = divide_index; j > 0; --j) {
+					if (i % subdivide[j] == 0) break;
+					height = height / 2 + 1;
+				}
 
-                    var layout = CreatePangoLayout(label);
-                    layout.FontDescription = font;
+				// Draw text for major ticks.
+				if (i % subdivide[divide_index] == 0) {
+					int label_value = (int) Math.Round (i * units_per_tick);
+					string label = label_value.ToString ();
 
-                    switch (Orientation)
-                    {
-                        case Orientation.Horizontal:
-                            cr.MoveTo(position + 2, border.Top);
-                            Pango.CairoHelper.ShowLayout(cr, layout);
-                            break;
-                        case Orientation.Vertical:
-                            PangoContext.BaseGravity = Pango.Gravity.East;
-                            PangoContext.GravityHint = Pango.GravityHint.Strong;
-                            cr.Save();
-                            cr.MoveTo(border.Left + font_size, position + font_size / 2);
-                            cr.Rotate(0.5 * Math.PI);
-                            Pango.CairoHelper.ShowLayout(cr, layout);
-                            cr.Restore();
-                            break;
-                    }
-                }
+					var layout = CreatePangoLayout (label);
+					layout.FontDescription = font;
 
-                // Draw ticks
-                switch (Orientation)
-                {
-                    case Orientation.Horizontal:
-                        cr.MoveTo(position, rheight + border.Top - height);
-                        cr.LineTo(position, rheight + border.Top);
-                        break;
-                    case Orientation.Vertical:
-                        cr.MoveTo(rheight + border.Left - height, position);
-                        cr.LineTo(rheight + border.Left, position);
-                        break;
-                }
+					switch (Orientation) {
+						case Orientation.Horizontal:
+							cr.MoveTo (position + 2, border.Top);
+							Pango.CairoHelper.ShowLayout (cr, layout);
+							break;
+						case Orientation.Vertical:
+							PangoContext.BaseGravity = Pango.Gravity.East;
+							PangoContext.GravityHint = Pango.GravityHint.Strong;
+							cr.Save ();
+							cr.MoveTo (border.Left + font_size, position + font_size / 2);
+							cr.Rotate (0.5 * Math.PI);
+							Pango.CairoHelper.ShowLayout (cr, layout);
+							cr.Restore ();
+							break;
+					}
+				}
 
-                cr.Stroke();
-            }
+				// Draw ticks
+				switch (Orientation) {
+					case Orientation.Horizontal:
+						cr.MoveTo (position, rheight + border.Top - height);
+						cr.LineTo (position, rheight + border.Top);
+						break;
+					case Orientation.Vertical:
+						cr.MoveTo (rheight + border.Left - height, position);
+						cr.LineTo (rheight + border.Left, position);
+						break;
+				}
 
-            // TODO-GTK3 - cache the ticks, and update the marker's position as the mouse moves.
+				cr.Stroke ();
+			}
 
-            return base.OnDrawn(cr);
-        }
+			// TODO-GTK3 - cache the ticks, and update the marker's position as the mouse moves.
 
-        private static int GetFontSize(Pango.FontDescription font)
-        {
-            int font_size = font.Size;
-            if (!font.SizeIsAbsolute)
-                font_size = (int)(font_size / Pango.Scale.PangoScale);
+			return base.OnDrawn (cr);
+		}
 
-            return font_size;
-        }
-    }
+		private static int GetFontSize (Pango.FontDescription font)
+		{
+			int font_size = font.Size;
+			if (!font.SizeIsAbsolute)
+				font_size = (int) (font_size / Pango.Scale.PangoScale);
+
+			return font_size;
+		}
+	}
 }


### PR DESCRIPTION
Tidy up `Pinta.Gui.Widgets`:
- Format code to fit `.editorconfig`
- Use modern C# like `var`, auto-properties, pattern matching, object initialization syntax, etc.
- Refactor to handle NRT correctly without needing the null-forgiveness operator.

This PR does not contain any functional changes.