### PR TITLE
ToolManager cleanup

### DIFF
--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -269,7 +269,7 @@ namespace Pinta.Core
 			Document doc = PintaCore.Workspace.ActiveDocument;
 
 			Gtk.Clipboard cb = Gtk.Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
-			if (PintaCore.Tools.CurrentTool.DoHandleCopy (doc, cb))
+			if (PintaCore.Tools.CurrentTool?.DoHandleCopy (doc, cb) == true)
 				return;
 
 			PintaCore.Tools.Commit ();
@@ -322,7 +322,7 @@ namespace Pinta.Core
 			var doc = PintaCore.Workspace.ActiveDocument;
 
 			Gtk.Clipboard cb = Gtk.Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
-			if (PintaCore.Tools.CurrentTool.DoHandleCut (doc, cb))
+			if (PintaCore.Tools.CurrentTool?.DoHandleCut (doc, cb) == true)
 				return;
 			PintaCore.Tools.Commit ();
 			
@@ -336,19 +336,19 @@ namespace Pinta.Core
 		private void HandlerPintaCoreActionsEditUndoActivated (object sender, EventArgs e)
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
-			if (PintaCore.Tools.CurrentTool.DoHandleUndo (doc))
+			if (PintaCore.Tools.CurrentTool?.DoHandleUndo (doc) == true)
 				return;
 			doc.History.Undo ();
-			PintaCore.Tools.CurrentTool.DoAfterUndo(doc);
+			PintaCore.Tools.CurrentTool?.DoAfterUndo(doc);
 		}
 
 		private void HandlerPintaCoreActionsEditRedoActivated (object sender, EventArgs e)
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
-			if (PintaCore.Tools.CurrentTool.DoHandleRedo (doc))
+			if (PintaCore.Tools.CurrentTool?.DoHandleRedo (doc) == true)
 				return;
 			doc.History.Redo ();
-			PintaCore.Tools.CurrentTool.DoAfterRedo(doc);
+			PintaCore.Tools.CurrentTool?.DoAfterRedo(doc);
 		}
 
 		private void HandlerPintaCoreActionsEditLoadPaletteActivated (object sender, EventArgs e)

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -293,12 +293,12 @@ namespace Pinta.Core
 		}
 
 		#region Toolbar
-		private ToggleToolButton? tool_item;
+		private ToolBoxButton? tool_item;
 		private ToolBarDropDownButton? antialiasing_button;
 		private ToolBarDropDownButton? alphablending_button;
 		private SeparatorToolItem? separator;
 
-		public virtual ToggleToolButton ToolItem => tool_item ??= CreateToolButton ();
+		public virtual ToolBoxButton ToolItem => tool_item ??= CreateToolButton ();
 
 		private SeparatorToolItem Separator => separator ??= new SeparatorToolItem ();
 
@@ -328,7 +328,7 @@ namespace Pinta.Core
 			}
 		}
 
-		private ToggleToolButton CreateToolButton () => new ToolBoxButton (this);
+		private ToolBoxButton CreateToolButton () => new ToolBoxButton (this);
 		#endregion
 
 		#region Event Invokers

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -187,7 +187,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Called when the tool is deselected from the toolbox.
 		/// </summary>
-		protected virtual void OnDeactivated (Document? document, BaseTool newTool)
+		protected virtual void OnDeactivated (Document? document, BaseTool? newTool)
 		{
 		}
 
@@ -360,7 +360,7 @@ namespace Pinta.Core
 
 		internal void DoCommit (Document? document) => OnCommit (document);
 
-		internal void DoDeactivated (Document? document, BaseTool newTool)
+		internal void DoDeactivated (Document? document, BaseTool? newTool)
 		{
 			SetCursor (null);
 			OnDeactivated (document, newTool);

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -432,7 +432,7 @@ namespace Pinta.Core
 		{
 			// Ensure that the current tool's modifications are finalized before
 			// switching layers.
-			PintaCore.Tools.CurrentTool.DoCommit (document);
+			PintaCore.Tools.CurrentTool?.DoCommit (document);
 
 			CurrentUserLayerIndex = i;
 			SelectedLayerChanged?.Invoke (this, EventArgs.Empty);

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -118,7 +118,7 @@ namespace Pinta.Core
 					CanvasSize = new Gdk.Size (new_x, new_y);
 					Invalidate ();
 
-					if (PintaCore.Tools.CurrentTool.CursorChangesOnZoom)
+					if (PintaCore.Tools.CurrentTool?.CursorChangesOnZoom == true)
 					{
 						//The current tool's cursor changes when the zoom changes.
 						PintaCore.Tools.CurrentTool.SetCursor(PintaCore.Tools.CurrentTool.DefaultCursor);

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -261,5 +261,13 @@ namespace Pinta.Core
 				return CairoExtensions.ToPixbuf (i);
 			}
 		}
+
+		public static Key ToUpper (this Key k1)
+		{
+			if (Enum.TryParse (k1.ToString ().ToUpperInvariant (), out Key result))
+				return result;
+
+			return k1;
+		}
 	}
 }

