### PR TITLE
[WIP] Add mnemonic for menu items / actions

### DIFF
--- a/Pinta.Core/Actions/FileActions.cs
+++ b/Pinta.Core/Actions/FileActions.cs
@@ -51,10 +51,10 @@ namespace Pinta.Core
 		
 		public FileActions ()
 		{
-			New = new Gtk.Action ("New", Catalog.GetString ("New..."), null, Stock.New);
-			NewScreenshot = new Gtk.Action ("NewScreenshot", Catalog.GetString ("New Screenshot..."), null, Stock.Fullscreen);
-			Open = new Gtk.Action ("Open", Catalog.GetString ("Open..."), null, Stock.Open);
-			OpenRecent = new RecentAction ("OpenRecent", Catalog.GetString ("Open Recent"), null, Stock.Open, RecentManager.Default);
+			New = new Gtk.Action ("New", Catalog.GetString ("_New..."), null, Stock.New);
+			NewScreenshot = new Gtk.Action ("NewScreenshot", Catalog.GetString ("New Screensho_t..."), null, Stock.Fullscreen);
+			Open = new Gtk.Action ("Open", Catalog.GetString ("_Open..."), null, Stock.Open);
+			OpenRecent = new RecentAction ("OpenRecent", Catalog.GetString ("Open _Recent"), null, Stock.Open, RecentManager.Default);
 			// Show tooltip on selected file displaying the full path
 			OpenRecent.ShowTips = true;
 			
@@ -63,11 +63,11 @@ namespace Pinta.Core
 			
 			(OpenRecent as RecentAction).AddFilter (recentFilter);
 			
-			Close = new Gtk.Action ("Close", Catalog.GetString ("Close"), null, Stock.Close);
-			Save = new Gtk.Action ("Save", Catalog.GetString ("Save"), null, Stock.Save);
-			SaveAs = new Gtk.Action ("SaveAs", Catalog.GetString ("Save As..."), null, Stock.SaveAs);
-			Print = new Gtk.Action ("Print", Catalog.GetString ("Print"), null, Stock.Print);
-			Exit = new Gtk.Action ("Exit", Catalog.GetString ("Quit"), null, Stock.Quit);
+			Close = new Gtk.Action ("Close", Catalog.GetString ("_Close"), null, Stock.Close);
+			Save = new Gtk.Action ("Save", Catalog.GetString ("_Save"), null, Stock.Save);
+			SaveAs = new Gtk.Action ("SaveAs", Catalog.GetString ("Save _As..."), null, Stock.SaveAs);
+			Print = new Gtk.Action ("Print", Catalog.GetString ("_Print"), null, Stock.Print);
+			Exit = new Gtk.Action ("Exit", Catalog.GetString ("_Quit"), null, Stock.Quit);
 
 			New.ShortLabel = Catalog.GetString ("New");
 			Open.ShortLabel = Catalog.GetString ("Open");

--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -160,7 +160,7 @@ namespace Pinta.Core
 
 			menu.AppendSeparator ();
 
-			Gtk.Action unit_action = new Gtk.Action ("RulerUnits", Mono.Unix.Catalog.GetString ("Ruler Units"), null, null);
+			Gtk.Action unit_action = new Gtk.Action ("RulerUnits", Mono.Unix.Catalog.GetString ("Ruler _Units"), null, null);
 			Menu unit_menu = (Menu)menu.AppendItem (unit_action.CreateSubMenuItem ()).Submenu;
 			unit_menu.Append (Pixels.CreateMenuItem ());
 			unit_menu.Append (Inches.CreateMenuItem ());

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -34,7 +34,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Noise"); }
+			get { return Catalog.GetString ("_Noise"); }
 		}
 
 		public NoiseData Data { get { return EffectData as NoiseData; } }

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Distort"); }
+			get { return Catalog.GetString ("_Distort"); }
 		}
 
 		public BulgeData Data {

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -35,7 +35,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Render"); }
+			get { return Catalog.GetString ("_Render"); }
 		}
 
 		public CloudsData Data { get { return EffectData as CloudsData; } }

--- a/Pinta.Effects/Effects/EdgeDetectEffect.cs
+++ b/Pinta.Effects/Effects/EdgeDetectEffect.cs
@@ -33,7 +33,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Stylize"); }
+			get { return Catalog.GetString ("_Stylize"); }
 		}
 
 		public EdgeDetectData Data { get { return EffectData as EdgeDetectData; } }

