### PR TITLE
Use system default dotnet to start Pinta on Linux.

### DIFF
--- a/installer/linux/pinta.in
+++ b/installer/linux/pinta.in
@@ -2,4 +2,4 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 
-exec @DOTNET@ @libdir@/@PACKAGE@/Pinta.dll "$@"
+exec dotnet @libdir@/@PACKAGE@/Pinta.dll "$@"


### PR DESCRIPTION
Use system default `dotnet` executable (in `$PATH`). This allows building with a SDK installed in a different path then the runtime. This is especially helpful for packaging.