### PR TITLE
Use GFile for file manipulation 

### DIFF
--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -428,7 +428,7 @@ namespace Pinta.Core
 				string extension = System.IO.Path.GetExtension (basename);
 				if (string.IsNullOrEmpty (extension)) {
 					var currentFormat = PintaCore.System.PaletteFormats.Formats.First (f => f.Filter == fcd.Filter);
-					basename = fcd.CurrentName + "." + currentFormat.Extensions.First ();
+					basename += "." + currentFormat.Extensions.First ();
 					file = file.Parent.GetChild (basename);
 				}
 

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -168,7 +168,7 @@ namespace Pinta.Core
 				Translations.GetString ("Open"),
 				Translations.GetString ("Cancel"));
 
-			fcd.SetCurrentFolder (PintaCore.System.GetDialogDirectory ());
+			fcd.SetCurrentFolderFile (PintaCore.System.GetDialogDirectory ());
 
 			// Add image files filter
 			var ff = new FileFilter ();
@@ -187,7 +187,7 @@ namespace Pinta.Core
 
 				string file = fcd.Filename;
 
-				string? directory = Path.GetDirectoryName (file);
+				GLib.IFile? directory = fcd.File.Parent;
 				if (directory is not null)
 					PintaCore.System.LastDialogDirectory = directory;
 

--- a/Pinta.Core/Actions/WindowActions.cs
+++ b/Pinta.Core/Actions/WindowActions.cs
@@ -99,7 +99,7 @@ namespace Pinta.Core
 		{
 			var doc = PintaCore.Workspace.OpenDocuments[idx];
 			var action_id = string.Format ("app.{0}({1})", doc_action_id, idx);
-			var label = string.Format ("{0}{1}", doc.Filename, doc.IsDirty ? "*" : string.Empty);
+			var label = string.Format ("{0}{1}", doc.DisplayName, doc.IsDirty ? "*" : string.Empty);
 			var menu_item = new GLib.MenuItem (label, action_id);
 			doc_section.AppendItem (menu_item);
 

--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -90,13 +90,6 @@ namespace Pinta.Core
 			return p;
 		}
 
-		public static Palette FromFile (string fileName)
-		{
-			Palette p = new Palette ();
-			p.Load (fileName);
-			return p;
-		}
-
 		public void LoadDefault ()
 		{
 			colors.Clear ();
@@ -156,26 +149,26 @@ namespace Pinta.Core
 			OnPaletteChanged ();
 		}
 
-		public void Load (string fileName)
+		public void Load (GLib.IFile file)
 		{
 			try {
-				var loader = PintaCore.System.PaletteFormats.GetFormatByFilename (fileName)?.Loader;
+				var loader = PintaCore.System.PaletteFormats.GetFormatByFilename (file.GetDisplayName ())?.Loader;
 
 				if (loader == null)
 					throw new FormatException ();
 
-				colors = loader.Load (fileName);
+				colors = loader.Load (file);
 				colors.TrimExcess ();
 				OnPaletteChanged ();
 			} catch (FormatException e) {
 				var parent = PintaCore.Chrome.MainWindow;
-				ShowUnsupportedFormatDialog (parent, fileName, "Unsupported palette format", e.ToString ());
+				ShowUnsupportedFormatDialog (parent, file.Uri.ToString (), "Unsupported palette format", e.ToString ());
 			}
 		}
 
-		public void Save (string fileName, IPaletteSaver saver)
+		public void Save (GLib.IFile file, IPaletteSaver saver)
 		{
-			saver.Save (colors, fileName);
+			saver.Save (colors, file);
 		}
 
 		private void ShowUnsupportedFormatDialog (Window parent, string filename, string primaryText, string details)

--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -162,7 +162,7 @@ namespace Pinta.Core
 				OnPaletteChanged ();
 			} catch (FormatException e) {
 				var parent = PintaCore.Chrome.MainWindow;
-				ShowUnsupportedFormatDialog (parent, file.Uri.ToString (), "Unsupported palette format", e.ToString ());
+				ShowUnsupportedFormatDialog (parent, file.ParsedName, "Unsupported palette format", e.ToString ());
 			}
 		}
 

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -674,7 +674,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns a new point, rounded to the nearest integer coordinates.
 		/// </summary>
-		public static PointD Rounded(this PointD p)
+		public static PointD Rounded (this PointD p)
 		{
 			return new PointD (Math.Round (p.X), Math.Round (p.Y));
 		}

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -273,11 +273,19 @@ namespace Pinta.Core
 		/// Return the display name for the file. Note that this can be very different from file.Basename,
 		/// and should only be used for display purposes rather than identifying the file.
 		/// </summary>
-		public static string GetDisplayName(this GLib.IFile file)
+		public static string GetDisplayName (this GLib.IFile file)
 		{
 			// TODO-GTK4: use G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME if there are bindings for it.
 			var info = file.QueryInfo ("standard::display-name", GLib.FileQueryInfoFlags.None, cancellable: null);
 			return info.DisplayName;
+		}
+
+		/// <summary>
+		/// Returns an output stream for overwriting the file, safely replacing the original file
+		/// if errors occur while writing.
+		public static GLib.OutputStream Replace (this GLib.IFile file)
+		{
+			return file.Replace (null, true, GLib.FileCreateFlags.None, null);
 		}
 	}
 }

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -281,11 +281,12 @@ namespace Pinta.Core
 		}
 
 		/// <summary>
