### PR TITLE
Use MIME filters for file dialogs on non-Windows systems 

### DIFF
--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -374,6 +374,14 @@ namespace Pinta.Core
 				}
 			}
 
+			if (SystemManager.GetOperatingSystem() != OS.Windows) {
+				foreach (var format in PintaCore.System.ImageFormats.Formats) {
+					foreach (var mime in format.Mimes) {
+						ff.AddMimeType (mime);
+					}
+				}
+			}
+
 			fcd.AddFilter (ff);
 
 			FileFilter ff2 = new FileFilter {

--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -374,14 +374,6 @@ namespace Pinta.Core
 				}
 			}
 
-			if (SystemManager.GetOperatingSystem() != OS.Windows) {
-				foreach (var format in PintaCore.System.ImageFormats.Formats) {
-					foreach (var mime in format.Mimes) {
-						ff.AddMimeType (mime);
-					}
-				}
-			}
-
 			fcd.AddFilter (ff);
 
 			FileFilter ff2 = new FileFilter {

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -181,6 +181,14 @@ namespace Pinta.Core
 				}
 			}
 
+			if (SystemManager.GetOperatingSystem() != OS.Windows) {
+				foreach (var format in PintaCore.System.ImageFormats.Formats) {
+					foreach (var mime in format.Mimes) {
+						ff.AddMimeType (mime);
+					}
+				}
+			}
+
 			ff.Name = Translations.GetString ("Image files");
 			fcd.AddFilter (ff);
 

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -181,6 +181,10 @@ namespace Pinta.Core
 				}
 			}
 
