### PR TITLE
[Bug 1909754] Use asterisk on image tab to denote image has not been saved.

### DIFF
--- a/Pinta/DocumentViewContent.cs
+++ b/Pinta/DocumentViewContent.cs
@@ -41,32 +41,14 @@ namespace Pinta
             this.Document = document;
             this.canvas_window = canvasWindow;
 
-            // TODO-GTK3 (docking)
-#if false
-            document.IsDirtyChanged += (o, e) => IsDirty = document.IsDirty;
-#endif
+            document.IsDirtyChanged += (o, e) => LabelChanged?.Invoke (this, EventArgs.Empty);
             document.Renamed += (o, e) => { LabelChanged?.Invoke(this, EventArgs.Empty); };
         }
 
         public event EventHandler? LabelChanged;
 
-        public string Label
-        {
-            get { return Document.Filename; }
-            set { Document.Filename = value; }
-        }
+        public string Label => Document.Filename + (Document.IsDirty ? "*" : string.Empty);
 
         public Gtk.Widget Widget { get { return canvas_window; } }
-
-        // TODO-GTK3 (docking)
-#if false
-        public bool IsDirty {
-            get { return Document.IsDirty; }
-            set {
-                if (DirtyChanged != null)
-                    DirtyChanged (this, EventArgs.Empty);
-            }
-        }
-#endif
     }
 }


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/pinta/+bug/1909754

It appears that the GTK Notebook does not have native support for a "dirty" state like the MonoDevelop docking library we previously used did.  We'll have to revert to the tried and true asterisk to denote a tab is dirty.