--- a/Pinta.Effects/Effects/EmbossEffect.cs
+++ b/Pinta.Effects/Effects/EmbossEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Stylize"); }
+			get { return Catalog.GetString ("_Stylize"); }
 		}
 
 		public EmbossData Data {

--- a/Pinta.Effects/Effects/FragmentEffect.cs
+++ b/Pinta.Effects/Effects/FragmentEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Blurs"); }
+			get { return Catalog.GetString ("_Blurs"); }
 		}
 
 		public FragmentData Data { get { return EffectData as FragmentData; } }

--- a/Pinta.Effects/Effects/FrostedGlassEffect.cs
+++ b/Pinta.Effects/Effects/FrostedGlassEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Distort"); }
+			get { return Catalog.GetString ("_Distort"); }
 		}
 
 		public FrostedGlassData Data {

--- a/Pinta.Effects/Effects/GaussianBlurEffect.cs
+++ b/Pinta.Effects/Effects/GaussianBlurEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
         }
 
         public override string EffectMenuCategory {
-            get { return Catalog.GetString ("Blurs"); }
+            get { return Catalog.GetString ("_Blurs"); }
         }
 
         public GaussianBlurData Data { get { return EffectData as GaussianBlurData; } }

--- a/Pinta.Effects/Effects/GlowEffect.cs
+++ b/Pinta.Effects/Effects/GlowEffect.cs
@@ -35,7 +35,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Photo"); }
+			get { return Catalog.GetString ("_Photo"); }
 		}
 
 		public GlowData Data { get { return EffectData as GlowData; } }

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -38,7 +38,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Artistic"); }
+			get { return Catalog.GetString ("_Artistic"); }
 		}
 
 		public InkSketchData Data { get { return EffectData as InkSketchData; } }

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Render"); }
+			get { return Catalog.GetString ("_Render"); }
 		}
 
 		public JuliaFractalData Data { get { return EffectData as JuliaFractalData; } }

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Render"); }
+			get { return Catalog.GetString ("_Render"); }
 		}
 
 		public MandelbrotFractalData Data { get { return EffectData as MandelbrotFractalData; } }

--- a/Pinta.Effects/Effects/MedianEffect.cs
+++ b/Pinta.Effects/Effects/MedianEffect.cs
@@ -33,7 +33,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Noise"); }
+			get { return Catalog.GetString ("_Noise"); }
 		}
 
 		public MedianData Data { get { return EffectData as MedianData; } }

--- a/Pinta.Effects/Effects/MotionBlurEffect.cs
+++ b/Pinta.Effects/Effects/MotionBlurEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Blurs"); }
+			get { return Catalog.GetString ("_Blurs"); }
 		}
 
 		public MotionBlurData Data { get { return EffectData as MotionBlurData; } }

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Artistic"); }
+			get { return Catalog.GetString ("_Artistic"); }
 		}
 
 		public OilPaintingData Data { get { return EffectData as OilPaintingData; } }

--- a/Pinta.Effects/Effects/OutlineEffect.cs
+++ b/Pinta.Effects/Effects/OutlineEffect.cs
@@ -33,7 +33,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Stylize"); }
+			get { return Catalog.GetString ("_Stylize"); }
 		}
 
 		public OutlineData Data { get { return EffectData as OutlineData; } }

--- a/Pinta.Effects/Effects/PencilSketchEffect.cs
+++ b/Pinta.Effects/Effects/PencilSketchEffect.cs
@@ -37,7 +37,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Artistic"); }
+			get { return Catalog.GetString ("_Artistic"); }
 		}
 
 		public PencilSketchData Data { get { return EffectData as PencilSketchData; } }

--- a/Pinta.Effects/Effects/PixelateEffect.cs
+++ b/Pinta.Effects/Effects/PixelateEffect.cs
@@ -34,7 +34,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Distort"); }
+			get { return Catalog.GetString ("_Distort"); }
 		}
 
 		public PixelateEffect () {

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -35,7 +35,7 @@ namespace Pinta.Effects
 
 		public override string EffectMenuCategory
 		{
-			get { return Catalog.GetString ("Distort"); }
+			get { return Catalog.GetString ("_Distort"); }
 		}
 
 		public PolarInversionEffect ()

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Blurs"); }
+			get { return Catalog.GetString ("_Blurs"); }
 		}
 
 		public RadialBlurData Data { get { return EffectData as RadialBlurData; } }

