### PR TITLE
Make ToolsManager.SetCurrentTool (string) take a type name.

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -328,25 +328,7 @@ namespace Pinta.Core
 			}
 		}
 
-		private ToggleToolButton CreateToolButton ()
-		{
-			var image = Image.NewFromIconName (Icon, IconSize.Button);
-			image.Show ();
-
-			var tool_item = new ToggleToolButton {
-				IconWidget = image,
-				Label = Name
-			};
-
-			tool_item.Show ();
-
-			if (ShortcutKey != 0)
-				tool_item.TooltipText = $"{Name}\n{Translations.GetString ("Shortcut key")}: {ShortcutKey.ToString ().ToUpperInvariant ()}\n\n{StatusBarText}";
-			else
-				tool_item.TooltipText = Name;
-
-			return tool_item;
-		}
+		private ToggleToolButton CreateToolButton () => new ToolBoxButton (this);
 		#endregion
 
 		#region Event Invokers

--- a/Pinta.Core/Extensions/ToolBoxButton.cs
+++ b/Pinta.Core/Extensions/ToolBoxButton.cs
@@ -1,0 +1,57 @@
+// 
+// ToolBoxButton.cs
+//  
+// Author:
+//       Jonathan Pobst <monkey@jpobst.com>
+// 
+// Copyright (c) 2020 Jonathan Pobst
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Gtk;
+
+namespace Pinta.Core
+{
+	/// <summary>
+	/// Buttons used by the ToolBoxWidget.
+	/// </summary>
+	public class ToolBoxButton : ToggleToolButton
+	{
+		public BaseTool Tool { get; }
+
+		public ToolBoxButton (BaseTool tool)
+		{
+			Tool = tool;
+
+			var image = Image.NewFromIconName (tool.Icon, IconSize.Button);
+			image.Show ();
+
+			IconWidget = image;
+			Label = tool.Name;
+
+			Show ();
+
+			if (tool.ShortcutKey != 0)
+				TooltipText = $"{tool.Name}\n{Translations.GetString ("Shortcut key")}: {tool.ShortcutKey.ToString ().ToUpperInvariant ()}\n\n{tool.StatusBarText}";
+			else
+				TooltipText = tool.Name;
+		}
+	}
+}

--- a/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
@@ -63,7 +63,7 @@ namespace Pinta.Core
 			old_selection_layer = swap_sel;
 
 			PintaCore.Workspace.Invalidate ();
-			PintaCore.Tools.SetCurrentTool (Translations.GetString ("Move Selected Pixels"));
+			PintaCore.Tools.SetCurrentTool ("MoveSelectedTool");
 		}
 
 		public override void Redo ()

--- a/Pinta.Core/HistoryItems/PasteHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/PasteHistoryItem.cs
@@ -61,7 +61,7 @@ namespace Pinta.Core
 			Swap ();
 
 			PintaCore.Workspace.Invalidate ();
-			PintaCore.Tools.SetCurrentTool (Translations.GetString ("Move Selected Pixels"));
+			PintaCore.Tools.SetCurrentTool ("MoveSelectedTool");
 		}
 
 		public override void Undo ()

