### PR TITLE
Fix text finalization after switching tools

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -506,7 +506,7 @@ namespace Pinta.Tools
 			PintaCore.Layers.LayerRemoved -= HandleSelectedLayerChanged;
 			PintaCore.Layers.SelectedLayerChanged -= HandleSelectedLayerChanged;
 
-			StopEditing(false);
+			StopEditing(true);
 		}
 #endregion
 


### PR DESCRIPTION
Fixes the bug reported here about text not being finalized when switching tools. https://bugs.launchpad.net/pinta/+bug/1909813

It almost seems like too easy of a fix. Perhaps there is more to the situation that I'm not understanding? I tried testing if there are any other bugs that occur from this, but I haven't found any. Switching tools finalizes the text, but adjusting text styling options does not, which is how it should be. I tested Paint.net and it finalizes text after switching tools as well. 