--- a/Pinta.Core/Managers/ToolManager.cs
+++ b/Pinta.Core/Managers/ToolManager.cs
@@ -82,7 +82,7 @@ namespace Pinta.Core
 
 	public class ToolManager : IEnumerable<BaseTool>, IToolService
 	{
-		private readonly SortedSet<BaseTool> tools = new SortedSet<BaseTool> (new ToolSorter ());
+		private readonly SortedSet<BaseTool> tools = new (new ToolSorter ());
 
 		public event EventHandler<ToolEventArgs>? ToolAdded;
 		public event EventHandler<ToolEventArgs>? ToolRemoved;

--- a/Pinta.Core/Managers/ToolManager.cs
+++ b/Pinta.Core/Managers/ToolManager.cs
@@ -34,6 +34,16 @@ namespace Pinta.Core
 	public interface IToolService
 	{
 		/// <summary>
+		/// Adds a new tool to the tool box.
+		/// </summary>
+		void AddTool (BaseTool tool);
+
+		/// <summary>
+		/// Instructs the current tool to commit any work that is in a temporary state.
+		/// </summary>
+		void Commit ();
+
+		/// <summary>
 		/// Gets the currently selected tool.
 		/// </summary>
 		BaseTool? CurrentTool { get; }
@@ -49,6 +59,11 @@ namespace Pinta.Core
 		BaseTool? PreviousTool { get; }
 
 		/// <summary>
+		/// Removes the first found tool of the specified type from tool box.
+		/// </summary>
+		void RemoveInstanceOfTool<T> () where T : BaseTool;
+
+		/// <summary>
 		/// Sets the current tool to the specified tool.
 		/// </summary>
 		void SetCurrentTool (BaseTool tool);
@@ -58,85 +73,68 @@ namespace Pinta.Core
 		/// 'PencilTool'. Returns a value indicating if tool was successfully changed.
 		/// </summary>
 		bool SetCurrentTool (string tool);
+
+		/// <summary>
+		/// Sets the current tool to the next tool with the specified shortcut.
+		/// </summary>
+		void SetCurrentTool (Gdk.Key shortcut);
 	}
 
 	public class ToolManager : IEnumerable<BaseTool>, IToolService
 	{
-		int index = -1;
-		int prev_index = -1;
-		
-		private List<BaseTool> Tools;
-		private Dictionary<Gdk.Key, List<BaseTool>> groupedTools;
-		private Gdk.Key LastUsedKey;
-		private int PressedShortcutCounter;
+		private readonly SortedSet<BaseTool> tools = new SortedSet<BaseTool> (new ToolSorter ());
 
 		public event EventHandler<ToolEventArgs>? ToolAdded;
 		public event EventHandler<ToolEventArgs>? ToolRemoved;
 
-		public ToolManager ()
-		{
-			Tools = new List<BaseTool> ();
-			groupedTools = new Dictionary<Gdk.Key, List<BaseTool>>();
-			PressedShortcutCounter = 0;
-		}
+		public BaseTool? CurrentTool { get; private set; }
+
+		public BaseTool? PreviousTool { get; private set; }
 
 		public void AddTool (BaseTool tool)
 		{
-			tool.ToolItem.Clicked += HandlePbToolItemClicked;
-			
-			Tools.Add (tool);
-			Tools.Sort (new ToolSorter ());
+			tool.ToolItem.Clicked += HandleToolBoxToolItemClicked;
 
-			OnToolAdded (tool);
+			tools.Add (tool);
 
-			if (CurrentTool == null)
+			ToolAdded?.Invoke (this, new ToolEventArgs (tool));
+
+			if (CurrentTool is null)
 				SetCurrentTool (tool);
-
-			if (!groupedTools.ContainsKey(tool.ShortcutKey))
-				groupedTools.Add(tool.ShortcutKey, new List<BaseTool>());
-
-			groupedTools[tool.ShortcutKey].Add(tool);
 		}
 
-		public void RemoveInstanceOfTool (System.Type tool_type)
+		public void RemoveInstanceOfTool<T> () where T : BaseTool
 		{
-			foreach (BaseTool tool in Tools) {
-				if (tool.GetType () == tool_type) {
-					tool.ToolItem.Clicked -= HandlePbToolItemClicked;
-					tool.ToolItem.Active = false;
-					tool.ToolItem.Sensitive = false;
+			var tool = tools.OfType<T> ().FirstOrDefault ();
 
-					Tools.Remove (tool);
-					Tools.Sort (new ToolSorter ());
+			if (tool is null)
+				return;
 
-					// Are we trying to remove the current tool?
-					if (CurrentTool == tool) {
-						// Can we set it back to the previous tool?
-						if (PreviousTool is not null && PreviousTool != CurrentTool)
-							SetCurrentTool (PreviousTool);
-						else if (Tools.Any ())  // Any tool?
-							SetCurrentTool (Tools.First ());
-						else {
-							// There are no tools left.
-							DeactivateTool (tool, null);
-							prev_index = -1;
-							index = -1;
-						}
-					}
+			tool.ToolItem.Clicked -= HandleToolBoxToolItemClicked;
+			tool.ToolItem.Active = false;
+			tool.ToolItem.Sensitive = false;
 
-					OnToolRemoved (tool);
+			tools.Remove (tool);
 
-					if (groupedTools[tool.ShortcutKey].Count > 1)
-						groupedTools[tool.ShortcutKey].Remove(tool);
-					else
-						groupedTools.Remove(tool.ShortcutKey);
-
-					return;
+			// Are we trying to remove the current tool?
+			if (CurrentTool == tool) {
+				// Can we set it back to the previous tool?
+				if (PreviousTool is not null && PreviousTool != CurrentTool)
+					SetCurrentTool (PreviousTool);
+				else if (tools.Any ())  // Any tool?
+					SetCurrentTool (tools.First ());
+				else {
+					// There are no tools left.
+					DeactivateTool (tool, null);
+					PreviousTool = null;
+					CurrentTool = null;
 				}
 			}
+
+			ToolRemoved?.Invoke (this, new ToolEventArgs (tool));
 		}
 
-		void HandlePbToolItemClicked (object? sender, EventArgs e)
+		private void HandleToolBoxToolItemClicked (object? sender, EventArgs e)
 		{
 			if (sender is not ToolBoxButton tb)
 				return;
@@ -145,7 +143,7 @@ namespace Pinta.Core
 
 			// Don't let the user unselect the current tool	
 			if (CurrentTool != null && new_tool.GetType ().Name == CurrentTool.GetType ().Name) {
-				if (prev_index != index)
+				if (PreviousTool != CurrentTool)
 					tb.Active = true;
 
 				return;
@@ -156,39 +154,31 @@ namespace Pinta.Core
 
 		private BaseTool? FindTool (string name)
 		{
-			return Tools.FirstOrDefault (t => string.Compare (name, t.GetType ().Name, true) == 0);
+			return tools.FirstOrDefault (t => string.Compare (name, t.GetType ().Name, true) == 0);
 		}
-
-		public BaseTool? CurrentTool => index >= 0 ? Tools[index] : null;
-
-		public BaseTool? PreviousTool => prev_index >= 0 ? Tools[prev_index] : null;
 
 		public void Commit ()
 		{
-			if (CurrentTool != null)
-				CurrentTool.DoCommit (PintaCore.Workspace.HasOpenDocuments ? PintaCore.Workspace.ActiveDocument : null);
+			CurrentTool?.DoCommit (PintaCore.Workspace.ActiveDocumentOrDefault);
 		}
 
-		public void SetCurrentTool(BaseTool tool)
+		public void SetCurrentTool (BaseTool tool)
 		{
-			int i = Tools.IndexOf (tool);
-			
-			if (index == i)
+			// Bail if this is already the current tool
+			if (CurrentTool == tool)
 				return;
 
 			// Unload previous tool if needed
-			if (index >= 0) {
-				prev_index = index;
-
-				var prev_tool = Tools[index];
-
-				DeactivateTool (prev_tool, tool);
+			if (CurrentTool is not null) {
+				PreviousTool = CurrentTool;
+				DeactivateTool (PreviousTool, tool);
 			}
-			
+
 			// Load new tool
-			index = i;
+			CurrentTool = tool;
+
 			tool.ToolItem.Active = true;
-			tool.DoActivated(PintaCore.Workspace.HasOpenDocuments ? PintaCore.Workspace.ActiveDocument : null);
+			tool.DoActivated (PintaCore.Workspace.ActiveDocumentOrDefault);
 
 			ToolImage.Set (tool.Icon);
 
@@ -197,56 +187,47 @@ namespace Pinta.Core
 			PintaCore.Chrome.ToolToolBar.AppendItem (ToolSeparator);
 
 			tool.DoBuildToolBar (PintaCore.Chrome.ToolToolBar);
-			
+
 			PintaCore.Workspace.Invalidate ();
-			PintaCore.Chrome.SetStatusBarText (string.Format (" {0}: {1}", tool.Name, tool.StatusBarText));
+			PintaCore.Chrome.SetStatusBarText ($" {tool.Name}: {tool.StatusBarText}");
 		}
 
 		public bool SetCurrentTool (string tool)
 		{
-			var t = FindTool (tool);
-			
-			if (t != null) {
+			if (FindTool (tool) is BaseTool t) {
 				SetCurrentTool (t);
 				return true;
 			}
-			
+
 			return false;
 		}
-		
+
 		public void SetCurrentTool (Gdk.Key shortcut)
 		{
-			BaseTool? tool = FindNextTool (shortcut);
-			
-			if (tool != null)
-				SetCurrentTool(tool);
+			if (FindNextTool (shortcut) is BaseTool tool)
+				SetCurrentTool (tool);
 		}
 
 		private BaseTool? FindNextTool (Gdk.Key shortcut)
 		{
-			shortcut = shortcut.ToUpper();
+			// Find all tools with this shortcut
+			var shortcut_tools = tools.Where (t => t.ShortcutKey.ToUpper () == shortcut.ToUpper ()).ToList ();
 
-			if (groupedTools.ContainsKey(shortcut))
-			{
-				for (int i = 0; i < groupedTools[shortcut].Count; i++)
-				{
-					if (LastUsedKey != shortcut)
-					{
-						// Return first tool in group.
-						PressedShortcutCounter = (1 % groupedTools[shortcut].Count);
-						LastUsedKey = shortcut;
-						return groupedTools[shortcut][0];
-					}
-					else if(i == PressedShortcutCounter)
-					{
-						var tool = groupedTools[shortcut][PressedShortcutCounter];
-						PressedShortcutCounter = (i + 1) % groupedTools[shortcut].Count;
-						return tool;
-					}
-				}
-			}
+			// No tools with this shortcut, bail
+			if (!shortcut_tools.Any ())
+				return null;
 
-            return null;
+			// Only one option, return it
+			if (shortcut_tools.Count == 1 || CurrentTool is null)
+				return shortcut_tools.First ();
+
+			// Get the tool after the currently selected tool
+			var next_index = shortcut_tools.IndexOf (CurrentTool) + 1;
+
+			// Wrap if we're past the final tool
+			if (next_index >= shortcut_tools.Count)
+				next_index = 0;
+			return shortcut_tools[next_index];
 		}
 
 		private void DeactivateTool (BaseTool tool, BaseTool? newTool)
@@ -256,7 +237,7 @@ namespace Pinta.Core
 			while (toolbar.NItems > 0)
 				toolbar.Remove (toolbar.Children[toolbar.NItems - 1]);
 
-			tool.DoDeactivated (PintaCore.Workspace.HasOpenDocuments ? PintaCore.Workspace.ActiveDocument : null, newTool);
+			tool.DoDeactivated (PintaCore.Workspace.ActiveDocumentOrDefault, newTool);
 			tool.ToolItem.Active = false;
 		}
 
@@ -269,31 +250,9 @@ namespace Pinta.Core
 		public void DoAfterSave (Document document) => CurrentTool?.DoAfterSave (document);
 		public bool DoHandlePaste (Document document, Clipboard clipboard) => CurrentTool?.DoHandlePaste (document, clipboard) ?? false;
 
-		private void OnToolAdded (BaseTool tool)
-		{
-			if (ToolAdded != null)
-				ToolAdded (this, new ToolEventArgs (tool));
-		}
+		public IEnumerator<BaseTool> GetEnumerator () => tools.GetEnumerator ();
 
-		private void OnToolRemoved (BaseTool tool)
-		{
-			if (ToolRemoved != null)
-				ToolRemoved (this, new ToolEventArgs (tool));
-		}
-
-		#region IEnumerable<BaseTool> implementation
-		public IEnumerator<BaseTool> GetEnumerator ()
-		{
-			return Tools.GetEnumerator ();
-		}
-		#endregion
-
-		#region IEnumerable implementation
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
-		{
-			return Tools.GetEnumerator ();
-		}
-		#endregion
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator () => tools.GetEnumerator ();
 
 		class ToolSorter : Comparer<BaseTool>
 		{
@@ -304,30 +263,12 @@ namespace Pinta.Core
 			}
 		}
 
-		protected ToolBarLabel? tool_label;
-		protected ToolBarImage? tool_image;
-		protected SeparatorToolItem? tool_sep;
+		private ToolBarLabel? tool_label;
+		private ToolBarImage? tool_image;
+		private SeparatorToolItem? tool_sep;
 
 		private ToolBarLabel ToolLabel => tool_label ??= new ToolBarLabel ($" {Translations.GetString ("Tool")}:  ");
 		private ToolBarImage ToolImage => tool_image ??= new ToolBarImage (string.Empty);
 		private SeparatorToolItem ToolSeparator => tool_sep ??= new SeparatorToolItem ();
-
-	}
-
-	//Key extensions for more convenient usage of Gdk key enumerator
-	public static class KeyExtensions
-    {
-		public static Gdk.Key ToUpper(this Gdk.Key k1)
-		{
-            try
-            {
-				return (Gdk.Key)Enum.Parse(typeof(Gdk.Key), k1.ToString().ToUpperInvariant());
-			}
-            catch (ArgumentException)
-            {
-				//there is a need to catch argument exception because some buttons have not its UpperCase variant
-				return k1;
-            }
-		}
 	}
 }

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -69,6 +69,8 @@ namespace Pinta.Core
 			}
 		}
 
+		public Document? ActiveDocumentOrDefault => HasOpenDocuments ? OpenDocuments[active_document_index] : null;
+
         public SelectionModeHandler SelectionHandler { get; private set; }
 
 		public DocumentWorkspace ActiveWorkspace {

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -151,7 +151,8 @@ namespace Pinta.Gui.Widgets
 
 			// Selection outline
 			if (document.Selection.Visible) {
-				var fillSelection = PintaCore.Tools.CurrentTool.GetType ().Name.Contains ("Select") && !PintaCore.Tools.CurrentTool.GetType ().Name.Contains ("Selected");
+				var tool_name = PintaCore.Tools.CurrentTool?.GetType ().Name ?? string.Empty;
+				var fillSelection = tool_name.Contains ("Select") && !tool_name.Contains ("Selected");
 				document.Selection.Draw (g, scale, fillSelection);
 			}
 

--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -22,11 +22,13 @@ namespace Pinta.Gui.Widgets
 			ShowAll ();
 		}
 
-		// TODO: This should handle sorting the items
-		public void AddItem (ToolButton item)
+		public void AddItem (ToolBoxButton item)
 		{
 			item.IsImportant = false;
-			Add (item);
+
+			var index = PintaCore.Tools.ToList ().IndexOf (item.Tool);
+
+			Insert (item.Tool.ToolItem, index);
 		}
 
 		public void RemoveItem (ToolButton item)

--- a/Pinta.Tools/CoreToolsExtension.cs
+++ b/Pinta.Tools/CoreToolsExtension.cs
@@ -81,28 +81,28 @@ namespace Pinta.Tools
 			PintaCore.PaintBrushes.RemoveInstanceOfPaintBrush (typeof (Brushes.SplatterBrush));
 			PintaCore.PaintBrushes.RemoveInstanceOfPaintBrush (typeof (Brushes.SquaresBrush));
 
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (RectangleSelectTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (MoveSelectedTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (LassoSelectTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (MoveSelectionTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (EllipseSelectTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (ZoomTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (MagicWandTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (PanTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (PaintBucketTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (GradientTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (PaintBrushTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (EraserTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (PencilTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (ColorPickerTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (CloneStampTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (RecolorTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (TextTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (LineCurveTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (RectangleTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (RoundedRectangleTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (EllipseTool));
-			PintaCore.Tools.RemoveInstanceOfTool (typeof (FreeformShapeTool));
+			PintaCore.Tools.RemoveInstanceOfTool<RectangleSelectTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<MoveSelectedTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<LassoSelectTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<MoveSelectionTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<EllipseSelectTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<ZoomTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<MagicWandTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<PanTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<PaintBucketTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<GradientTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<PaintBrushTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<EraserTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<PencilTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<ColorPickerTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<CloneStampTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<RecolorTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<TextTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<LineCurveTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<RectangleTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<RoundedRectangleTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<EllipseTool> ();
+			PintaCore.Tools.RemoveInstanceOfTool<FreeformShapeTool> ();
 		}
 		#endregion
 	}

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -382,7 +382,7 @@ namespace Pinta.Tools
             PintaCore.Palette.SecondaryColorChanged += new EventHandler(Palette_SecondaryColorChanged);
         }
 
-		public virtual void HandleDeactivated(BaseTool newTool)
+		public virtual void HandleDeactivated(BaseTool? newTool)
 		{
 			SelectedPointIndex = -1;
 			SelectedShapeIndex = -1;
@@ -390,7 +390,7 @@ namespace Pinta.Tools
 			StorePreviousSettings();
 
 			//Determine if the tool being switched to will be another editable tool.
-			if (PintaCore.Workspace.HasOpenDocuments && !newTool.IsEditableShapeTool)
+			if (PintaCore.Workspace.HasOpenDocuments && !(newTool?.IsEditableShapeTool == true))
 			{
 				//The tool being switched to is not editable. Finalize every editable shape not yet finalized.
 				FinalizeAllShapes();
@@ -1076,7 +1076,8 @@ namespace Pinta.Tools
 			if (oldTool != null)
 			{
 				//The tool has switched, so call DrawActiveShape again but inside that tool.
-				((ShapeTool)PintaCore.Tools.CurrentTool).EditEngine.DrawActiveShape(
+				if (PintaCore.Tools.CurrentTool is ShapeTool tool)
+					tool.EditEngine.DrawActiveShape(
 					calculateOrganizedPoints, finalize, drawHoverSelection, shiftKey, preventSwitchBack);
 
 				//Afterwards, switch back to the old tool, unless specified otherwise.
@@ -1740,7 +1741,11 @@ namespace Pinta.Tools
 				//The active tool needs to be switched to the corresponding tool.
 				PintaCore.Tools.SetCurrentTool(correspondingTool);
 
-				ShapeTool newTool = (ShapeTool)PintaCore.Tools.CurrentTool;
+				var newTool = (ShapeTool?)PintaCore.Tools.CurrentTool;
+
+				// This shouldn't be possible, but we need a null check.
+				if (newTool is null)
+					return null;
 
 				//What happens next depends on whether the old tool was an editable ShapeTool.
 				if (oldTool != null && oldTool.IsEditableShapeTool)

--- a/Pinta.Tools/HistoryItems/ShapesHistoryItem.cs
+++ b/Pinta.Tools/HistoryItems/ShapesHistoryItem.cs
@@ -149,7 +149,7 @@ namespace Pinta.Tools
 
 				if (redraw)
 				{
-					((ShapeTool)PintaCore.Tools.CurrentTool).EditEngine.DrawAllShapes();
+					((ShapeTool?)PintaCore.Tools.CurrentTool)?.EditEngine.DrawAllShapes();
 				}
 			}
 		}

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -156,7 +156,7 @@ namespace Pinta.Tools
 			return false;
 		}
 
-		protected override void OnDeactivated (Document? document, BaseTool newTool)
+		protected override void OnDeactivated (Document? document, BaseTool? newTool)
 		{
 			origin = new Cairo.Point (int.MinValue, int.MinValue);
 		}

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Ctrl-left click to set origin, left click to paint.");
 		public override bool CursorChangesOnZoom => true;
 		public override Key ShortcutKey { get { return Key.L; } }
-		public override int Priority => 33;
+		public override int Priority => 47;
 		protected override bool ShowAntialiasingButton => true;
 
 		public override Cursor DefaultCursor {

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -50,7 +50,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click to set primary color. Right click to set secondary color.");
 		public override bool CursorChangesOnZoom => true;
 		public override Gdk.Key ShortcutKey => Gdk.Key.K;
-		public override int Priority => 31;
+		public override int Priority => 33;
 		private int SampleSize => SampleSizeDropDown.SelectedItem.GetTagOrDefault (1);
 		private bool SampleLayerOnly => SampleTypeDropDown.SelectedItem.GetTagOrDefault (false);
 

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -123,7 +123,7 @@ namespace Pinta.Tools
 
 			button_down = MouseButton.None;
 
-			if (ToolSelectionDropDown.SelectedItem.GetTagOrDefault (0) == 1)
+			if (ToolSelectionDropDown.SelectedItem.GetTagOrDefault (0) == 1 && tools.PreviousTool is not null)
 				tools.SetCurrentTool (tools.PreviousTool);
 			else if (ToolSelectionDropDown.SelectedItem.GetTagOrDefault (0) == 2)
 				tools.SetCurrentTool (nameof (PencilTool));

--- a/Pinta.Tools/Tools/EllipseSelectTool.cs
+++ b/Pinta.Tools/Tools/EllipseSelectTool.cs
@@ -40,7 +40,7 @@ namespace Pinta.Tools
 		public override string Icon => Pinta.Resources.Icons.ToolSelectEllipse;
 		public override string StatusBarText => Translations.GetString ("Click and drag to draw an elliptical selection. Hold Shift to constrain to a circle.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.EllipseSelect.png"), 9, 18);
-		public override int Priority => 13;
+		public override int Priority => 15;
 
 		protected override void DrawShape (Document document, Rectangle r, Layer l)
 		{

--- a/Pinta.Tools/Tools/EllipseTool.cs
+++ b/Pinta.Tools/Tools/EllipseTool.cs
@@ -39,7 +39,7 @@ namespace Pinta.Tools
 		public override string Name => Translations.GetString ("Ellipse");
 		public override string Icon => Pinta.Resources.Icons.ToolEllipse;
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Ellipse.png"), 9, 18);
-		public override int Priority => 45;
+		public override int Priority => 43;
 
 		public override string StatusBarText {
 			get {

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -52,7 +52,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click to draw with primary color, right click to draw with secondary color.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.FreeformShape.png"), 9, 18);
 		public override Gdk.Key ShortcutKey => Gdk.Key.O;
-		public override int Priority => 47;
+		public override int Priority => 45;
 
 		protected override void OnBuildToolBar (Toolbar tb)
 		{

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -50,7 +50,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Click and drag to draw gradient from primary to secondary color.  Right click to reverse.");
 		public override Gdk.Key ShortcutKey => Gdk.Key.G;
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Gradient.png"), 9, 18);
-		public override int Priority => 23;
+		public override int Priority => 31;
 		private GradientType SelectedGradientType => GradientDropDown.SelectedItem.GetTagOrDefault (GradientType.Linear);
 
 		protected override void OnBuildToolBar (Gtk.Toolbar tb)

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -55,7 +55,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Click and drag to draw the outline for a selection area.");
 		public override Gdk.Key ShortcutKey => Gdk.Key.S;
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.LassoSelect.png"), 9, 18);
-		public override int Priority => 9;
+		public override int Priority => 17;
 
 		protected override void OnBuildToolBar (Toolbar tb)
 		{

--- a/Pinta.Tools/Tools/LineCurveTool.cs
+++ b/Pinta.Tools/Tools/LineCurveTool.cs
@@ -39,7 +39,7 @@ namespace Pinta.Tools
 		public override string Name => Translations.GetString ("Line/Curve");
 		public override string Icon => Pinta.Resources.Icons.ToolLine;
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Line.png"), 9, 18);
-		public override int Priority => 39;
+		public override int Priority => 37;
 
 		public override string StatusBarText => Translations.GetString ("Left click to draw a shape with the primary color." +
 				      "\nLeft click on a shape to add a control point." +

--- a/Pinta.Tools/Tools/MagicWandTool.cs
+++ b/Pinta.Tools/Tools/MagicWandTool.cs
@@ -49,7 +49,7 @@ namespace Pinta.Tools
 		public override string Icon => Pinta.Resources.Icons.ToolSelectMagicWand;
 		public override string StatusBarText => Translations.GetString ("Click to select region of similar color.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.MagicWand.png"), 21, 10);
-		public override int Priority => 17;
+		public override int Priority => 19;
 
 		protected override void OnBuildToolBar (Gtk.Toolbar tb)
 		{

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -134,7 +134,7 @@ namespace Pinta.Tools
 			document?.FinishSelection ();
 		}
 
-		protected override void OnDeactivated (Document? document, BaseTool newTool)
+		protected override void OnDeactivated (Document? document, BaseTool? newTool)
 		{
 			base.OnDeactivated (document, newTool);
 

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -45,7 +45,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click and drag the selection to move selected content. Hold Ctrl to scale instead of move. Right click and drag the selection to rotate selected content. Hold Shift to rotate in steps. Use arrow keys to move selected content by a single pixel.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Gtk.IconTheme.Default.LoadIcon (Pinta.Resources.Icons.ToolMove, 16), 0, 0);
 		public override Gdk.Key ShortcutKey => Gdk.Key.M;
-		public override int Priority => 7;
+		public override int Priority => 5;
 
 		protected override Rectangle GetSourceRectangle (Document document)
 		{

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -44,7 +44,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click and drag the selection to move selection outline. Hold Ctrl to scale instead of move. Right click and drag the selection to rotate selection outline. Hold Shift to rotate in steps. Use arrow keys to move selection outline by a single pixel.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Gtk.IconTheme.Default.LoadIcon (Pinta.Resources.Icons.ToolMoveSelection, 16), 0, 0);
 		public override Gdk.Key ShortcutKey => Gdk.Key.M;
-		public override int Priority => 11;
+		public override int Priority => 7;
 
 		protected override Rectangle GetSourceRectangle (Document document)
 		{

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -60,7 +60,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click to draw with primary color, right click to draw with secondary color.");
 		public override bool CursorChangesOnZoom => true;
 		public override Gdk.Key ShortcutKey => Gdk.Key.B;
-		public override int Priority => 25;
+		public override int Priority => 21;
 
 		public override Gdk.Cursor DefaultCursor {
 			get {

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click to fill a region with the primary color, right click to fill with the secondary color.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, PintaCore.Resources.GetIcon ("Cursor.PaintBucket.png"), 21, 21);
 		public override Gdk.Key ShortcutKey => Gdk.Key.F;
-		public override int Priority => 21;
+		public override int Priority => 29;
 		protected override bool CalculatePolygonSet => false;
 
 		protected override void OnMouseDown (Document document, ToolMouseEventArgs e)

--- a/Pinta.Tools/Tools/PanTool.cs
+++ b/Pinta.Tools/Tools/PanTool.cs
@@ -44,7 +44,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Click and drag to navigate image.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Pan.png"), 8, 8);
 		public override Gdk.Key ShortcutKey => Gdk.Key.H;
-		public override int Priority => 19;
+		public override int Priority => 11;
 
 		protected override void OnMouseDown (Document document, ToolMouseEventArgs e)
 		{

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -50,7 +50,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click to draw freeform one-pixel wide lines with the primary color. Right click to use the secondary color.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Pencil.png"), 7, 24);
 		public override Gdk.Key ShortcutKey => Gdk.Key.P;
-		public override int Priority => 29;
+		public override int Priority => 25;
 		protected override bool ShowAlphaBlendingButton => true;
 
 		protected override void OnMouseDown (Document document, ToolMouseEventArgs e)

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -59,7 +59,7 @@ namespace Pinta.Tools
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Recolor.png"), 9, 18);
 		public override Gdk.Key ShortcutKey => Gdk.Key.R;
 		protected float Tolerance => (float) (ToleranceSlider.Slider.Value / 100);
-		public override int Priority => 35;
+		public override int Priority => 49;
 
 		protected override void OnBuildToolBar (Toolbar tb)
 		{

--- a/Pinta.Tools/Tools/RectangleSelectTool.cs
+++ b/Pinta.Tools/Tools/RectangleSelectTool.cs
@@ -40,7 +40,7 @@ namespace Pinta.Tools
 		public override string Icon => Pinta.Resources.Icons.ToolSelectRectangle;
 		public override string StatusBarText => Translations.GetString ("Click and drag to draw a rectangular selection. Hold Shift to constrain to a square.");
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.RectangleSelect.png"), 9, 18);
-		public override int Priority => 5;
+		public override int Priority => 13;
 
 		protected override void DrawShape (Document document, Rectangle r, Layer l)
 		{

--- a/Pinta.Tools/Tools/RectangleTool.cs
+++ b/Pinta.Tools/Tools/RectangleTool.cs
@@ -39,7 +39,7 @@ namespace Pinta.Tools
 		public override string Name => Translations.GetString ("Rectangle");
 		public override string Icon => Pinta.Resources.Icons.ToolRectangle;
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.Rectangle.png"), 9, 18);
-		public override int Priority => 41;
+		public override int Priority => 39;
 
 		public override string StatusBarText {
 			get {

--- a/Pinta.Tools/Tools/RoundedRectangleTool.cs
+++ b/Pinta.Tools/Tools/RoundedRectangleTool.cs
@@ -39,7 +39,7 @@ namespace Pinta.Tools
 		public override string Name => Translations.GetString ("Rounded Rectangle");
 		public override string Icon => Pinta.Resources.Icons.ToolRectangleRounded;
 		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Resources.GetIcon ("Cursor.RoundedRectangle.png"), 9, 18);
-		public override int Priority => 43;
+		public override int Priority => 41;
 
 		public override string StatusBarText {
 			get {

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -186,7 +186,7 @@ namespace Pinta.Tools
 			}
 		}
 
-		protected override void OnDeactivated (Document? document, BaseTool newTool)
+		protected override void OnDeactivated (Document? document, BaseTool? newTool)
 		{
 			base.OnDeactivated (document, newTool);
 

--- a/Pinta.Tools/Tools/ShapeTool.cs
+++ b/Pinta.Tools/Tools/ShapeTool.cs
@@ -74,7 +74,7 @@ namespace Pinta.Tools
 			base.OnActivated (document);
 		}
 
-		protected override void OnDeactivated (Document? document, BaseTool newTool)
+		protected override void OnDeactivated (Document? document, BaseTool? newTool)
 		{
 			EditEngine.HandleDeactivated (newTool);
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -378,7 +378,7 @@ namespace Pinta.Tools
 			StopEditing(false);
 		}
 
-		protected override void OnDeactivated(Document? document, BaseTool newTool)
+		protected override void OnDeactivated(Document? document, BaseTool? newTool)
 		{
 			base.OnDeactivated (document, newTool);
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -91,7 +91,7 @@ namespace Pinta.Tools
 		private string FinalizeName { get { return Translations.GetString("Text - Finalize"); } }
 		public override string Icon { get { return Pinta.Resources.Icons.ToolText; } }
 		public override Gdk.Key ShortcutKey { get { return Gdk.Key.T; } }
-		public override int Priority { get { return 37; } }
+		public override int Priority { get { return 35; } }
 
 		public override string StatusBarText {
 			get { return Translations.GetString ("Left click to place cursor, then type desired text. Text color is primary color."); }

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -58,7 +58,7 @@ namespace Pinta.Tools
 		public override string StatusBarText => Translations.GetString ("Left click to zoom in. Right click to zoom out. Click and drag to zoom in selection.");
 		public override Gdk.Cursor DefaultCursor => cursorZoom;
 		public override Gdk.Key ShortcutKey => Gdk.Key.Z;
-		public override int Priority => 15;
+		public override int Priority => 9;
 
 		protected override void OnMouseDown (Document document, ToolMouseEventArgs e)
 		{

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -167,7 +167,7 @@ namespace Pinta
 
 			PintaCore.Workspace.SetActiveDocument (view.Document);
 
-			((CanvasWindow) view.Widget).Canvas.Window.Cursor = PintaCore.Tools.CurrentTool.CurrentCursor;
+			((CanvasWindow) view.Widget).Canvas.Window.Cursor = PintaCore.Tools.CurrentTool?.CurrentCursor;
 		}
 
 		private void Workspace_DocumentCreated (object? sender, DocumentEventArgs e)


### PR DESCRIPTION
- Makes `CurrentTool` and `PreviousTool` nullable.  It used to be nullable, and then it was changed to return `DummyTool` ([commit](https://github.com/PintaProject/Pinta/commit/c3ceda1d11070129820f81dea383d0c61a408b68)), so calling code sometimes expected it to be nullable and sometimes not.  Now that we have NRT we can safely use nullable.
- Change `Tools` collection to a `SortedSet` so we don't need to re-sort the whole thing when it changes.
- Remove a lot of complexity and state around shortcut processing.
- Create a nullable `WorkspaceManager.ActiveDocumentOrDefault` (following LINQ convention) to simplify places that were checking `WorkspaceManager.HasOpenDocuments` but were happy with a `null` `Document`.
- Update `ToolBoxWidget` to properly sort tools by `Priority`.
- Update all tools to have updated priorities to match the new 1-column toolbox.