### PR TITLE
Fix text tool esc key finalize

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -784,7 +784,7 @@ namespace Pinta.Tools
 						break;
 
 					case Gdk.Key.Escape:
-						StopEditing(false);
+						StopEditing(true);
 						return;
 					case Gdk.Key.Insert:
 						if (modifier.IsShiftPressed ())


### PR DESCRIPTION
As described in this bug report, the ESC key should finalize text. However, it was set not the finalize it. This fixes that. https://bugs.launchpad.net/pinta/+bug/1428574