-		/// Returns an output stream for overwriting the file, safely replacing the original file
-		/// if errors occur while writing.
+		/// Returns an output stream for creating or overwriting the file.
+		/// NOTE: if you don't wrap this in a GLib.GioStream, you must call Close() !
+		/// </summary>
 		public static GLib.OutputStream Replace (this GLib.IFile file)
 		{
-			return file.Replace (null, true, GLib.FileCreateFlags.None, null);
+			return file.Replace (null, false, GLib.FileCreateFlags.None, null);
 		}
 	}
 }

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -268,5 +268,16 @@ namespace Pinta.Core
 			Accelerator.Parse ("<Alt>", out var key, out var mods);
 			return Accelerator.GetLabel (key, mods);
 		}
+
+		/// <summary>
+		/// Return the display name for the file. Note that this can be very different from file.Basename,
+		/// and should only be used for display purposes rather than identifying the file.
+		/// </summary>
+		public static string GetDisplayName(this GLib.IFile file)
+		{
+			// TODO-GTK4: use G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME if there are bindings for it.
+			var info = file.QueryInfo ("standard::display-name", GLib.FileQueryInfoFlags.None, cancellable: null);
+			return info.DisplayName;
+		}
 	}
 }

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -43,24 +43,24 @@ namespace Pinta.Core
 
 		#region IImageImporter implementation
 
