### PR TITLE
Fix text background outside of selection

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -1039,13 +1039,13 @@ namespace Pinta.Tools
 
 				//Fill in background
 				if (BackgroundFill) {
-					if (selection != null) {
-						g2.AppendPath (selection.SelectionPath);
-						g2.FillRule = Cairo.FillRule.EvenOdd;
-						g2.Clip ();
-					}
-					
 					using (var g2 = new Cairo.Context (surf)) {
+						if (selection != null) {
+							g2.AppendPath (selection.SelectionPath);
+							g2.FillRule = Cairo.FillRule.EvenOdd;
+							g2.Clip ();
+						}
+						
 						g2.FillRectangle(CurrentTextLayout.GetLayoutBounds().ToCairoRectangle(), PintaCore.Palette.SecondaryColor);
 					}
 				}

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -1039,6 +1039,12 @@ namespace Pinta.Tools
 
 				//Fill in background
 				if (BackgroundFill) {
+					if (selection != null) {
+						g2.AppendPath (selection.SelectionPath);
+						g2.FillRule = Cairo.FillRule.EvenOdd;
+						g2.Clip ();
+					}
+					
 					using (var g2 = new Cairo.Context (surf)) {
 						g2.FillRectangle(CurrentTextLayout.GetLayoutBounds().ToCairoRectangle(), PintaCore.Palette.SecondaryColor);
 					}

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -1028,9 +1028,7 @@ namespace Pinta.Tools
 				}
 
 				if (selection != null) {
-					g.AppendPath (selection.SelectionPath);
-					g.FillRule = Cairo.FillRule.EvenOdd;
-					g.Clip ();
+					selection.Clip(g);
 				}
 
 				g.MoveTo (new Cairo.PointD (CurrentTextEngine.Origin.X, CurrentTextEngine.Origin.Y));
@@ -1041,9 +1039,7 @@ namespace Pinta.Tools
 				if (BackgroundFill) {
 					using (var g2 = new Cairo.Context (surf)) {
 						if (selection != null) {
-							g2.AppendPath (selection.SelectionPath);
-							g2.FillRule = Cairo.FillRule.EvenOdd;
-							g2.Clip ();
+							selection.Clip(g2);
 						}
 						
 						g2.FillRectangle(CurrentTextLayout.GetLayoutBounds().ToCairoRectangle(), PintaCore.Palette.SecondaryColor);


### PR DESCRIPTION
This fixes the text background appearing outside of the selection box as reported here. https://bugs.launchpad.net/pinta/+bug/1910511

However, the bug report also mentions that the text tool can click outside of the selection area and that this is a bug. I tested how Paint.net handles this and it's the same. You are allowed to click outside of a selection box. Considering that other tools, like the paint brush and shape tools also let you click outside the selection box, it appears this is intended behavior. I think it would be best to have the user resubmit it as an idea/wishlist if they want it changed.

Also, I don't have any experience with C# or Cairo, so my solution might not be good. From what I was able to figure out, the text background used a separate Cairo context and it wasn't being clipped to the selection like the rest of the text was. The solution was to apply the same selection clipping to it. Below is a before and after.

![Text Background Before and After](https://user-images.githubusercontent.com/87916368/127239280-60e2bcbd-7ee3-4aad-9dcc-380a304221d1.png)