--- a/Pinta.Core/Managers/ToolManager.cs
+++ b/Pinta.Core/Managers/ToolManager.cs
@@ -33,10 +33,30 @@ namespace Pinta.Core
 {
 	public interface IToolService
 	{
+		/// <summary>
+		/// Gets the currently selected tool.
+		/// </summary>
 		BaseTool CurrentTool { get; }
+
+		/// <summary>
+		/// Performs the mouse down event for the currently selected tool.
+		/// </summary>
 		void DoMouseDown (Document document, ToolMouseEventArgs e);
+
+		/// <summary>
+		/// Gets the previously selected tool.
+		/// </summary>
 		BaseTool PreviousTool { get; }
+
+		/// <summary>
+		/// Sets the current tool to the specified tool.
+		/// </summary>
 		void SetCurrentTool (BaseTool tool);
+
+		/// <summary>
+		/// Sets the current tool to the first tool with the specified tool type name, like
+		/// 'PencilTool'. Returns a value indicating if tool was successfully changed.
+		/// </summary>
 		bool SetCurrentTool (string tool);
 	}
 
@@ -104,37 +124,25 @@ namespace Pinta.Core
 
 		void HandlePbToolItemClicked (object? sender, EventArgs e)
 		{
-			ToggleToolButton? tb = (ToggleToolButton?)sender;
-
-			if (tb is null)
+			if (sender is not ToolBoxButton tb)
 				return;
 
-			BaseTool? t = FindTool (tb.Label);
-
-			if (t is null)
-				return;
+			var new_tool = tb.Tool;
 
 			// Don't let the user unselect the current tool	
-			if (CurrentTool != null && t.Name == CurrentTool.Name) {
+			if (CurrentTool != null && new_tool.GetType ().Name == CurrentTool.GetType ().Name) {
 				if (prev_index != index)
 					tb.Active = true;
+
 				return;
 			}
 
-			SetCurrentTool(t);
+			SetCurrentTool (new_tool);
 		}
 
 		private BaseTool? FindTool (string name)
 		{
-			name = name.ToLowerInvariant ();
-			
-			foreach (BaseTool tool in Tools) {
-				if (tool.Name.ToLowerInvariant () == name) {
-					return tool;
-				}
-			}
-			
-			return null;
+			return Tools.FirstOrDefault (t => string.Compare (name, t.GetType ().Name, true) == 0);
 		}
 		
 		public BaseTool CurrentTool {
@@ -198,10 +206,10 @@ namespace Pinta.Core
 
 		public bool SetCurrentTool (string tool)
 		{
-			BaseTool? t = FindTool (tool);
+			var t = FindTool (tool);
 			
 			if (t != null) {
-				SetCurrentTool(t);
+				SetCurrentTool (t);
 				return true;
 			}
 			

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -151,7 +151,7 @@ namespace Pinta.Gui.Widgets
 
 			// Selection outline
 			if (document.Selection.Visible) {
-				var fillSelection = PintaCore.Tools.CurrentTool.Name.Contains ("Select") && !PintaCore.Tools.CurrentTool.Name.Contains ("Selected");
+				var fillSelection = PintaCore.Tools.CurrentTool.GetType ().Name.Contains ("Select") && !PintaCore.Tools.CurrentTool.GetType ().Name.Contains ("Selected");
 				document.Selection.Draw (g, scale, fillSelection);
 			}
 

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -126,7 +126,7 @@ namespace Pinta.Tools
 			if (ToolSelectionDropDown.SelectedItem.GetTagOrDefault (0) == 1)
 				tools.SetCurrentTool (tools.PreviousTool);
 			else if (ToolSelectionDropDown.SelectedItem.GetTagOrDefault (0) == 2)
-				tools.SetCurrentTool (Translations.GetString ("Pencil"));
+				tools.SetCurrentTool (nameof (PencilTool));
 		}
 
 		private unsafe Color GetColorFromPoint (Document document, Point point)

--- a/Pinta/Actions/Edit/PasteAction.cs
+++ b/Pinta/Actions/Edit/PasteAction.cs
@@ -141,7 +141,7 @@ namespace Pinta.Actions
 			doc.Layers.SelectionLayer.Transform.InitIdentity ();
 			doc.Layers.SelectionLayer.Transform.Translate (x, y);
 
-			PintaCore.Tools.SetCurrentTool (Translations.GetString ("Move Selected Pixels"));
+			PintaCore.Tools.SetCurrentTool ("MoveSelectedTool");
 
 			var old_selection = doc.Selection.Clone ();
 

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -104,7 +104,7 @@ namespace Pinta
 #endif
 
 			// Try to set the default tool to the PaintBrush
-			PintaCore.Tools.SetCurrentTool (Translations.GetString ("Paintbrush"));
+			PintaCore.Tools.SetCurrentTool ("PaintBrushTool");
 
 			// Load the user's previous settings
 			LoadUserSettings ();


### PR DESCRIPTION
Today, `BaseTool.Name` is localized.  This can cause issues when we try to set or retrieve a tool based on its name, as we have to specify the localized name. There is a case where we do not do this, which likely does not work on certain locales:

- https://github.com/PintaProject/Pinta/blob/gtk3-v2/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs#L154

While we could (maybe?) fix this call, it seems like a bad design that might bite us again in the future.

Instead of operating on localized tool names, change `ToolManager.SetCurrentTool (string)` to work on type names, as they are not localized.