-		public void Import (string fileName, Gtk.Window parent)
+		public void Import (GLib.IFile file, Gtk.Window parent)
 		{
 			Pixbuf bg;
 
 			// Handle any EXIF orientation flags
-			using (var fs = new FileStream (fileName, FileMode.Open, FileAccess.Read))
-				bg = new Pixbuf (fs);
+			using (var fs = file.Read (cancellable: null))
+				bg = new Pixbuf (fs, cancellable: null);
 
 			bg = bg.ApplyEmbeddedOrientation ();
 
 			Size imagesize = new Size (bg.Width, bg.Height);
 
-			Document doc = PintaCore.Workspace.CreateAndActivateDocument (fileName, imagesize);
+			Document doc = PintaCore.Workspace.CreateAndActivateDocument (file.Path, imagesize); // FIXME - store GLib.IFile 
 			doc.HasFile = true;
 			doc.ImageSize = imagesize;
 			doc.Workspace.CanvasSize = imagesize;
 
-			Layer layer = doc.Layers.AddNewLayer (Path.GetFileName (fileName));
+			Layer layer = doc.Layers.AddNewLayer (file.GetDisplayName ());
 
 			using (Cairo.Context g = new Cairo.Context (layer.Surface)) {
 				CairoHelper.SetSourcePixbuf (g, bg, 0, 0);

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -55,8 +55,7 @@ namespace Pinta.Core
 
 			Size imagesize = new Size (bg.Width, bg.Height);
 
-			Document doc = PintaCore.Workspace.CreateAndActivateDocument (file.Path, imagesize); // FIXME - store GLib.IFile 
-			doc.HasFile = true;
+			Document doc = PintaCore.Workspace.CreateAndActivateDocument (file, imagesize);
 			doc.ImageSize = imagesize;
 			doc.Workspace.CanvasSize = imagesize;
 
@@ -94,91 +93,19 @@ namespace Pinta.Core
 
 		#endregion
 
-		protected virtual void DoSave (Pixbuf pb, string fileName, string fileType, Gtk.Window parent)
+		protected virtual void DoSave (Pixbuf pb, GLib.IFile file, string fileType, Gtk.Window parent)
 		{
-			pb.SaveUtf8 (fileName, fileType);
+			using var stream = file.Replace ();
+			// TODO-GTK4: the simpler SaveToStream() seems to be missing in GtkSharp.
+			pb.SaveToStreamv (stream, fileType, null, null, null);
 		}
 
-		public void Export (Document document, string fileName, Gtk.Window parent)
+		public void Export (Document document, GLib.IFile file, Gtk.Window parent)
 		{
-			Cairo.ImageSurface surf = document.GetFlattenedImage ();
+			using var surf = document.GetFlattenedImage ();
 
-			Pixbuf pb = surf.ToPixbuf ();
-			DoSave (pb, fileName, filetype, parent);
-
-			(pb as IDisposable).Dispose ();
-			(surf as IDisposable).Dispose ();
-		}
-	}
-
-	/// <summary>
-	/// Contains bindings for gdk_pixbuf_save_utf8 and gdk_pixbuf_savev_utf8, which are not exposed by gtk-sharp.
-	/// </summary>
-	internal static class PixbufExtensions
-	{
-		[DllImport ("libgdk_pixbuf-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		private static extern bool gdk_pixbuf_save_utf8 (IntPtr raw, IntPtr filename, IntPtr type, out IntPtr error, IntPtr dummy);
-
-		public static bool SaveUtf8 (this Pixbuf pb, string filename, string type)
-		{
-			if (PintaCore.System.OperatingSystem == OS.Windows) {
-				IntPtr error = IntPtr.Zero;
-				IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup (filename);
-				IntPtr native_type = GLib.Marshaller.StringToPtrGStrdup (type);
-				bool result = gdk_pixbuf_save_utf8 (pb.Handle, native_filename, native_type, out error, IntPtr.Zero);
-				GLib.Marshaller.Free (native_filename);
-				GLib.Marshaller.Free (native_type);
-				if (error != IntPtr.Zero) {
-					throw new GLib.GException (error);
-				}
-				return result;
-			} else {
-				return pb.Save (filename, type);
-			}
-		}
-
-		[DllImport ("libgdk_pixbuf-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
-		private static extern bool gdk_pixbuf_savev_utf8 (IntPtr raw, IntPtr filename, IntPtr type, IntPtr[] option_keys, IntPtr[] option_values, out IntPtr error);
-
-		public static bool SavevUtf8 (this Pixbuf pb, string filename, string type, string?[]? option_keys, string?[]? option_values)
-		{
-			if (PintaCore.System.OperatingSystem == OS.Windows) {
-				IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup (filename);
-				IntPtr native_type = GLib.Marshaller.StringToPtrGStrdup (type);
-
-				int num = (option_keys == null) ? 0 : option_keys.Length;
-				IntPtr[] native_keys = new IntPtr[num];
-				for (int i = 0; i < num; i++) {
-					native_keys[i] = GLib.Marshaller.StringToPtrGStrdup (option_keys![i]); // NRT - num is null-checked length of option_keys
-				}
-
-				int num2 = (option_values == null) ? 0 : option_values.Length;
-				IntPtr[] native_values = new IntPtr[num2];
-				for (int j = 0; j < num2; j++) {
-					native_values[j] = GLib.Marshaller.StringToPtrGStrdup (option_values![j]); // NRT - num2 is null-checked length of option_values
-				}
-
-				IntPtr error = IntPtr.Zero;
-				bool result = gdk_pixbuf_savev_utf8 (pb.Handle, native_filename, native_type, native_keys, native_values, out error);
-
-				GLib.Marshaller.Free (native_filename);
-				GLib.Marshaller.Free (native_type);
-				ReleaseArray (native_keys);
-				ReleaseArray (native_values);
-
-				if (error != IntPtr.Zero) {
-					throw new GLib.GException (error);
-				}
-				return result;
-			} else {
-				return pb.Savev (filename, type, option_keys, option_values);
-			}
-		}
-
-		private static void ReleaseArray (IntPtr[] arr)
-		{
-			foreach (IntPtr p in arr)
-				GLib.Marshaller.Free (p);
+			using Pixbuf pb = surf.ToPixbuf ();
+			DoSave (pb, file, filetype, parent);
 		}
 	}
 }

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -48,8 +48,13 @@ namespace Pinta.Core
 			Pixbuf bg;
 
 			// Handle any EXIF orientation flags
-			using (var fs = file.Read (cancellable: null))
-				bg = new Pixbuf (fs, cancellable: null);
+			using (var fs = file.Read (cancellable: null)) {
+				try {
+					bg = new Pixbuf (fs, cancellable: null);
+				} finally {
+					fs.Close (null);
+				}
+			}
 
 			bg = bg.ApplyEmbeddedOrientation ();
 
@@ -96,8 +101,12 @@ namespace Pinta.Core
 		protected virtual void DoSave (Pixbuf pb, GLib.IFile file, string fileType, Gtk.Window parent)
 		{
 			using var stream = file.Replace ();
-			// TODO-GTK4: the simpler SaveToStream() seems to be missing in GtkSharp.
-			pb.SaveToStreamv (stream, fileType, null, null, null);
+			try {
+				// TODO-GTK4: the simpler SaveToStream() seems to be missing in GtkSharp.
+				pb.SaveToStreamv (stream, fileType, null, null, null);
+			} finally {
+				stream.Close (null);
+			}
 		}
 
 		public void Export (Document document, GLib.IFile file, Gtk.Window parent)

--- a/Pinta.Core/ImageFormats/IImageExporter.cs
+++ b/Pinta.Core/ImageFormats/IImageExporter.cs
@@ -38,12 +38,12 @@ namespace Pinta.Core
 		/// <param name='document'>
 		/// The document to be saved.
 		/// </param>
-		/// <param name='fileName'>
-		/// File name to save to.
+		/// <param name='file'>
+		/// File identifier to save to.
 		/// </param>
 		/// <param name='parent'>
 		/// Window to be used as a parent for any dialogs that are shown.
 		/// </param>
-		void Export (Document document, string fileName, Gtk.Window parent);
+		void Export (Document document, GLib.IFile file, Gtk.Window parent);
 	}
 }

--- a/Pinta.Core/ImageFormats/IImageImporter.cs
+++ b/Pinta.Core/ImageFormats/IImageImporter.cs
@@ -35,11 +35,11 @@ namespace Pinta.Core
 		/// <summary>
 		/// Imports a document into Pinta.
 		/// </summary>
-		/// <param name='filename'>The name of the file to be imported.</param>
+		/// <param name='file'>The identifier of the file to be imported.</param>
 		/// <param name='parent'>
 		/// Window to be used as a parent for any dialogs that are shown.
 		/// </param>
-		void Import (string filename, Gtk.Window parent);
+		void Import (GLib.IFile file, Gtk.Window parent);
 
 		/// <summary>
 		/// Returns a thumbnail of an image.

--- a/Pinta.Core/ImageFormats/JpegFormat.cs
+++ b/Pinta.Core/ImageFormats/JpegFormat.cs
@@ -64,13 +64,14 @@ namespace Pinta.Core
 			//Store the "previous" JPG compression quality value (before saving with it).
 			PintaCore.Settings.PutSetting (JpgCompressionQualitySetting, level);
 
-			// FIXME - SaveToStreamv() isn't wrapped correctly by GtkSharp, so the quality setting is skipped for now...
 			using var stream = file.Replace ();
-			pb.SaveToStreamv (stream, fileType, null, null, null);
-#if false
-			pb.SavevUtf8 (fileName, fileType, new string?[] { "quality", null }, new string?[] { level.ToString (), null });
-#else
-#endif
+			try {
+				// FIXME - SaveToStreamv() isn't wrapped correctly by GtkSharp, so the quality setting is skipped for now...
+				pb.SaveToStreamv (stream, fileType, null, null, null);
+				//pb.SavevUtf8 (fileName, fileType, new string?[] { "quality", null }, new string?[] { level.ToString (), null });
+			} finally {
+				stream.Close (null);
+			}
 		}
 	}
 }

