### PR TITLE
Install appdata into /usr/share/metainfo/ directory

### DIFF
--- a/xdg/Makefile.am
+++ b/xdg/Makefile.am
@@ -3,7 +3,7 @@ desktop_in_files = pinta.desktop.in
 desktop_DATA 	 = $(desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
 
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_in_files = pinta.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 @INTLTOOL_XML_RULE@


### PR DESCRIPTION
/usr/share/appdata/ is the legacy path. See: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location