### PR TITLE
Fix for #1964398: Added hasSelection check in PerformCut()

### DIFF
--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -341,7 +341,9 @@ namespace Pinta.Core
 		public void PerformCut (Gtk.Clipboard clipboard)
 		{
 			PerformCopy (clipboard);
-			DeleteSelection ();
+			if (HasSelection ()) {
+				DeleteSelection ();
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
https://bugs.launchpad.net/pinta/+bug/1964398

When Ctrl+x is pressed with the text tool active, with empty text or some text entered(without finalizing) and without selecting the text, an exception is raised by the app.

This commit fixes that issue by adding a `hasSelection()` prior to calling `DeleteSelection()`. Works fine as far as I tested.