### PR TITLE
[Bug 1922668] Ensure color palette widget requests enough vertical space.

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -43,7 +43,7 @@ namespace Pinta.Gui.Widgets
 
 		const int PALETTE_ROWS = 2;
 		const int SWATCH_SIZE = 19;
-		const int WIDGET_HEIGHT = 35;
+		const int WIDGET_HEIGHT = 42;
 		const int PALETTE_MARGIN = 10;
 
 		private readonly Gdk.Pixbuf swap_icon;


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/pinta/+bug/1922668

`StatusBarColorPaletteWidget` doesn't seem to be requesting enough height to fully draw itself.  This doesn't show on Windows because the other status bar items request enough height to cover it.  Removing them will also cut off the color palette on Windows.

Fix by requesting 42 pixels instead of 35.