### PR TITLE
Add benchmark test suite.

### DIFF
--- a/Pinta.Core/Classes/Translations.cs
+++ b/Pinta.Core/Classes/Translations.cs
@@ -30,7 +30,7 @@ namespace Pinta.Core
 {
 	public static class Translations
 	{
-		private static ICatalog catalog = null!; // NRT - Always set by Init
+		private static ICatalog? catalog;
 
 		public static void Init (string domain, string locale_dir)
 		{
@@ -39,12 +39,12 @@ namespace Pinta.Core
 
 		public static string GetString (string text)
 		{
-			return catalog.GetString (text);
+			return catalog?.GetString (text) ?? text;
 		}
 
 		public static string GetString (string text, params object[] args)
 		{
-			return catalog.GetString (text, args);
+			return catalog?.GetString (text, args) ?? text;
 		}
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -14,11 +14,12 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Widgets
 {
-	class CanvasRenderer
+	public class CanvasRenderer
 	{
 		private static Cairo.Pattern tranparent_pattern;
 
 		private readonly bool enable_pixel_grid;
+		private readonly bool enable_live_preview;
 
 		private Size source_size;
 		private Size destination_size;
@@ -30,9 +31,10 @@ namespace Pinta.Gui.Widgets
 		private int[]? s2dLookupX;
 		private int[]? s2dLookupY;
 
-		public CanvasRenderer (bool enable_pixel_grid)
+		public CanvasRenderer (bool enable_pixel_grid, bool enableLivePreview)
 		{
 			this.enable_pixel_grid = enable_pixel_grid;
+			enable_live_preview = enableLivePreview;
 		}
 
 		static CanvasRenderer ()
@@ -62,7 +64,6 @@ namespace Pinta.Gui.Widgets
 
 			// Our rectangle of interest
 			var r = new Rectangle (offset, dst.GetBounds ().Size).ToCairoRectangle ();
-			var doc = PintaCore.Workspace.ActiveDocument;
 
 			using (var g = new Cairo.Context (dst)) {
 				// Create the transparent checkerboard background
@@ -73,7 +74,7 @@ namespace Pinta.Gui.Widgets
 					var layer = layers[i];
 
 					// If we're in LivePreview, substitute current layer with the preview layer
-					if (layer == doc.Layers.CurrentUserLayer && PintaCore.LivePreview.IsEnabled)
+					if (enable_live_preview && layer == PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer && PintaCore.LivePreview.IsEnabled)
 						layer = CreateLivePreviewLayer (layer);
 
 					// If the layer is offset, handle it here

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -45,7 +45,7 @@ namespace Pinta.Gui.Widgets
 			CanvasWindow = window;
 			this.document = document;
 
-			cr = new CanvasRenderer (true);
+			cr = new CanvasRenderer (true, true);
 
 			// Keep the widget the same size as the canvas
 			document.Workspace.CanvasSizeChanged += delegate (object? sender, EventArgs e) {

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListWidget.cs
@@ -45,7 +45,7 @@ namespace Pinta.Gui.Widgets
 		// For the active layer, we also draw the selection layer on top of it,
 		// so we can't directly use that layer's surface.
 		private Cairo.ImageSurface? active_layer_surface;
-		private readonly CanvasRenderer canvas_renderer = new CanvasRenderer (false);
+		private readonly CanvasRenderer canvas_renderer = new CanvasRenderer (false, false);
 
 		private const int store_index_thumbnail = 0;
 		private const int store_index_name = 1;

--- a/Pinta.sln
+++ b/Pinta.sln
@@ -22,6 +22,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinta.Docking", "Pinta.Dock
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinta.Core.Tests", "tests\Pinta.Core.Tests\Pinta.Core.Tests.csproj", "{B207624A-5378-4F31-B2C9-43DE7F7CC10B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PintaBenchmarks", "tests\PintaBenchmarks\PintaBenchmarks.csproj", "{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8D23D7B9-C97E-498C-A1C5-6159E305D9BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,9 +64,17 @@ Global
 		{B207624A-5378-4F31-B2C9-43DE7F7CC10B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B207624A-5378-4F31-B2C9-43DE7F7CC10B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B207624A-5378-4F31-B2C9-43DE7F7CC10B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B207624A-5378-4F31-B2C9-43DE7F7CC10B} = {8D23D7B9-C97E-498C-A1C5-6159E305D9BA}
+		{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864} = {8D23D7B9-C97E-498C-A1C5-6159E305D9BA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4985F1D9-0ABE-4E83-98D2-8D119EA4075D}

--- a/tests/PintaBenchmarks/AdjustmentsBenchmarks.cs
+++ b/tests/PintaBenchmarks/AdjustmentsBenchmarks.cs
@@ -1,0 +1,96 @@
+using BenchmarkDotNet.Attributes;
+using Cairo;
+using Pinta.Core;
+using Pinta.Effects;
+
+namespace PintaBenchmarks;
+
+[MemoryDiagnoser]
+[Config (typeof (MillisecondConfig))]
+public class AdjustmentsBenchmarks
+{
+	private readonly ImageSurface surface;
+	private readonly ImageSurface dest_surface;
+	private readonly Gdk.Rectangle bounds;
+
+	public AdjustmentsBenchmarks ()
+	{
+		surface = TestData.Get2000PixelImage ();
+		dest_surface = new ImageSurface (Format.Argb32, 2000, 2000);
+		bounds = surface.GetBounds ();
+	}
+
+	[Benchmark]
+	public void AutoLevelEffect ()
+	{
+		var effect = new AutoLevelEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void BlackAndWhiteEffect ()
+	{
+		var effect = new BlackAndWhiteEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void BrightnessContrastEffect ()
+	{
+		var effect = new BrightnessContrastEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void CurvesEffect ()
+	{
+		var effect = new CurvesEffect ();
+
+		var points = new SortedList<int, int> ();
+
+		points.Add (0, 0);
+		points.Add (75, 110);
+		points.Add (225, 175);
+		points.Add (255, 255);
+
+		(effect.EffectData as CurvesData)!.ControlPoints = new[] { points };
+		(effect.EffectData as CurvesData)!.Mode = ColorTransferMode.Luminosity;
+
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void HueSaturationEffect ()
+	{
+		var effect = new HueSaturationEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void InvertColorsEffect ()
+	{
+		var effect = new InvertColorsEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void LevelsEffect ()
+	{
+		var effect = new LevelsEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void PosterizeEffect ()
+	{
+		var effect = new PosterizeEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void SepiaEffect ()
+	{
+		var effect = new SepiaEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+}

--- a/tests/PintaBenchmarks/CanvasRendererBenchmarks.cs
+++ b/tests/PintaBenchmarks/CanvasRendererBenchmarks.cs
@@ -1,0 +1,96 @@
+using BenchmarkDotNet.Attributes;
+using Cairo;
+using Pinta.Core;
+using Pinta.Gui.Widgets;
+
+namespace PintaBenchmarks;
+
+[MemoryDiagnoser]
+[Config (typeof (MillisecondConfig))]
+public class CanvasRendererBenchmarks
+{
+	private readonly ImageSurface surface;
+
+	private readonly ImageSurface dest_surface;
+	private readonly ImageSurface dest_surface_zoom_in;
+	private readonly ImageSurface dest_surface_zoom_out;
+
+	private readonly Gdk.Size src_size;
+	private readonly Gdk.Size dest_size_zoom_in;
+	private readonly Gdk.Size dest_size_zoom_out;
+
+	private readonly List<Layer> layers = new List<Layer> ();
+	private readonly List<Layer> ten_laters = new List<Layer> ();
+
+	public CanvasRendererBenchmarks ()
+	{
+		surface = TestData.Get2000PixelImage ();
+
+		layers.Add (new Layer (surface));
+
+		for (var i = 0; i < 10; i++)
+			ten_laters.Add (new Layer (surface));
+
+		dest_surface = new ImageSurface (Format.Argb32, 2000, 2000);
+		dest_surface_zoom_in = new ImageSurface (Format.Argb32, 3500, 3500);
+		dest_surface_zoom_out = new ImageSurface (Format.Argb32, 1350, 1350);
+
+		src_size = dest_surface.GetSize ();
+		dest_size_zoom_in = dest_surface_zoom_in.GetSize ();
+		dest_size_zoom_out = dest_surface_zoom_out.GetSize ();
+	}
+
+	[Benchmark]
+	public void RenderOneToOne ()
+	{
+		var renderer = new CanvasRenderer (false, false);
+
+		renderer.Initialize (src_size, src_size);
+		renderer.Render (layers, dest_surface, Gdk.Point.Zero);
+	}
+
+	[Benchmark]
+	public void RenderManyOneToOne ()
+	{
+		var renderer = new CanvasRenderer (false, false);
+
+		renderer.Initialize (src_size, src_size);
+		renderer.Render (ten_laters, dest_surface, Gdk.Point.Zero);
+	}
+
+	[Benchmark]
+	public void RenderZoomIn ()
+	{
+		var renderer = new CanvasRenderer (false, false);
+
+		renderer.Initialize (src_size, dest_size_zoom_in);
+		renderer.Render (layers, dest_surface_zoom_in, Gdk.Point.Zero);
+	}
+
+	[Benchmark]
+	public void RenderManyZoomIn ()
+	{
+		var renderer = new CanvasRenderer (false, false);
+
+		renderer.Initialize (src_size, dest_size_zoom_in);
+		renderer.Render (ten_laters, dest_surface_zoom_in, Gdk.Point.Zero);
+	}
+
+	[Benchmark]
+	public void RenderZoomOut ()
+	{
+		var renderer = new CanvasRenderer (false, false);
+
+		renderer.Initialize (src_size, dest_size_zoom_out);
+		renderer.Render (layers, dest_surface_zoom_out, Gdk.Point.Zero);
+	}
+
+	[Benchmark]
+	public void RenderManyZoomOut ()
+	{
+		var renderer = new CanvasRenderer (false, false);
+
+		renderer.Initialize (src_size, dest_size_zoom_out);
+		renderer.Render (ten_laters, dest_surface_zoom_out, Gdk.Point.Zero);
+	}
+}

--- a/tests/PintaBenchmarks/EffectsBenchmarks.cs
+++ b/tests/PintaBenchmarks/EffectsBenchmarks.cs
@@ -1,0 +1,218 @@
+using BenchmarkDotNet.Attributes;
+using Cairo;
+using Pinta.Core;
+using Pinta.Effects;
+
+namespace PintaBenchmarks;
+
+[MemoryDiagnoser]
+[Config (typeof (MillisecondConfig))]
+public class EffectsBenchmarks
+{
+	private readonly ImageSurface surface;
+	private readonly ImageSurface dest_surface;
+	private readonly Gdk.Rectangle bounds;
+
+	public EffectsBenchmarks ()
+	{
+		surface = TestData.Get2000PixelImage ();
+		dest_surface = new ImageSurface (Format.Argb32, 2000, 2000);
+		bounds = surface.GetBounds ();
+	}
+
+	[Benchmark]
+	public void AddNoiseEffect ()
+	{
+		var effect = new AddNoiseEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void BulgeEffect ()
+	{
+		var effect = new BulgeEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	//[Benchmark] // Requires initialized PintaCore
+	public void CloudsEffect ()
+	{
+		var effect = new CloudsEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void EdgeDetectEffect ()
+	{
+		var effect = new EdgeDetectEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void EmbossEffect ()
+	{
+		var effect = new EmbossEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void FragmentEffect ()
+	{
+		var effect = new FragmentEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void FrostedGlassEffect ()
+	{
+		var effect = new FrostedGlassEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void GaussianBlurEffect ()
+	{
+		var effect = new GaussianBlurEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void GlowEffect ()
+	{
+		var effect = new GlowEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void InkSketchEffect ()
+	{
+		var effect = new InkSketchEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void JuliaFractalEffect ()
+	{
+		var effect = new JuliaFractalEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark] // Very slow
+	public void MandelbrotFractalEffect ()
+	{
+		var effect = new MandelbrotFractalEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void MedianEffect ()
+	{
+		var effect = new MedianEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void MotionBlurEffect ()
+	{
+		var effect = new MotionBlurEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void OilPaintingEffect ()
+	{
+		var effect = new OilPaintingEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void OutlineEffect ()
+	{
+		var effect = new OutlineEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void PencilSketchEffect ()
+	{
+		var effect = new PencilSketchEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void PixelateEffect ()
+	{
+		var effect = new PixelateEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	//[Benchmark] // Requires initialized PintaCore
+	public void PolarInversionEffect ()
+	{
+		var effect = new PolarInversionEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void RadialBlurEffect ()
+	{
+		var effect = new RadialBlurEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void RedEyeRemoveEffect ()
+	{
+		var effect = new RedEyeRemoveEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void ReliefEffect ()
+	{
+		var effect = new ReliefEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void SharpenEffect ()
+	{
+		var effect = new SharpenEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void SoftenPortraitEffect ()
+	{
+		var effect = new SoftenPortraitEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void TileEffect ()
+	{
+		var effect = new TileEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void TwistEffect ()
+	{
+		var effect = new TwistEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void UnfocusEffect ()
+	{
+		var effect = new UnfocusEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+
+	[Benchmark]
+	public void ZoomBlurEffect ()
+	{
+		var effect = new ZoomBlurEffect ();
+		effect.Render (surface, dest_surface, new[] { bounds });
+	}
+}

--- a/tests/PintaBenchmarks/PintaBenchmarks.csproj
+++ b/tests/PintaBenchmarks/PintaBenchmarks.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Pinta.Core\Pinta.Core.csproj" />
+    <ProjectReference Include="..\..\Pinta.Effects\Pinta.Effects.csproj" />
+    <ProjectReference Include="..\..\Pinta.Gui.Widgets\Pinta.Gui.Widgets.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Assets\2000px-test.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/PintaBenchmarks/Program.cs
+++ b/tests/PintaBenchmarks/Program.cs
@@ -1,0 +1,17 @@
+using BenchmarkDotNet.Running;
+
+namespace PintaBenchmarks;
+
+public class Program
+{
+	public static void Main ()
+	{
+		// Run all benchmarks
+		BenchmarkRunner.Run (typeof (Program).Assembly);
+
+		// Run individual benchmark suites
+		//BenchmarkRunner.Run<CanvasRendererBenchmarks> ();
+		//BenchmarkRunner.Run<AdjustmentsBenchmarks> ();
+		//BenchmarkRunner.Run<EffectsBenchmarks> ();
+	}
+}

--- a/tests/PintaBenchmarks/Utilities/MillisecondConfig.cs
+++ b/tests/PintaBenchmarks/Utilities/MillisecondConfig.cs
@@ -1,0 +1,12 @@
+using BenchmarkDotNet.Configs;
+using Perfolizer.Horology;
+
+namespace PintaBenchmarks;
+
+internal class MillisecondConfig : ManualConfig
+{
+	public MillisecondConfig ()
+	{
+		SummaryStyle = BenchmarkDotNet.Reports.SummaryStyle.Default.WithTimeUnit (TimeUnit.Millisecond);
+	}
+}

--- a/tests/PintaBenchmarks/Utilities/TestData.cs
+++ b/tests/PintaBenchmarks/Utilities/TestData.cs
@@ -1,0 +1,15 @@
+using Cairo;
+
+namespace PintaBenchmarks;
+
+internal class TestData
+{
+	public static ImageSurface Get2000PixelImage ()
+	{
+		var assembly_path = System.IO.Path.GetDirectoryName (typeof (TestData).Assembly.Location);
+		var file = System.IO.Path.Combine (assembly_path!, "Assets", "2000px-test.png");
+		var surf = new ImageSurface (file);
+
+		return surf;
+	}
+}


### PR DESCRIPTION
Add a benchmark test suite based on `BenchmarkDotNet` to help inform future performance work.  Made a few modifications to ensure that performance sensitive classes we are profiling do not attempt to use `PintaCore`, which fails to initialize because we are not running in the full Pinta context.

Example data:

## CanvasRendererBenchmarks
|             Method |       Mean |     Error |     StdDev | Allocated |
|------------------- |-----------:|----------:|-----------:|----------:|
|     RenderOneToOne |   2.237 ms | 0.0264 ms |  0.0247 ms |     242 B |
| RenderManyOneToOne |  10.498 ms | 0.1357 ms |  0.1133 ms |     824 B |
|       RenderZoomIn |  40.482 ms | 0.7919 ms |  1.2094 ms |  28,384 B |
|   RenderManyZoomIn | 392.806 ms | 7.7580 ms | 20.7075 ms |  29,600 B |
|      RenderZoomOut |   8.614 ms | 0.1719 ms |  0.2465 ms |     272 B |
|  RenderManyZoomOut |  81.198 ms | 1.5619 ms |  1.5340 ms |   1,210 B |

## AdjustmentsBenchmarks

|                   Method |      Mean |     Error |    StdDev | Allocated |
|------------------------- |----------:|----------:|----------:|----------:|
|          AutoLevelEffect | 10.808 ms | 0.0446 ms | 0.0417 ms |  38,272 B |
|      BlackAndWhiteEffect |  4.174 ms | 0.0348 ms | 0.0326 ms |     100 B |
| BrightnessContrastEffect | 25.697 ms | 0.1338 ms | 0.1186 ms |  65,760 B |
|             CurvesEffect | 24.951 ms | 0.0989 ms | 0.0877 ms |   1,055 B |
|      HueSaturationEffect |  1.433 ms | 0.0286 ms | 0.0734 ms |     137 B |
|       InvertColorsEffect | 13.063 ms | 0.0566 ms | 0.0530 ms |     104 B |
|             LevelsEffect |  5.969 ms | 0.0224 ms | 0.0209 ms |  31,828 B |
|          PosterizeEffect |  5.911 ms | 0.0097 ms | 0.0076 ms |   1,116 B |
|              SepiaEffect | 10.337 ms | 0.0336 ms | 0.0314 ms |  31,888 B |

## EffectsBenchmarks
|                  Method |           Mean |      Error |     StdDev |  Gen 0 | Allocated |
|------------------------ |---------------:|-----------:|-----------:|-------:|----------:|
|          AddNoiseEffect |     72.4007 ms |  0.2340 ms |  0.2189 ms |      - |   1,782 B |
|             BulgeEffect |    112.4787 ms |  0.5340 ms |  0.4459 ms |      - |     854 B |
|        EdgeDetectEffect |    100.2455 ms |  0.4837 ms |  0.4525 ms |      - |   1,034 B |
|            EmbossEffect |     97.0405 ms |  0.2867 ms |  0.2541 ms |      - |     823 B |
|          FragmentEffect |     51.5395 ms |  0.1307 ms |  0.1159 ms |      - |     285 B |
|      FrostedGlassEffect |  2,211.9132 ms |  9.4710 ms |  8.3958 ms |      - |     864 B |
|      GaussianBlurEffect |    343.2805 ms |  0.6922 ms |  0.5780 ms |      - |     624 B |
|              GlowEffect |    809.3206 ms |  4.1138 ms |  3.8481 ms |      - |  68,608 B |
|         InkSketchEffect |  1,220.4223 ms |  5.3317 ms |  4.9873 ms |      - |  66,808 B |
|      JuliaFractalEffect |  2,368.4472 ms |  8.9078 ms |  8.3324 ms |      - |     800 B |
| MandelbrotFractalEffect | 21,537.9682 ms | 27.2776 ms | 25.5155 ms |      - |     816 B |
|            MedianEffect |  1,075.0979 ms |  5.9932 ms |  5.6060 ms |      - |   4,016 B |
|        MotionBlurEffect |  1,512.9423 ms |  6.9157 ms |  6.4690 ms |      - |   1,072 B |
|       OilPaintingEffect |  1,090.6768 ms |  4.6068 ms |  4.3092 ms |      - |     784 B |
|           OutlineEffect |  1,149.5528 ms |  5.1036 ms |  4.2617 ms |      - |   2,672 B |
|      PencilSketchEffect |    454.8726 ms |  2.3629 ms |  2.2103 ms |      - |  66,528 B |
|          PixelateEffect |    205.1557 ms |  0.9675 ms |  0.9050 ms |      - |   1,365 B |
|        RadialBlurEffect |  4,831.2495 ms | 14.5624 ms | 13.6217 ms |      - |   4,032 B |
|      RedEyeRemoveEffect |      0.0000 ms |  0.0000 ms |  0.0000 ms | 0.0062 |     104 B |
|            ReliefEffect |     76.2343 ms |  0.4159 ms |  0.3890 ms |      - |     815 B |
|           SharpenEffect |  1,020.6530 ms |  4.8440 ms |  4.5310 ms |      - |   1,720 B |
|    SoftenPortraitEffect |    472.7912 ms |  1.7758 ms |  1.5742 ms |      - |  77,280 B |
|              TileEffect |  1,962.5189 ms |  9.5011 ms |  7.9339 ms |      - |     792 B |
|             TwistEffect |    674.4668 ms |  6.7750 ms |  6.3373 ms |      - |     800 B |
|           UnfocusEffect |    831.7850 ms |  4.4885 ms |  4.1986 ms |      - |   4,016 B |
|          ZoomBlurEffect |    759.0730 ms |  3.4809 ms |  3.2561 ms |      - |     808 B |