--- a/Pinta.Core/ImageFormats/JpegFormat.cs
+++ b/Pinta.Core/ImageFormats/JpegFormat.cs
@@ -46,7 +46,7 @@ namespace Pinta.Core
 		{
 		}
 
-		protected override void DoSave (Pixbuf pb, string fileName, string fileType, Gtk.Window parent)
+		protected override void DoSave (Pixbuf pb, GLib.IFile file, string fileType, Gtk.Window parent)
 		{
 			//Load the JPG compression quality, but use the default value if there is no saved value.
 			int level = PintaCore.Settings.GetSetting<int> (JpgCompressionQualitySetting, defaultQuality);
@@ -64,8 +64,13 @@ namespace Pinta.Core
 			//Store the "previous" JPG compression quality value (before saving with it).
 			PintaCore.Settings.PutSetting (JpgCompressionQualitySetting, level);
 
-			//Save the file.
+			// FIXME - SaveToStreamv() isn't wrapped correctly by GtkSharp, so the quality setting is skipped for now...
+			using var stream = file.Replace ();
+			pb.SaveToStreamv (stream, fileType, null, null, null);
+#if false
 			pb.SavevUtf8 (fileName, fileType, new string?[] { "quality", null }, new string?[] { level.ToString (), null });
+#else
+#endif
 		}
 	}
 }

--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -148,7 +148,7 @@ namespace Pinta.Core
 			var palette_file = System.IO.Path.Combine (PintaCore.Settings.GetUserSettingsDirectory (), PALETTE_FILE);
 
 			if (System.IO.File.Exists (palette_file))
-				CurrentPalette.Load (palette_file);
+				CurrentPalette.Load (GLib.FileFactory.NewForPath (palette_file));
 		}
 
 		private void PopulateRecentlyUsedColors ()
@@ -181,7 +181,7 @@ namespace Pinta.Core
 			var palette_saver = PintaCore.System.PaletteFormats.Formats.FirstOrDefault (p => p.Extensions.Contains ("txt"))?.Saver;
 
 			if (palette_saver is not null)
-				CurrentPalette.Save (palette_file, palette_saver);
+				CurrentPalette.Save (GLib.FileFactory.NewForPath (palette_file), palette_saver);
 		}
 
 		private void SaveRecentlyUsedColors ()

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -38,7 +38,7 @@ namespace Pinta.Core
 	{
 		private static OS operating_system;
 
-		private string last_dialog_directory;
+		private GLib.IFile last_dialog_directory;
 		private RecentData recent_data;
 
 		public ImageConverterManager ImageFormats { get; private set; }
@@ -74,7 +74,7 @@ namespace Pinta.Core
 		}
 
 		#region Public Properties
