### PR TITLE
Fix formating for headers in patch-guidelines.md

### DIFF
--- a/patch-guidelines.md
+++ b/patch-guidelines.md
@@ -6,14 +6,14 @@ reading the excellent documentation on GitHub, or if you want an even
 deeper understanding read [Pro Git](http://progit.org/book/).
 
 
-####Claiming a bug to work on
+#### Claiming a bug to work on
 
 If you plan to work on a bug that has been registered on our [Launchpad
 page](https://bugs.launchpad.net/pinta/+bugs), then go to the relevant
 bug and make sure no one else is already working on it, then leave
 comment saying that you are working on it.
 
-####Creating a GitHub Fork of Pinta
+#### Creating a GitHub Fork of Pinta
 
 First you need  to make yourself an account with GitHub if you haven't
 already got one. It is recommended that you use your full name, because
@@ -22,7 +22,7 @@ Repository](https://github.com/PintaProject/Pinta) , and pull the code
 down to your local machine. (All explained [here]
 (http://help.github.com/fork-a-repo/))
 
-####Writing, Compiling, and Testing Code
+#### Writing, Compiling, and Testing Code
 
 This is where the magic happens! Make whatever changes are necessary to
 the source code, but please do not attempt to clean up existing code. We
@@ -33,7 +33,7 @@ instructions](https://github.com/PintaProject/Pinta/blob/master/readme.md),
 and test it to make sure it does what it's supposed to and doesn't do
 anything it's not supposed to.
 
-####Committing Your Modification to GitHub
+#### Committing Your Modification to GitHub
 
 When you are satisfied that you have a great fix to share with the
 world, commit it to your GitHub fork. (See the second part of
@@ -43,7 +43,7 @@ so that the devlopers know what exactly they are looking at. Then it
 will be publicly visible for scrutiny, which comes in handy for the next
 step.
 
-####Sending a GitHub Pull Request
+#### Sending a GitHub Pull Request
 
 Pull requests are thoroughly explained [here](http://help.github.com/send-pull-requests/). You will want to send a
 pull request to the Pinta repository from your fork. When the developers


### PR DESCRIPTION
The headers were not being displayed as headers by GitHub. This is because GitHub requires that the hash symbols are followed by a space character to recognize text as a header.