### PR TITLE
Show full file paths as tooltips for opened tabs and for 'recently opened' files

### DIFF
--- a/Pinta.Core/Actions/FileActions.cs
+++ b/Pinta.Core/Actions/FileActions.cs
@@ -55,6 +55,8 @@ namespace Pinta.Core
 			NewScreenshot = new Gtk.Action ("NewScreenshot", Catalog.GetString ("New Screenshot..."), null, Stock.Fullscreen);
 			Open = new Gtk.Action ("Open", Catalog.GetString ("Open..."), null, Stock.Open);
 			OpenRecent = new RecentAction ("OpenRecent", Catalog.GetString ("Open Recent"), null, Stock.Open, RecentManager.Default);
+			// Show tooltip on selected file displaying the full path
+			OpenRecent.ShowTips = true;
 			
 			RecentFilter recentFilter = new RecentFilter ();
 			recentFilter.AddApplication ("Pinta");

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -153,7 +153,12 @@ namespace Pinta.Core
 		/// Directory and file name, like "C:\MyPictures\dog.jpg".
 		/// </summary>
 		public string PathAndFileName {
-			get { return System.IO.Path.Combine (Pathname, Filename); }
+			get {
+				if (!string.IsNullOrEmpty(Pathname) && !string.IsNullOrEmpty(Filename))
+					return System.IO.Path.Combine (Pathname, Filename);
+
+				return string.Empty;
+			}
 			set {
 				if (string.IsNullOrEmpty (value)) {
 					Pathname = string.Empty;

--- a/Pinta.Docking/MonoDevelop.Ide.Gui/IViewContent.cs
+++ b/Pinta.Docking/MonoDevelop.Ide.Gui/IViewContent.cs
@@ -32,6 +32,7 @@ namespace Pinta.Docking.Gui
     public interface IViewContent : IBaseViewContent
 	{
         string ContentName { get; set; }
+        string FullContentName { get; set; }
         string UntitledName { get; set; }
         string StockIconId { get; }
 

--- a/Pinta.Docking/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/Pinta.Docking/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -576,7 +576,13 @@ namespace Pinta.Docking.Gui
 			tab.Text = Title;
 			tab.Notify = show_notification;
 			tab.Dirty = content.IsDirty;
-			if (content.ContentName != null && content.ContentName != "") {
+
+			if (!string.IsNullOrEmpty(content.FullContentName))
+			{
+				tab.Tooltip = content.FullContentName;
+			}
+			else if (!string.IsNullOrEmpty(content.ContentName))
+			{
 				tab.Tooltip = content.ContentName;
 			}
             // JONTODO ?

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -231,7 +231,8 @@ namespace Pinta.Actions
 				return false;
 			}
 
-			document.Filename = Path.GetFileName (file);
+			// Set Pathname and Filename properties which triggers the document.Renamed event
+			document.PathAndFileName = file;
 
 			PintaCore.Tools.CurrentTool.DoAfterSave();
 

--- a/Pinta/DocumentViewContent.cs
+++ b/Pinta/DocumentViewContent.cs
@@ -56,6 +56,11 @@ namespace Pinta
             set { Document.Filename = value; }
         }
 
+        public string FullContentName {
+            get { return Document.PathAndFileName; }
+            set { Document.PathAndFileName = value; }
+        }
+
         public string UntitledName { get; set; }
 
         // We don't put icons on the tabs


### PR DESCRIPTION
Currently, tooltips on the opened tabs only display its filename, which isn't very helpful if there are multiple tabs open with the same filename. This PR changes the tooltip behavior to display the full path of that file to help differentiate between each tab.

I also added the display of full-path tooltips for the list of files under 'File > Recently opened..'. Fortunately, GTK has the logic covered and just needed to flip a boolean value.