### PR TITLE
[Bug 1909577] Do not let New/Open Image history be undone.

### DIFF
--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -46,7 +46,7 @@ namespace Pinta.Core
 		}
 
 		public bool CanRedo => Pointer < history.Count - 1;
-		public bool CanUndo => Pointer >= 0;
+		public bool CanUndo => Pointer > 0;
 
 		public BaseHistoryItem? Current {
 			get {


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/pinta/+bug/1909577.

The history stack works on the assumption that the initial history item (`New Image` or `Open Image`) cannot be "undone".  In some cleanup the `CanUndo` function began checking `Pointer >= 0` instead of `Pointer > 0`.

Original code:
https://github.com/PintaProject/Pinta/blob/master/Pinta.Core/Classes/DocumentWorkspaceHistory.cs#L116-L119