### PR TITLE
Revert "Bump GtkSharp from 3.24.24.34 to 3.24.24.38 (#230)"

### DIFF
--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
     <PackageReference Include="NGettext" Version="0.6.7" />
     <PackageReference Include="SharpZipLib" Version="1.4.0" />
     <PackageReference Include="ParagonClipper" Version="6.4.2" />

--- a/Pinta.Docking/Pinta.Docking.csproj
+++ b/Pinta.Docking/Pinta.Docking.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />

--- a/Pinta.Effects/Pinta.Effects.csproj
+++ b/Pinta.Effects/Pinta.Effects.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />

--- a/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
+++ b/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />

--- a/Pinta.Resources/Pinta.Resources.csproj
+++ b/Pinta.Resources/Pinta.Resources.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="icons/hicolor/*/*/*">

--- a/Pinta.Tools/Pinta.Tools.csproj
+++ b/Pinta.Tools/Pinta.Tools.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />

--- a/Pinta/Pinta.csproj
+++ b/Pinta/Pinta.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
     <PackageReference Include="Tmds.DBus" Version="0.11.0" />
   </ItemGroup>
 

--- a/tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj
+++ b/tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />


### PR DESCRIPTION
This reverts commit 31e3a842295be2362518afa765bc4cc35d31ba50.

Fixes https://bugs.launchpad.net/pinta/+bug/1993035

Note: gtksharp does not have a 3.24.24.38 release on their github releases page, the latest is still 3.24.24.34