--- a/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
+++ b/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
@@ -33,7 +33,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Photo"); }
+			get { return Catalog.GetString ("_Photo"); }
 		}
 
 		public RedEyeRemoveData Data { get { return EffectData as RedEyeRemoveData; } }

--- a/Pinta.Effects/Effects/ReduceNoiseEffect.cs
+++ b/Pinta.Effects/Effects/ReduceNoiseEffect.cs
@@ -33,7 +33,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Noise"); }
+			get { return Catalog.GetString ("_Noise"); }
 		}
 
 		public ReduceNoiseData Data { get { return EffectData as ReduceNoiseData; } }

--- a/Pinta.Effects/Effects/ReliefEffect.cs
+++ b/Pinta.Effects/Effects/ReliefEffect.cs
@@ -29,7 +29,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Stylize"); }
+			get { return Catalog.GetString ("_Stylize"); }
 		}
 
 		public override bool LaunchConfiguration () {

--- a/Pinta.Effects/Effects/SharpenEffect.cs
+++ b/Pinta.Effects/Effects/SharpenEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Photo"); }
+			get { return Catalog.GetString ("_Photo"); }
 		}
 
 		public SharpenData Data { get { return EffectData as SharpenData; } }

--- a/Pinta.Effects/Effects/SoftenPortraitEffect.cs
+++ b/Pinta.Effects/Effects/SoftenPortraitEffect.cs
@@ -63,7 +63,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Photo"); }
+			get { return Catalog.GetString ("_Photo"); }
 		}
 
 		public SoftenPortraitData Data { get { return EffectData as SoftenPortraitData; } }

--- a/Pinta.Effects/Effects/TileEffect.cs
+++ b/Pinta.Effects/Effects/TileEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Distort"); }
+			get { return Catalog.GetString ("_Distort"); }
 		}
 
 		public TileData Data {

--- a/Pinta.Effects/Effects/TwistEffect.cs
+++ b/Pinta.Effects/Effects/TwistEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Distort"); }
+			get { return Catalog.GetString ("_Distort"); }
 		}
 
 		public TwistData Data { get { return EffectData as TwistData; } }

--- a/Pinta.Effects/Effects/UnfocusEffect.cs
+++ b/Pinta.Effects/Effects/UnfocusEffect.cs
@@ -32,7 +32,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Blurs"); }
+			get { return Catalog.GetString ("_Blurs"); }
 		}
 
 		public UnfocusData Data { get { return EffectData as UnfocusData; } }

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -30,7 +30,7 @@ namespace Pinta.Effects
 		}
 
 		public override string EffectMenuCategory {
-			get { return Catalog.GetString ("Blurs"); }
+			get { return Catalog.GetString ("_Blurs"); }
 		}
 
 		public ZoomBlurData Data { get { return EffectData as ZoomBlurData; } }

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -343,7 +343,7 @@ namespace Pinta
 			window_menu.Submenu = new Menu ();
 			main_menu.Append (window_menu);
 
-			Gtk.Action pads = new Gtk.Action ("pads", Mono.Unix.Catalog.GetString ("Tool Windows"), null, null);
+			Gtk.Action pads = new Gtk.Action ("pads", Mono.Unix.Catalog.GetString ("Tool _Windows"), null, null);
 			view_menu.Submenu = new Menu ();
 			show_pad = (Menu)((Menu)(view_menu.Submenu)).AppendItem (pads.CreateSubMenuItem ()).Submenu;
 


### PR DESCRIPTION
https://bugs.launchpad.net/pinta/+bug/1940763

In this PR, I started to define single-letter mnemonics as shortcuts (used with the Alt key).

E.g.:
```po
#: ../Pinta/MainWindow.cs:330
msgid "_File"
msgstr "_Datei"

```

This can not be done only in .po files because one `msgid`s in .po files often reference names of menu items *and* labels in other places. E.g. "Palette" appears as a menu item as well as a label for the palette toolbar. Therefore I cannot just change the `msgstr` in the .po files.

Also, it seems good to change the original `msgid` because this hints translators to also define mnemonics.

If maintainers agree, I'd continue with:

- [ ] Add more mnemonics
- [ ] Update .po files (but not translations)
- [ ] Update German .po file