-		public string LastDialogDirectory {
+		public GLib.IFile LastDialogDirectory {
 			get { return last_dialog_directory; }
 			set {
 				// The file chooser dialog may return null for the current folder in certain cases,
@@ -84,8 +84,8 @@ namespace Pinta.Core
 			}
 		}
 
-		public string DefaultDialogDirectory {
-			get { return System.Environment.GetFolderPath (Environment.SpecialFolder.MyPictures); }
+		public GLib.IFile DefaultDialogDirectory {
+			get { return GLib.FileFactory.NewForPath (System.Environment.GetFolderPath (Environment.SpecialFolder.MyPictures)); }
 		}
 
 		public RecentData RecentData { get { return recent_data; } }
@@ -95,9 +95,9 @@ namespace Pinta.Core
 		/// Returns a directory for use in a dialog. The last dialog directory is
 		/// returned if it exists, otherwise the default directory is used.
 		/// </summary>
-		public string GetDialogDirectory ()
+		public GLib.IFile GetDialogDirectory ()
 		{
-			return Directory.Exists (LastDialogDirectory) ? LastDialogDirectory : DefaultDialogDirectory;
+			return last_dialog_directory.Exists ? last_dialog_directory : DefaultDialogDirectory;
 		}
 
 		public static string GetExecutablePathName ()

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -211,7 +211,7 @@ namespace Pinta.Core
 		}
 
 		// TODO: Standardize add to recent files
-		public bool OpenFile (string file, Window? parent = null)
+		public bool OpenFile (GLib.IFile file, Window? parent = null)
 		{
 			bool fileOpened = false;
 
@@ -220,13 +220,13 @@ namespace Pinta.Core
 
 			try {
 				// Open the image and add it to the layers
-				IImageImporter? importer = PintaCore.System.ImageFormats.GetImporterByFile (file);
+				IImageImporter? importer = PintaCore.System.ImageFormats.GetImporterByFile (file.GetDisplayName ());
 				if (importer == null)
 					throw new FormatException (Translations.GetString ("Unsupported file format"));
 
 				importer.Import (file, parent);
 
-				PintaCore.Workspace.ActiveDocument.PathAndFileName = file;
+				PintaCore.Workspace.ActiveDocument.PathAndFileName = file.Path; // FIXME - store GLib.IFile 
 				PintaCore.Workspace.ActiveWorkspace.History.PushNewItem (new BaseHistoryItem (Resources.StandardIcons.DocumentOpen, Translations.GetString ("Open Image")));
 				PintaCore.Workspace.ActiveDocument.History.SetClean ();
 				PintaCore.Workspace.ActiveDocument.HasFile = true;
@@ -240,11 +240,11 @@ namespace Pinta.Core
 
 				fileOpened = true;
 			} catch (UnauthorizedAccessException) {
-				ShowFilePermissionErrorDialog (parent, file);
+				ShowFilePermissionErrorDialog (parent, file.Uri.ToString ());
 			} catch (FormatException e) {
-				ShowUnsupportedFormatDialog (parent, file, e.Message, e.ToString ());
+				ShowUnsupportedFormatDialog (parent, file.Uri.ToString (), e.Message, e.ToString ());
 			} catch (Exception e) {
-				ShowOpenFileErrorDialog (parent, file, e.Message, e.ToString ());
+				ShowOpenFileErrorDialog (parent, file.Uri.ToString (), e.Message, e.ToString ());
 			}
 
 			return fileOpened;

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -238,11 +238,11 @@ namespace Pinta.Core
 
 				fileOpened = true;
 			} catch (UnauthorizedAccessException) {
-				ShowFilePermissionErrorDialog (parent, file.Uri.ToString ());
+				ShowFilePermissionErrorDialog (parent, file.ParsedName);
 			} catch (FormatException e) {
-				ShowUnsupportedFormatDialog (parent, file.Uri.ToString (), e.Message, e.ToString ());
+				ShowUnsupportedFormatDialog (parent, file.ParsedName, e.Message, e.ToString ());
 			} catch (Exception e) {
-				ShowOpenFileErrorDialog (parent, file.Uri.ToString (), e.Message, e.ToString ());
+				ShowOpenFileErrorDialog (parent, file.ParsedName, e.Message, e.ToString ());
 			}
 
 			return fileOpened;

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -104,14 +104,14 @@ namespace Pinta.Core
 		public List<Document> OpenDocuments { get; private set; }
 		public bool HasOpenDocuments { get { return OpenDocuments.Count > 0; } }
 
-		public Document CreateAndActivateDocument (string? filename, Gdk.Size size)
+		public Document CreateAndActivateDocument (GLib.IFile? file, Gdk.Size size)
 		{
 			Document doc = new Document (size);
 
-			if (string.IsNullOrEmpty (filename))
-				doc.Filename = string.Format (Translations.GetString ("Unsaved Image {0}"), new_file_name++);
+			if (file is not null)
+				doc.File = file;
 			else
-				doc.PathAndFileName = filename;
+				doc.DisplayName = Translations.GetString ("Unsaved Image {0}", new_file_name++);
 
 			OpenDocuments.Add (doc);
 			OnDocumentCreated (new DocumentEventArgs (doc));
@@ -226,10 +226,8 @@ namespace Pinta.Core
 
 				importer.Import (file, parent);
 
-				PintaCore.Workspace.ActiveDocument.PathAndFileName = file.Path; // FIXME - store GLib.IFile 
 				PintaCore.Workspace.ActiveWorkspace.History.PushNewItem (new BaseHistoryItem (Resources.StandardIcons.DocumentOpen, Translations.GetString ("Open Image")));
 				PintaCore.Workspace.ActiveDocument.History.SetClean ();
-				PintaCore.Workspace.ActiveDocument.HasFile = true;
 
 				// This ensures these are called after the window is done being created and sized.
 				// Without it, we sometimes try to zoom when the window has a size of (0, 0).
@@ -302,7 +300,7 @@ namespace Pinta.Core
 		internal void ResetTitle ()
 		{
 			if (HasOpenDocuments)
-				PintaCore.Chrome.MainWindow.Title = string.Format ("{0}{1} - Pinta", ActiveDocument.Filename, ActiveDocument.IsDirty ? "*" : "");
+				PintaCore.Chrome.MainWindow.Title = string.Format ("{0}{1} - Pinta", ActiveDocument.DisplayName, ActiveDocument.IsDirty ? "*" : "");
 			else
 				PintaCore.Chrome.MainWindow.Title = "Pinta";
 		}

--- a/Pinta.Core/PaletteFormats/GimpPalette.cs
+++ b/Pinta.Core/PaletteFormats/GimpPalette.cs
@@ -35,10 +35,11 @@ namespace Pinta.Core
 {
 	public class GimpPalette : IPaletteLoader, IPaletteSaver
 	{
-		public List<Color> Load (string fileName)
+		public List<Color> Load (GLib.IFile file)
 		{
 			List<Color> colors = new List<Color> ();
-			StreamReader reader = new StreamReader (fileName);
+			using var stream = new GLib.GioStream (file.Read (null));
+			StreamReader reader = new StreamReader (stream);
 			string? line = reader.ReadLine ();
 
 			if (line is null || !line.StartsWith ("GIMP"))
@@ -63,9 +64,10 @@ namespace Pinta.Core
 			return colors;
 		}
 
-		public void Save (List<Color> colors, string fileName)
+		public void Save (List<Color> colors, GLib.IFile file)
 		{
-			StreamWriter writer = new StreamWriter (fileName);
+			using var stream = new GLib.GioStream (file.Replace ());
+			StreamWriter writer = new StreamWriter (stream);
 			writer.WriteLine ("GIMP Palette");
 			writer.WriteLine ("Name: Pinta Created {0}", DateTime.Now.ToString (DateTimeFormatInfo.InvariantInfo.RFC1123Pattern));
 			writer.WriteLine ("#");

--- a/Pinta.Core/PaletteFormats/IPaletteLoader.cs
+++ b/Pinta.Core/PaletteFormats/IPaletteLoader.cs
@@ -34,6 +34,6 @@ namespace Pinta.Core
 	// [TypeExtensionPoint]
 	public interface IPaletteLoader
 	{
-		List<Color> Load (string fileName);
+		List<Color> Load (GLib.IFile file);
 	}
 }

--- a/Pinta.Core/PaletteFormats/IPaletteSaver.cs
+++ b/Pinta.Core/PaletteFormats/IPaletteSaver.cs
@@ -34,6 +34,6 @@ namespace Pinta.Core
 	// [TypeExtensionPoint]
 	public interface IPaletteSaver
 	{
-		void Save (List<Color> colors, string fileName);
+		void Save (List<Color> colors, GLib.IFile file);
 	}
 }

--- a/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
@@ -35,10 +35,11 @@ namespace Pinta.Core
 {
 	public class PaintDotNetPalette : IPaletteLoader, IPaletteSaver
 	{
-		public List<Color> Load (string fileName)
+		public List<Color> Load (GLib.IFile file)
 		{
 			List<Color> colors = new List<Color> ();
-			StreamReader reader = new StreamReader (fileName);
+			using var stream = new GLib.GioStream (file.Read (null));
+			StreamReader reader = new StreamReader (stream);
 
 			try {
 				string? line = reader.ReadLine ();
@@ -60,9 +61,10 @@ namespace Pinta.Core
 			}
 		}
 
-		public void Save (List<Color> colors, string fileName)
+		public void Save (List<Color> colors, GLib.IFile file)
 		{
-			StreamWriter writer = new StreamWriter (fileName);
+			using var stream = new GLib.GioStream (file.Replace ());
+			StreamWriter writer = new StreamWriter (stream);
 			writer.WriteLine ("; Hexadecimal format: aarrggbb");
 
 			foreach (Color color in colors) {

--- a/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
@@ -34,12 +34,13 @@ namespace Pinta.Core
 {
 	public class PaintShopProPalette : IPaletteLoader, IPaletteSaver
 	{
-		public List<Color> Load (string fileName)
+		public List<Color> Load (GLib.IFile file)
 		{
 			List<Color> colors = new List<Color> ();
-			StreamReader reader = new StreamReader (fileName);
-			string? line = reader.ReadLine ();
+			using var stream = new GLib.GioStream (file.Read (null));
+			StreamReader reader = new StreamReader (stream);
 
+			string? line = reader.ReadLine ();
 			if (line is null || !line.StartsWith ("JASC-PAL"))
 				throw new InvalidDataException ("Not a valid PaintShopPro palette file.");
 
@@ -64,9 +65,10 @@ namespace Pinta.Core
 			return colors;
 		}
 
-		public void Save (List<Color> colors, string fileName)
+		public void Save (List<Color> colors, GLib.IFile file)
 		{
-			StreamWriter writer = new StreamWriter (fileName);
+			using var stream = new GLib.GioStream (file.Replace ());
+			StreamWriter writer = new StreamWriter (stream);
 			writer.WriteLine ("JASC-PAL");
 			writer.WriteLine ("0100");
 			writer.WriteLine (colors.Count.ToString ());

--- a/Pinta/Actions/File/CloseDocumentAction.cs
+++ b/Pinta/Actions/File/CloseDocumentAction.cs
@@ -63,7 +63,7 @@ namespace Pinta.Actions
 
 			using var md = new MessageDialog (PintaCore.Chrome.MainWindow, DialogFlags.Modal,
 						    MessageType.Question, ButtonsType.None, true,
-						    message, System.IO.Path.GetFileName (PintaCore.Workspace.ActiveDocument.Filename));
+						    message, PintaCore.Workspace.ActiveDocument.DisplayName);
 
 			// Use the standard button order for each OS.
 			Widget closeButton;

--- a/Pinta/Actions/File/OpenDocumentAction.cs
+++ b/Pinta/Actions/File/OpenDocumentAction.cs
@@ -73,21 +73,23 @@ namespace Pinta.Actions
 			ff2.AddPattern ("*.*");
 			fcd.AddFilter (ff2);
 
-			fcd.SetCurrentFolder (PintaCore.System.GetDialogDirectory ());
+			fcd.SetCurrentFolderFile (PintaCore.System.GetDialogDirectory ());
 			fcd.SelectMultiple = true;
+			fcd.LocalOnly = false;
 
 			var response = (ResponseType) fcd.Run ();
 
 			if (response == ResponseType.Accept) {
-				PintaCore.System.LastDialogDirectory = fcd.CurrentFolder;
+				PintaCore.System.LastDialogDirectory = fcd.CurrentFolderFile;
 
-				foreach (var file in fcd.Filenames) {
+				foreach (var file in fcd.Files) {
 					if (PintaCore.Workspace.OpenFile (file)) {
-						RecentManager.Default.AddFull (fcd.Uri, PintaCore.System.RecentData);
+						RecentManager.Default.AddFull (file.Uri.ToString (), PintaCore.System.RecentData);
 
-						var directory = System.IO.Path.GetDirectoryName (file);
-						if (directory is not null)
+						var directory = file.Parent;
+						if (directory is not null) {
 							PintaCore.System.LastDialogDirectory = directory;
+						}
 					}
 				}
 			}

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -74,7 +74,8 @@ namespace Pinta.Actions
 				FileChooserAction.Save,
 				Translations.GetString ("Save"),
 				Translations.GetString ("Cancel")) {
-				DoOverwriteConfirmation = true
+				DoOverwriteConfirmation = true,
+				LocalOnly = false
 			};
 
 			fcd.SetCurrentFolderFile (PintaCore.System.GetDialogDirectory ());

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -77,7 +77,7 @@ namespace Pinta.Actions
 				DoOverwriteConfirmation = true
 			};
 
-			fcd.SetCurrentFolder (PintaCore.System.GetDialogDirectory ());
+			fcd.SetCurrentFolderFile (PintaCore.System.GetDialogDirectory ());
 
 			if (document.HasFile)
 				fcd.SetFilename (document.PathAndFileName);
@@ -149,7 +149,7 @@ namespace Pinta.Actions
 				if (format_type != null)
 					format = format_type;
 
-				var directory = System.IO.Path.GetDirectoryName (file);
+				var directory = fcd.File.Parent;
 				if (directory is not null)
 					PintaCore.System.LastDialogDirectory = directory;
 

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -112,8 +112,9 @@ namespace Pinta.Actions
 				// Gtk doesn't like it if we set the file name to an extension that we don't have
 				// a filter for, so we change the extension to our default extension.
 				if (document.HasFile) {
-					// FIXME - this may not be correct for GLib.IFile.
-					fcd.SetFile (GLib.FileFactory.NewForPath (Path.ChangeExtension (document.File!.Path.ToString (), format_desc.Extensions[0])));
+					var file = document.File!;
+					var basename = file.Parent.GetRelativePath (file);
+					fcd.SetFile (file.Parent.GetChild (Path.ChangeExtension (basename, format_desc.Extensions[0])));
 				}
 			}
 
@@ -134,12 +135,11 @@ namespace Pinta.Actions
 				var file = fcd.File;
 
 				// Note that we can't use file.GetDisplayName() because the file doesn't exist.
-				var display_name = fcd.CurrentFolderFile.GetRelativePath (file);
-				if (!string.IsNullOrEmpty(Path.GetExtension(display_name))) {
+				var display_name = file.Parent.GetRelativePath (file);
+				if (string.IsNullOrEmpty(Path.GetExtension(display_name))) {
 					// No extension; add one from the format descriptor.
 					display_name = string.Format ("{0}.{1}", display_name, format.Extensions[0]);
-					fcd.CurrentName = display_name;
-					file = fcd.File;
+					file = file.Parent.GetChild (display_name);
 
 					// We also need to display an overwrite confirmation message manually,
 					// because MessageDialog won't do this for us in this case.

--- a/Pinta/DocumentViewContent.cs
+++ b/Pinta/DocumentViewContent.cs
@@ -47,7 +47,7 @@ namespace Pinta
 
 		public event EventHandler? LabelChanged;
 
-		public string Label => Document.Filename + (Document.IsDirty ? "*" : string.Empty);
+		public string Label => Document.DisplayName + (Document.IsDirty ? "*" : string.Empty);
 
 		public Gtk.Widget Widget { get { return canvas_window; } }
 	}

--- a/Pinta/Main.cs
+++ b/Pinta/Main.cs
@@ -125,11 +125,7 @@ namespace Pinta
 
 			if (extra.Count > 0) {
 				foreach (var file in extra) {
-					string path = file;
-					if (path.StartsWith ("file://"))
-						path = new Uri (path).LocalPath;
-
-					PintaCore.Workspace.OpenFile (path);
+					PintaCore.Workspace.OpenFile (GLib.FileFactory.NewFromCommandlineArg (file));
 				}
 			} else {
 				// Create a blank document
@@ -172,7 +168,7 @@ namespace Pinta
 					GLib.Timeout.Add (10, delegate {
 						foreach (string filename in e.Documents.Keys) {
 							System.Console.Error.WriteLine ("Opening: {0}", filename);
-							PintaCore.Workspace.OpenFile (filename);
+							PintaCore.Workspace.OpenFile (GLib.FileFactory.NewFromCommandlineArg (filename));
 						}
 						return false;
 					});

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -529,10 +529,10 @@ namespace Pinta
 							contentStream.CopyTo (fileStream);
 						}
 
-						if (PintaCore.Workspace.OpenFile (GLib.FileFactory.NewForPath(tempFilePath))) {
+						if (PintaCore.Workspace.OpenFile (GLib.FileFactory.NewForPath (tempFilePath))) {
 							// Mark as not having a file, so that the user doesn't unintentionally
 							// save using the temp file.
-							PintaCore.Workspace.ActiveDocument.HasFile = false;
+							PintaCore.Workspace.ActiveDocument.ClearFileReference ();
 						}
 					} catch (Exception e) {
 						progressDialog.Hide ();

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -453,8 +453,9 @@ namespace Pinta
 			PintaCore.Actions.View.ToolBox.Value = PintaCore.Settings.GetSetting ("toolbox-shown", true);
 			PintaCore.Actions.View.ImageTabs.Value = PintaCore.Settings.GetSetting ("image-tabs-shown", true);
 			PintaCore.Actions.View.PixelGrid.Value = PintaCore.Settings.GetSetting ("pixel-grid-shown", false);
-			PintaCore.System.LastDialogDirectory = PintaCore.Settings.GetSetting (LastDialogDirSettingKey,
-											      PintaCore.System.DefaultDialogDirectory);
+
+			var dialog_uri = PintaCore.Settings.GetSetting (LastDialogDirSettingKey, PintaCore.System.DefaultDialogDirectory.Uri.ToString ());
+			PintaCore.System.LastDialogDirectory = GLib.FileFactory.NewForUri (dialog_uri);
 
 			var ruler_metric = (MetricType) PintaCore.Settings.GetSetting ("ruler-metric", (int) MetricType.Pixels);
 			PintaCore.Actions.View.RulerMetric.Activate (new GLib.Variant ((int) ruler_metric));
@@ -478,7 +479,7 @@ namespace Pinta
 			PintaCore.Settings.PutSetting ("statusbar-shown", PintaCore.Actions.View.StatusBar.Value);
 			PintaCore.Settings.PutSetting ("toolbox-shown", PintaCore.Actions.View.ToolBox.Value);
 			PintaCore.Settings.PutSetting ("pixel-grid-shown", PintaCore.Actions.View.PixelGrid.Value);
-			PintaCore.Settings.PutSetting (LastDialogDirSettingKey, PintaCore.System.LastDialogDirectory);
+			PintaCore.Settings.PutSetting (LastDialogDirSettingKey, PintaCore.System.LastDialogDirectory.Uri.ToString ());
 
 			if (PintaCore.Tools.CurrentTool is BaseTool tool)
 				PintaCore.Settings.PutSetting (LastSelectedToolSettingKey, tool.GetType ().Name);
@@ -528,7 +529,7 @@ namespace Pinta
 							contentStream.CopyTo (fileStream);
 						}
 
-						if (PintaCore.Workspace.OpenFile (tempFilePath)) {
+						if (PintaCore.Workspace.OpenFile (GLib.FileFactory.NewForPath(tempFilePath))) {
 							// Mark as not having a file, so that the user doesn't unintentionally
 							// save using the temp file.
 							PintaCore.Workspace.ActiveDocument.HasFile = false;
@@ -542,8 +543,8 @@ namespace Pinta
 						progressDialog.Hide ();
 						PintaCore.Chrome.MainWindowBusy = false;
 					}
-				} else if (file.StartsWith ("file://")) {
-					PintaCore.Workspace.OpenFile (new Uri (file).LocalPath);
+				} else {
+					PintaCore.Workspace.OpenFile (GLib.FileFactory.NewFromCommandlineArg (file));
 				}
 			}
 		}


### PR DESCRIPTION
This is very much a work in progress so far..

Using [GFile](https://docs.gtk.org/gio/iface.File.html) allows us to better support virtual filesystems - e.g. for [bug 1958763](https://bugs.launchpad.net/pinta/+bug/1958763), we can show the real filename (like `test.png`) for a file loaded from the Gnome Google Drive mount, rather than a unique identifier that isn't user-friendly

In GTK4, the [file chooser](https://docs.gtk.org/gtk4/iface.FileChooser.html) will also only provide us with a [GFile](https://docs.gtk.org/gio/iface.File.html) so this also helps us prepare a bit for GTK4 

TODO
- [x] Update the file chooser usage in the Layer -> Import from File action
- [x] Update the file chooser usage for saving / loading palettes
- [ ] Fix `Gdk.Pixbuf.SaveToStreamv()` bindings so that the jpeg exporter can use the quality setting. A [pull request](https://github.com/GtkSharp/GtkSharp/pull/316) has been submitted upstream to properly fix the bindings
- [x] Thoroughly test on all platforms