### PR TITLE
Cache a few things to speed up canvas rendering.

### DIFF
--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -19,12 +19,12 @@ namespace Pinta.Core
 	/// </summary>
 	public struct ScaleFactor
 	{
-		private int denominator;
-		private int numerator;
+		private readonly int denominator;
+		private readonly int numerator;
 
 		public int Denominator { get { return denominator; } }
 		public int Numerator { get { return numerator; } }
-		public double Ratio { get { return (double) numerator / (double) denominator; } }
+		public double Ratio { get; }
 
 		public static readonly ScaleFactor OneToOne = new ScaleFactor (1, 1);
 		public static readonly ScaleFactor MinValue = new ScaleFactor (1, 100);
@@ -369,6 +369,7 @@ namespace Pinta.Core
 
 			this.numerator = numerator;
 			this.denominator = denominator;
+			Ratio = (double) numerator / (double) denominator;
 			this.Clamp ();
 		}
 	}


### PR DESCRIPTION
Caching a few values and a scratch surface can give us some nice wins, particularly for rendering a zoomed in canvas.

## Original

|             Method |       Mean |     Error |    StdDev | Allocated |
|------------------- |-----------:|----------:|----------:|----------:|
|     RenderOneToOne |   2.159 ms | 0.0388 ms | 0.0363 ms |     242 B |
| RenderManyOneToOne |   9.597 ms | 0.1060 ms | 0.0940 ms |     824 B |
|       RenderZoomIn |  42.322 ms | 0.2513 ms | 0.2350 ms |  29,294 B |
|   RenderManyZoomIn | 404.774 ms | 3.2200 ms | 3.0120 ms |  29,600 B |
|      RenderZoomOut |   8.205 ms | 0.1055 ms | 0.0987 ms |     272 B |
|  RenderManyZoomOut |  76.499 ms | 0.7711 ms | 0.7213 ms |   1,574 B |

## PR

|             Method |       Mean |     Error |    StdDev | Allocated |
|------------------- |-----------:|----------:|----------:|----------:|
|     RenderOneToOne |   2.144 ms | 0.0155 ms | 0.0145 ms |     250 B |
| RenderManyOneToOne |   9.529 ms | 0.0866 ms | 0.0810 ms |     832 B |
|       RenderZoomIn |  22.584 ms | 0.1647 ms | 0.1460 ms |  28,358 B |
|   RenderManyZoomIn | 123.765 ms | 0.7484 ms | 0.7001 ms |  29,637 B |
|      RenderZoomOut |   8.179 ms | 0.0824 ms | 0.0771 ms |     280 B |
|  RenderManyZoomOut |  65.336 ms | 0.3871 ms | 0.3432 ms |     983 B |