+			// On Unix-like systems, file extensions are often considered optional.
+			// Files can often also be identified by their MIME types.
+			// Windows does not understand MIME types natively.
+			// Adding a MIME filter on Windows would break the native file picker and force a GTK file picker instead.
 			if (SystemManager.GetOperatingSystem() != OS.Windows) {
 				foreach (var format in PintaCore.System.ImageFormats.Formats) {
 					foreach (var mime in format.Mimes) {

--- a/Pinta.Core/ImageFormats/FormatDescriptor.cs
+++ b/Pinta.Core/ImageFormats/FormatDescriptor.cs
@@ -45,6 +45,7 @@ namespace Pinta.Core
 
 		/// <summary>
 		/// A list of supported MIME types (for example, "image/jpg" and "image/png").
+		/// </summary>
 		public string[] Mimes { get; private set; }
 
 		/// <summary>
@@ -69,6 +70,7 @@ namespace Pinta.Core
 		/// in the file dialog's filter.
 		/// </param>
 		/// <param name="extensions">A list of supported file extensions (for example, "jpeg" and "JPEG").</param>
+		/// <param name="mimes">A list of supported file MIME types (for example, "image/jpeg" and "image/png").</param>
 		/// <param name="importer">The importer for this file format, or null if importing is not supported.</param>
 		/// <param name="exporter">The exporter for this file format, or null if exporting is not supported.</param>
 		public FormatDescriptor (string displayPrefix, string[] extensions, string[] mimes,

--- a/Pinta.Core/ImageFormats/FormatDescriptor.cs
+++ b/Pinta.Core/ImageFormats/FormatDescriptor.cs
@@ -99,7 +99,7 @@ namespace Pinta.Core
 
 			if (SystemManager.GetOperatingSystem() != OS.Windows) {
 				foreach (string mime in mimes) {
-					ff.AddPattern (mime);
+					ff.AddMimeType (mime);
 				}
 			}
 

--- a/Pinta.Core/ImageFormats/FormatDescriptor.cs
+++ b/Pinta.Core/ImageFormats/FormatDescriptor.cs
@@ -44,6 +44,10 @@ namespace Pinta.Core
 		public string[] Extensions { get; private set; }
 
 		/// <summary>
+		/// A list of supported MIME types (for example, "image/jpg" and "image/png").
+		public string[] Mimes { get; private set; }
+
+		/// <summary>
 		/// The importer for this file format. This may be null if only exporting
 		/// is supported for this format.
 		/// </summary>
@@ -67,7 +71,7 @@ namespace Pinta.Core
 		/// <param name="extensions">A list of supported file extensions (for example, "jpeg" and "JPEG").</param>
 		/// <param name="importer">The importer for this file format, or null if importing is not supported.</param>
 		/// <param name="exporter">The exporter for this file format, or null if exporting is not supported.</param>
-		public FormatDescriptor (string displayPrefix, string[] extensions,
+		public FormatDescriptor (string displayPrefix, string[] extensions, string[] mimes,
 					 IImageImporter? importer, IImageExporter? exporter)
 		{
 			if (extensions == null || (importer == null && exporter == null)) {
@@ -75,6 +79,7 @@ namespace Pinta.Core
 			}
 
 			this.Extensions = extensions;
+			this.Mimes = mimes;
 			this.Importer = importer;
 			this.Exporter = exporter;
 
@@ -88,6 +93,12 @@ namespace Pinta.Core
 				string wildcard = string.Format ("*.{0}", ext);
 				ff.AddPattern (wildcard);
 				formatNames.Append (wildcard);
+			}
+
+			if (SystemManager.GetOperatingSystem() != OS.Windows) {
+				foreach (string mime in mimes) {
+					ff.AddPattern (mime);
+				}
 			}
 
 			ff.Name = string.Format (Translations.GetString ("{0} image ({1})"), displayPrefix, formatNames);

--- a/Pinta.Core/ImageFormats/FormatDescriptor.cs
+++ b/Pinta.Core/ImageFormats/FormatDescriptor.cs
@@ -97,6 +97,10 @@ namespace Pinta.Core
 				formatNames.Append (wildcard);
 			}
 
+			// On Unix-like systems, file extensions are often considered optional.
+			// Files can often also be identified by their MIME types.
+			// Windows does not understand MIME types natively.
+			// Adding a MIME filter on Windows would break the native file picker and force a GTK file picker instead.
 			if (SystemManager.GetOperatingSystem() != OS.Windows) {
 				foreach (string mime in mimes) {
 					ff.AddMimeType (mime);

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -70,12 +70,12 @@ namespace Pinta.Core
 				else
 					exporter = null;
 
-				RegisterFormat (new FormatDescriptor (formatNameUpperCase, extensions, importer, exporter));
+				RegisterFormat (new FormatDescriptor (formatNameUpperCase, extensions, format.MimeTypes, importer, exporter));
 			}
 
 			// Create all the formats we have our own importers/exporters for
 			OraFormat oraHandler = new OraFormat ();
-			RegisterFormat (new FormatDescriptor ("OpenRaster", new string[] { "ora", "ORA" }, oraHandler, oraHandler));
+			RegisterFormat (new FormatDescriptor ("OpenRaster", new string[] { "ora", "ORA" }, new string[] { "image/openraster" }, oraHandler, oraHandler));
 		}
 
 		public IEnumerable<FormatDescriptor> Formats { get { return formats; } }

--- a/Pinta/Actions/File/OpenDocumentAction.cs
+++ b/Pinta/Actions/File/OpenDocumentAction.cs
@@ -65,6 +65,10 @@ namespace Pinta.Actions
 				}
 			}
 
+			// On Unix-like systems, file extensions are often considered optional.
+			// Files can often also be identified by their MIME types.
+			// Windows does not understand MIME types natively.
+			// Adding a MIME filter on Windows would break the native file picker and force a GTK file picker instead.
 			if (SystemManager.GetOperatingSystem() != OS.Windows) {
 				foreach (var format in PintaCore.System.ImageFormats.Formats) {
 					foreach (var mime in format.Mimes) {

--- a/Pinta/Actions/File/OpenDocumentAction.cs
+++ b/Pinta/Actions/File/OpenDocumentAction.cs
@@ -65,6 +65,14 @@ namespace Pinta.Actions
 				}
 			}
 
+			if (SystemManager.GetOperatingSystem() != OS.Windows) {
+				foreach (var format in PintaCore.System.ImageFormats.Formats) {
+					foreach (var mime in format.Mimes) {
+						ff.AddMimeType (mime);
+					}
+				}
+			}
+
 			fcd.AddFilter (ff);
 
 			var ff2 = new FileFilter {


### PR DESCRIPTION
Tested on Ubuntu 20.04

Pinta currently sets the filter for files in the file chooser dialogs based entirely on filenames. Instead, it is preferable to base this filter based on MIME types. This means that on Linux systems for example, there is no need to specify a file extension to be recognised as an image file. The identification of the file is left to the system, which can use more advanced heuristics, primarily, identifying the type based on the files binary header / magic number.

The observed effect is is that when filtering for images, Pinta will be capable of identifying image files without a file extension, whilst excluding other types of files, e.g ODT documents, that would be found with "All Files" filter.

It isn't strictly necessary to remove the file extensions filtering, the filter object can take both file extension filters and also MIME type filters concurrently. However it seems the more technically correct solution to only rely on one or the other IMO. However, it might be the more pragmatic solution to actually use both.