### PR TITLE
Fix missing rectangle shape corner

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -183,6 +183,7 @@ namespace Pinta.Core
 			}
 
 			g.SetSourceColor (color);
+			g.LineCap = LineCap.Square;
 
 			Rectangle dirty = g.FixedStrokeExtents ();
 			g.Stroke ();


### PR DESCRIPTION
Fixes the corner missing when using the rectangle shape tool with an outline. https://bugs.launchpad.net/pinta/+bug/1922470

Since this bug was marked as a 1.8 milestone, I wasn't sure if it should be added to the gtk 3 branch or master branch. I've attached a before and after picture.

![Before and After](https://user-images.githubusercontent.com/87916368/127069537-c3e4393c-4bb2-4b60-8316-68d1b5576282.png)
