### PR TITLE
[Bug 1909578] Add Move Layer Down/Up actions to Gtk.Application so they function.

### DIFF
--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -95,6 +95,9 @@ namespace Pinta.Core
 
 			app.AddAccelAction(Properties, "F4");
 			prop_section.AppendItem(Properties.CreateMenuItem());
+
+			app.AddAction (MoveLayerDown);
+			app.AddAction (MoveLayerUp);
 		}
 
 		public void CreateLayerWindowToolBar (Gtk.Toolbar toolbar)


### PR DESCRIPTION
Fix bug https://bugs.launchpad.net/pinta/+bug/1909578 by adding Move Layer Down/Up actions to the Gtk.Application.  These appear to have been left out because they aren't part of the main menu, only the Layer pad toolbar.