### PR TITLE
Fix Ruler rendering issue.

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/Ruler.cs
+++ b/Pinta.Gui.Widgets/Widgets/Ruler.cs
@@ -247,10 +247,8 @@ namespace Pinta.Gui.Widgets
 							Pango.CairoHelper.ShowLayout (cr, layout);
 							break;
 						case Orientation.Vertical:
-							PangoContext.BaseGravity = Pango.Gravity.East;
-							PangoContext.GravityHint = Pango.GravityHint.Strong;
 							cr.Save ();
-							cr.MoveTo (border.Left + font_size, position + font_size / 2);
+							cr.MoveTo (border.Left + font_size * 1.5, position + font_size / 2);
 							cr.Rotate (0.5 * Math.PI);
 							Pango.CairoHelper.ShowLayout (cr, layout);
 							cr.Restore ();


### PR DESCRIPTION
Do you know what the intent behind these Gravity flags is?  Using one of them is fine, but when using both of them it causes the values to be written as squares.  (Win10)

This PR fixes this by removing the flags and moving the text into place, but it may not be the correct fix. 🤷‍♂️ 

![ruler](https://user-images.githubusercontent.com/179295/150650200-9f90d403-fef0-48ee-977f-7e1843ea2488.png)

