### PR TITLE
Added new cursor icon for tool move selected

### DIFF
--- a/Pinta.Resources/Icons.cs
+++ b/Pinta.Resources/Icons.cs
@@ -157,6 +157,7 @@ namespace Pinta.Resources
 		public const string ToolGradient = "tool-gradient-symbolic";
 		public const string ToolLine = "tool-line-symbolic";
 		public const string ToolMove = "tool-move-symbolic";
+		public const string ToolMoveCursor = "tool-move-cursor-symbolic";
 		public const string ToolMoveSelection = "tool-move-selection-symbolic";
 		public const string ToolPaintBrush = "tool-paintbrush-symbolic";
 		public const string ToolPaintBucket = "tool-paintbucket-symbolic";

--- a/Pinta.Resources/icons/hicolor/scalable/actions/tool-move-cursor-symbolic.svg
+++ b/Pinta.Resources/icons/hicolor/scalable/actions/tool-move-cursor-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg974"
+   sodipodi:docname="tool-move-cursor-symbolic.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs978" />
+  <sodipodi:namedview
+     id="namedview976"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="35.458333"
+     inkscape:cx="11.224442"
+     inkscape:cy="9.4477087"
+     inkscape:window-width="1920"
+     inkscape:window-height="1023"
+     inkscape:window-x="0"
+     inkscape:window-y="20"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg974" />
+  <path
+     id="path972"
+     style="stroke:#ffffff;stroke-opacity:1;stroke-linejoin:miter;stroke-width:0.601;stroke-miterlimit:4;stroke-dasharray:none;stroke-linecap:butt;paint-order:markers fill stroke"
+     d="M 12 1 L 7 6 L 10 6 L 10 9 L 14 9 L 14 6 L 17 6 L 12 1 z M 6 7 L 1 12 L 6 17 L 6 14 L 9 14 L 9 10 L 6 10 L 6 7 z M 18 7 L 18 10 L 15 10 L 15 14 L 18 14 L 18 17 L 23 12 L 18 7 z M 10 15 L 10 18 L 7 18 L 12 23 L 17 18 L 14 18 L 14 15 L 10 15 z " />
+</svg>

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -44,7 +44,7 @@ namespace Pinta.Tools
 		public override string Icon => Pinta.Resources.Icons.ToolMove;
 		// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
 		public override string StatusBarText => Translations.GetString ("Left click and drag the selection to move selected content. Hold {0} to scale instead of move. Right click and drag the selection to rotate selected content. Hold Shift to rotate in steps. Use arrow keys to move selected content by a single pixel.", GtkExtensions.CtrlLabel ());
-		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Gtk.IconTheme.Default.LoadIcon (Pinta.Resources.Icons.ToolMove, 16), 0, 0);
+		public override Gdk.Cursor DefaultCursor => new Gdk.Cursor (Gdk.Display.Default, Gtk.IconTheme.Default.LoadIcon (Pinta.Resources.Icons.ToolMoveCursor, 16), 0, 0);
 		public override Gdk.Key ShortcutKey => Gdk.Key.M;
 		public override int Priority => 5;
 


### PR DESCRIPTION
This PR fixes that the "Move Selected Pixels" tool had a cursor that was not visible on a dark background. 

In #204 amazing icons where added, however the new cursor for the tool "Move Selected Items" (Pinta.Resources/icons/hicolor/scalable/actions/tool-move-symbolic.svg) only contains the color black. This means it is not visible against a dark background.
This PR fixes that by adding a white stroke to the svg. 
A new file has been made specifically for the cursor because otherwise the toolbar icon wouldn't look nice.

![new_cursor](https://user-images.githubusercontent.com/23642000/150660923-bf40f587-a829-49be-b08a-17938117dd34.png)![new_cursor_zoomed](https://user-images.githubusercontent.com/23642000/150660927-2d48e38e-ee54-4bc3-b3b4-2d28ec132a0a.png)
<sub>The new cursor up close</sub>



https://user-images.githubusercontent.com/23642000/150661125-dff1fa47-2282-4dd4-88fa-809e8acffab8.mp4


