### PR TITLE
Changed occurrences of ArgumentOutOfRangeException and ArgumentException to use nameof() operator

### DIFF
--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -392,7 +392,7 @@ namespace Pinta.Core
 		private void ForeachLine (TextPosition start, TextPosition end, Action action)
 		{
 			if (start.CompareTo (end) > 0)
-				throw new ArgumentException ("Invalid start position", "start");
+				throw new ArgumentException ("Invalid start position", nameof(start));
 
 			while (start.Line < end.Line) {
 				action (start.Line, start.Offset, lines[start.Line].Length);
@@ -473,7 +473,7 @@ namespace Pinta.Core
 		private void DeleteText (TextPosition start, TextPosition end)
 		{
 			if (start.CompareTo (end) >= 0)
-				throw new ArgumentException ("Invalid start position", "start");
+				throw new ArgumentException ("Invalid start position", nameof(start));
 
 			lines[start.Line] = lines[start.Line].Substring (0, start.Offset) +
 					    lines[end.Line].Substring (end.Offset);

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -359,11 +359,11 @@ namespace Pinta.Core
 		public ScaleFactor (int numerator, int denominator)
 		{
 			if (denominator <= 0) {
-				throw new ArgumentOutOfRangeException ("denominator", "must be greater than 0(denominator = " + denominator + ")");
+				throw new ArgumentOutOfRangeException (nameof(denominator), "must be greater than 0(denominator = " + denominator + ")");
 			}
 
 			if (numerator < 0) {
-				throw new ArgumentOutOfRangeException ("numerator", "must be greater than 0(numerator = " + numerator + ")");
+				throw new ArgumentOutOfRangeException (nameof(numerator), "must be greater than 0(numerator = " + numerator + ")");
 			}
 
 			this.numerator = numerator;

--- a/Pinta.Core/Effects/BinaryPixelOp.cs
+++ b/Pinta.Core/Effects/BinaryPixelOp.cs
@@ -57,15 +57,15 @@ namespace Pinta.Core
 
 			// If any of those Rectangles actually got clipped, then throw an exception
 			if (dstRect != dstClip) {
-				throw new ArgumentOutOfRangeException ("roiSize", "Destination roi out of bounds");
+				throw new ArgumentOutOfRangeException (nameof(roiSize), "Destination roi out of bounds");
 			}
 
 			if (lhsRect != lhsClip) {
-				throw new ArgumentOutOfRangeException ("roiSize", "lhs roi out of bounds");
+				throw new ArgumentOutOfRangeException (nameof(roiSize), "lhs roi out of bounds");
 			}
 
 			if (rhsRect != rhsClip) {
-				throw new ArgumentOutOfRangeException ("roiSize", "rhs roi out of bounds");
+				throw new ArgumentOutOfRangeException (nameof(roiSize), "rhs roi out of bounds");
 			}
 #endif
 

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -87,7 +87,7 @@ namespace Pinta.Core
 		public unsafe byte this[int channel] {
 			get {
 				if (channel < 0 || channel > 3) {
-					throw new ArgumentOutOfRangeException ("channel", channel, "valid range is [0,3]");
+					throw new ArgumentOutOfRangeException (nameof(channel), channel, "valid range is [0,3]");
 				}
 
 				fixed (byte* p = &B) {
@@ -97,7 +97,7 @@ namespace Pinta.Core
 
 			set {
 				if (channel < 0 || channel > 3) {
-					throw new ArgumentOutOfRangeException ("channel", channel, "valid range is [0,3]");
+					throw new ArgumentOutOfRangeException (nameof(channel), channel, "valid range is [0,3]");
 				}
 
 				fixed (byte* p = &B) {

--- a/Pinta.Core/Effects/Histogram.cs
+++ b/Pinta.Core/Effects/Histogram.cs
@@ -28,7 +28,7 @@ namespace Pinta.Core
 					this.histogram = value;
 					OnHistogramUpdated ();
 				} else {
-					throw new ArgumentException ("value muse be an array of arrays of matching size", "value");
+					throw new ArgumentException ("value muse be an array of arrays of matching size", nameof(value));
 				}
 			}
 		}

--- a/Pinta.Core/Effects/HsvColor.cs
+++ b/Pinta.Core/Effects/HsvColor.cs
@@ -49,15 +49,15 @@ namespace Pinta.Core
 		public HsvColor (int hue, int saturation, int value)
 		{
 			if (hue < 0 || hue > 360) {
-				throw new ArgumentOutOfRangeException ("hue", "must be in the range [0, 360]");
+				throw new ArgumentOutOfRangeException (nameof(hue), "must be in the range [0, 360]");
 			}
 
 			if (saturation < 0 || saturation > 100) {
-				throw new ArgumentOutOfRangeException ("saturation", "must be in the range [0, 100]");
+				throw new ArgumentOutOfRangeException (nameof(saturation), "must be in the range [0, 100]");
 			}
 
 			if (value < 0 || value > 100) {
-				throw new ArgumentOutOfRangeException ("value", "must be in the range [0, 100]");
+				throw new ArgumentOutOfRangeException (nameof(value), "must be in the range [0, 100]");
 			}
 
 			Hue = hue;

--- a/Pinta.Core/Effects/PixelOp.cs
+++ b/Pinta.Core/Effects/PixelOp.cs
@@ -69,7 +69,7 @@ namespace Pinta.Core
 			if (dstRect != dstClip)
 				throw new ArgumentOutOfRangeException
 				(
-				    "roiSize",
+				    nameof(roiSize),
 				    "Destination roi out of bounds" +
 				    string.Format (", dst.Size=({0},{1}", dst.Width, dst.Height) +
 				    ", dst.Bounds=" + dst.GetBounds ().ToString () +
@@ -84,7 +84,7 @@ namespace Pinta.Core
 				);
 
 			if (srcRect != srcClip)
-				throw new ArgumentOutOfRangeException ("roiSize", "Source roi out of bounds");
+				throw new ArgumentOutOfRangeException (nameof(roiSize), "Source roi out of bounds");
 
 			// Cache the width and height properties
 			int width = roiSize.Width;

--- a/Pinta.Core/Effects/RgbColor.cs
+++ b/Pinta.Core/Effects/RgbColor.cs
@@ -29,13 +29,13 @@ namespace Pinta.Core
 		{
 #if DEBUG
 			if (R < 0 || R > 255) {
-				throw new ArgumentOutOfRangeException ("R", R, "R must corrospond to a byte value");
+				throw new ArgumentOutOfRangeException (nameof(R), R, $"{nameof(R)} must correspond to a byte value");
 			}
 			if (G < 0 || G > 255) {
-				throw new ArgumentOutOfRangeException ("G", G, "G must corrospond to a byte value");
+				throw new ArgumentOutOfRangeException (nameof(G), G, $"{nameof(G)} must correspond to a byte value");
 			}
 			if (B < 0 || B > 255) {
-				throw new ArgumentOutOfRangeException ("B", B, "B must corrospond to a byte value");
+				throw new ArgumentOutOfRangeException (nameof(B), B, $"{nameof(B)} must correspond to a byte value");
 			}
 #endif
 			Red = R;

--- a/Pinta.Core/Effects/UnaryPixelOp.cs
+++ b/Pinta.Core/Effects/UnaryPixelOp.cs
@@ -52,7 +52,7 @@ namespace Pinta.Core
 			RectangleI regionBounds = Utility.GetRegionBounds (roi, startIndex, length);
 
 			if (regionBounds != RectangleI.Intersect (surface.GetBounds (), regionBounds))
-				throw new ArgumentOutOfRangeException ("roi", "Region is out of bounds");
+				throw new ArgumentOutOfRangeException (nameof(roi), "Region is out of bounds");
 
 			for (int x = startIndex; x < startIndex + length; ++x)
 				ApplyRectangle (surface, roi[x]);

--- a/Pinta.Core/Effects/UnaryPixelOps.cs
+++ b/Pinta.Core/Effects/UnaryPixelOps.cs
@@ -573,7 +573,7 @@ namespace Pinta.Core
 			public float GetGamma (int index)
 			{
 				if (index < 0 || index >= 3) {
-					throw new ArgumentOutOfRangeException ("index", index, "Index must be between 0 and 2");
+					throw new ArgumentOutOfRangeException (nameof(index), index, "Index must be between 0 and 2");
 				}
 
 				return gamma[index];
@@ -582,7 +582,7 @@ namespace Pinta.Core
 			public void SetGamma (int index, float val)
 			{
 				if (index < 0 || index >= 3) {
-					throw new ArgumentOutOfRangeException ("index", index, "Index must be between 0 and 2");
+					throw new ArgumentOutOfRangeException (nameof(index), index, "Index must be between 0 and 2");
 				}
 
 				gamma[index] = Utility.Clamp (val, 0.1f, 10.0f);

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -288,11 +288,11 @@ namespace Pinta.Core
 		public static void GetRgssOffsets (Span<PointD> samplesArray, int sampleCount, int quality)
 		{
 			if (sampleCount < 1) {
-				throw new ArgumentOutOfRangeException ("sampleCount", "sampleCount must be [0, int.MaxValue]");
+				throw new ArgumentOutOfRangeException (nameof(sampleCount), "sampleCount must be [0, int.MaxValue]");
 			}
 
 			if (sampleCount != quality * quality) {
-				throw new ArgumentOutOfRangeException ("sampleCount != (quality * quality)");
+				throw new ArgumentOutOfRangeException (nameof(sampleCount), $"{nameof(sampleCount)} != ({nameof(quality)} * {nameof(quality)})");
 			}
 
 			if (sampleCount == 1) {

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -288,11 +288,14 @@ namespace Pinta.Core
 		public static void GetRgssOffsets (Span<PointD> samplesArray, int sampleCount, int quality)
 		{
 			if (sampleCount < 1) {
-				throw new ArgumentOutOfRangeException (nameof(sampleCount), "sampleCount must be [0, int.MaxValue]");
+				throw new ArgumentOutOfRangeException (
+					nameof(sampleCount),
+					$"{nameof(sampleCount)} must be [0, int.MaxValue]"
+				);
 			}
 
 			if (sampleCount != quality * quality) {
-				throw new ArgumentOutOfRangeException (nameof(sampleCount), $"{nameof(sampleCount)} != ({nameof(quality)} * {nameof(quality)})");
+				throw new ArgumentOutOfRangeException ("sampleCount != (quality * quality)");
 			}
 
 			if (sampleCount == 1) {

--- a/Pinta.Core/Extensions/GioStream.cs
+++ b/Pinta.Core/Extensions/GioStream.cs
@@ -128,11 +128,11 @@ namespace Pinta.Core
 		public override int Read (byte[] buffer, int offset, int count)
 		{
 			if (offset + count - 1 > buffer.Length)
-				throw new ArgumentException ("(offset + count - 1) is greater than the length of buffer");
+				throw new ArgumentException ($"({nameof(offset)} + {nameof(count)} - {1}) is greater than the length of buffer");
 			if (offset < 0)
-				throw new ArgumentOutOfRangeException ("offset");
+				throw new ArgumentOutOfRangeException (nameof(offset));
 			if (count < 0)
-				throw new ArgumentOutOfRangeException ("count");
+				throw new ArgumentOutOfRangeException (nameof(count));
 			if (!CanRead)
 				throw new NotSupportedException ("The stream does not support reading");
 			if (is_disposed)
@@ -158,11 +158,11 @@ namespace Pinta.Core
 		public override void Write (byte[] buffer, int offset, int count)
 		{
 			if (offset + count > buffer.Length)
-				throw new ArgumentException ("(offset + count) is greater than the length of buffer");
+				throw new ArgumentException ($"({nameof(offset)} + {nameof(count)}) is greater than the length of buffer");
 			if (offset < 0)
-				throw new ArgumentOutOfRangeException ("offset");
+				throw new ArgumentOutOfRangeException (nameof(offset));
 			if (count < 0)
-				throw new ArgumentOutOfRangeException ("count");
+				throw new ArgumentOutOfRangeException (nameof(count));
 			if (!CanWrite)
 				throw new NotSupportedException ("The stream does not support writing");
 			if (is_disposed)

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -313,9 +313,15 @@ namespace Pinta.Core
 		public void SetActiveDocument (int index)
 		{
 			if (index >= OpenDocuments.Count)
-				throw new ArgumentOutOfRangeException ("Tried to WorkspaceManager.SetActiveDocument greater than OpenDocuments.");
+				throw new ArgumentOutOfRangeException (
+					nameof(index),
+					$"Tried to {nameof(WorkspaceManager)}.{nameof(SetActiveDocument)} greater than {nameof(OpenDocuments)}."
+				);
 			if (index < 0)
-				throw new ArgumentOutOfRangeException ("Tried to WorkspaceManager.SetActiveDocument less that zero.");
+				throw new ArgumentOutOfRangeException (
+					nameof(index),
+					$"Tried to {nameof(WorkspaceManager)}.{nameof(SetActiveDocument)} less that zero."
+				);
 
 			SetActiveDocument (OpenDocuments[index]);
 		}

--- a/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
@@ -82,7 +82,7 @@ namespace Pinta.Gui.Widgets
 			[MemberNotNull (nameof (vals))]
 			set {
 				if (value < 2 || value > 3)
-					throw new ArgumentOutOfRangeException ("value", value, "Count must be 2 or 3");
+					throw new ArgumentOutOfRangeException (nameof(value), value, "Count must be 2 or 3");
 
 				vals = new double[value];
 

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -279,7 +279,7 @@ namespace Pinta.Tools
 					}
 					break;
 				default:
-					throw new ArgumentOutOfRangeException ("handle");
+					throw new ArgumentOutOfRangeException (nameof(handle));
 			}
 		}
 

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -207,7 +207,7 @@ namespace Mono.Options
 			if (c.Option == null)
 				throw new InvalidOperationException ("OptionContext.Option is null.");
 			if (index >= c.Option.MaxValueCount)
-				throw new ArgumentOutOfRangeException ("index");
+				throw new ArgumentOutOfRangeException (nameof(index));
 			if (c.Option.OptionValueType == OptionValueType.Required &&
 					index >= values.Count)
 				throw new OptionException (string.Format (
@@ -303,9 +303,9 @@ namespace Mono.Options
 		protected Option (string prototype, string description, int maxValueCount)
 		{
 			if (prototype.Length == 0)
-				throw new ArgumentException ("Cannot be the empty string.", "prototype");
+				throw new ArgumentException ("Cannot be the empty string.", nameof(prototype));
 			if (maxValueCount < 0)
-				throw new ArgumentOutOfRangeException ("maxValueCount");
+				throw new ArgumentOutOfRangeException (nameof(maxValueCount));
 
 			this.prototype = prototype;
 			this.names = prototype.Split ('|');
@@ -317,17 +317,17 @@ namespace Mono.Options
 				throw new ArgumentException (
 						"Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
 							"OptionValueType.Optional.",
-						"maxValueCount");
+						nameof(maxValueCount));
 			if (this.type == OptionValueType.None && maxValueCount > 1)
 				throw new ArgumentException (
 						string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
-						"maxValueCount");
+						nameof(maxValueCount));
 			if (Array.IndexOf (names, "<>") >= 0 &&
 					((names.Length == 1 && this.type != OptionValueType.None) ||
 					 (names.Length > 1 && this.MaxValueCount > 1)))
 				throw new ArgumentException (
 						"The default option handler '<>' cannot require values.",
-						"prototype");
+						nameof(prototype));
 		}
 
 		public string Prototype { get { return prototype; } }
@@ -381,7 +381,7 @@ namespace Mono.Options
 			for (int i = 0; i < names.Length; ++i) {
 				string name = names[i];
 				if (name.Length == 0)
-					throw new ArgumentException ("Empty option names are not supported.", "prototype");
+					throw new ArgumentException ("Empty option names are not supported.", nameof(prototype));
 
 				int end = name.IndexOfAny (NameTerminator);
 				if (end == -1)
@@ -392,7 +392,7 @@ namespace Mono.Options
 				else
 					throw new ArgumentException (
 							string.Format ("Conflicting option types: '{0}' vs. '{1}'.", type, name[end]),
-							"prototype");
+							nameof(prototype));
 				AddSeparators (name, end, seps);
 			}
 
@@ -402,7 +402,7 @@ namespace Mono.Options
 			if (count <= 1 && seps.Count != 0)
 				throw new ArgumentException (
 						string.Format ("Cannot provide key/value separators for Options taking {0} value(s).", count),
-						"prototype");
+						nameof(prototype));
 			if (count > 1) {
 				if (seps.Count == 0)
 					this.separators = new string[] { ":", "=" };
@@ -424,14 +424,14 @@ namespace Mono.Options
 						if (start != -1)
 							throw new ArgumentException (
 									string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
-									"prototype");
+									nameof(prototype));
 						start = i + 1;
 						break;
 					case '}':
 						if (start == -1)
 							throw new ArgumentException (
 									string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
-									"prototype");
+									nameof(prototype));
 						seps.Add (name.Substring (start, i - start));
 						start = -1;
 						break;
@@ -444,7 +444,7 @@ namespace Mono.Options
 			if (start != -1)
 				throw new ArgumentException (
 						string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
-						"prototype");
+						nameof(prototype));
 		}
 
 		public void Invoke (OptionContext c)


### PR DESCRIPTION
I am thinking of doing a major modernization (and later a refactoring) of the Pinta codebase, but splitting it into very safe, bite-sized pieces. This is one of them. And very few things are safer and more bite-sized than using the `nameof()` operator for exceptions :)

On a related note, in a previous pull request I was asked not to change certain file too much because it was third-party code. I saw that the file in question was licensed to Novell, so I assume that is what was being talked about. Is my guess correct? What is the policy on third-party code? It's probably important to note that the file in question is under a permissive, MIT-like license.