### PR TITLE
Use Directory.Build.props to simplify version management.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <!-- Versioning and assembly info -->
+    <Version>2.0.1.0</Version>
+    <Authors>PintaProject</Authors>
+    <Company />
+    <Product />
+  </PropertyGroup>
+</Project>

--- a/Makefile.am
+++ b/Makefile.am
@@ -104,7 +104,7 @@ releasezip:
 
 EXTRA_DIST = Pinta Pinta.Core Pinta.Docking Pinta.Effects Pinta.Gui.Widgets Pinta.Resources Pinta.Tools po xdg tests license-mit.txt \
            license-pdn.txt Pinta.sln pinta.pc.in readme.md intltool-extract.in \
-           intltool-merge.in intltool-update.in installer/linux/install.proj
+           intltool-merge.in intltool-update.in installer/linux/install.proj Directory.Build.props
 
 CLEANFILES = intltool-extract \
 	     intltool-update \

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -1,15 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Pinta.Core</RootNamespace>
-    <AssemblyName>Pinta.Core</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.34" />

--- a/Pinta.Docking/Pinta.Docking.csproj
+++ b/Pinta.Docking/Pinta.Docking.csproj
@@ -1,15 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-
-    <RootNamespace>Pinta.Docking</RootNamespace>
-    <AssemblyName>Pinta.Docking</AssemblyName>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.34" />

--- a/Pinta.Effects/Pinta.Effects.csproj
+++ b/Pinta.Effects/Pinta.Effects.csproj
@@ -1,15 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Pinta.Effects</RootNamespace>
-    <AssemblyName>Pinta.Effects</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.34" />

--- a/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
+++ b/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
@@ -1,15 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Pinta.Gui.Widgets</RootNamespace>
-    <AssemblyName>Pinta.Gui.Widgets</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.34" />

--- a/Pinta.Resources/Pinta.Resources.csproj
+++ b/Pinta.Resources/Pinta.Resources.csproj
@@ -1,14 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Pinta.Resources</RootNamespace>
-    <AssemblyName>Pinta.Resources</AssemblyName>
     <Nullable>enable</Nullable>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pinta.Tools/Pinta.Tools.csproj
+++ b/Pinta.Tools/Pinta.Tools.csproj
@@ -1,15 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Pinta.Tools</RootNamespace>
-    <AssemblyName>Pinta.Tools</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.34" />

--- a/Pinta/Pinta.csproj
+++ b/Pinta/Pinta.csproj
@@ -1,27 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>Pinta</RootNamespace>
-    <AssemblyName>Pinta</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Pinta.ico</ApplicationIcon>
     <OutputPath>..\bin</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
-
     <!-- Disabled by default as it requires gettext to be installed. -->
     <BuildTranslations>false</BuildTranslations>
-
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.34" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />
     <ProjectReference Include="..\Pinta.Docking\Pinta.Docking.csproj" />
@@ -37,6 +31,7 @@
   <ItemGroup>
     <Translation Include="../po/*.po" />
   </ItemGroup>
+
   <Target Name="CompileTranslations" BeforeTargets="Build" Condition="'$(BuildTranslations)' == 'true'" Inputs="@(Translation)" Outputs="$(OutputPath)/locale/%(Translation.Filename)/LC_MESSAGES/pinta.mo">
 
     <MakeDir Directories="$(OutputPath)/locale/%(Translation.Filename)/LC_MESSAGES" />

--- a/tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj
+++ b/tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj
@@ -1,14 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Pinta.Core.Tests</RootNamespace>
-    <AssemblyName>Pinta.Core.Tests</AssemblyName>
     <IsPublishable>false</IsPublishable>
-
-    <Version>2.0.1.0</Version>
-    <Authors>PintaProject</Authors>
-    <Company />
-    <Product />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Anything put in the magically-named `Directory.Build.props` file will be automatically pulled in to any `.csproj` files in a tree.  By moving `<Version>` there, it only needs to be updated in one place instead of X places.

Additionally remove `<RootNamespace>` and `<AssemblyName>`.  These values are defaulted to the `.csproj` name, so specifying them is redundant in an SDK-style `.csproj` world.