### PR TITLE
Refactored `CreatePolygonSet` algorithm

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1156,7 +1156,7 @@ namespace Pinta.Core
 					scans[i] = cairo_rect.ToRectangleI ();
 				}
 			} else {
-				scans = new RectangleI[0];
+				scans = Array.Empty<RectangleI> ();
 			}
 
 			foreach (var rect in scans) {
@@ -1270,7 +1270,7 @@ namespace Pinta.Core
 					scans[i] = cairo_rect.ToRectangleI ();
 				}
 			} else {
-				scans = new RectangleI[0];
+				scans = Array.Empty<RectangleI> ();
 			}
 
 			foreach (var rect in scans)

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -65,40 +65,58 @@ namespace Pinta.Core
 
 				PointI last = new (start.X, start.Y + 1);
 				PointI curr = new (start.X, start.Y);
-				PointI next = curr;
-				PointI left = new ();
-				PointI right = new ();
-
+				
 				// trace island outline
 				while (true) {
-					left.X = ((curr.X - last.X) + (curr.Y - last.Y) + 2) / 2 + curr.X - 1;
-					left.Y = ((curr.Y - last.Y) - (curr.X - last.X) + 2) / 2 + curr.Y - 1;
 
-					right.X = ((curr.X - last.X) - (curr.Y - last.Y) + 2) / 2 + curr.X - 1;
-					right.Y = ((curr.Y - last.Y) + (curr.X - last.X) + 2) / 2 + curr.Y - 1;
+					// Calculation zone
 
-					if (bounds.ContainsPoint (left.X, left.Y) && stencil[left]) {
+					int currLastDiffX = curr.X - last.X;
+					int currLastDiffY = curr.Y - last.Y;
+					int currXDecreased = curr.X - 1;
+					int currYDecreased = curr.Y - 1;
+
+					int leftX = currXDecreased + ((currLastDiffX + currLastDiffY + 2) / 2);
+					int leftY = currYDecreased + ((currLastDiffY - currLastDiffX + 2) / 2);
+
+					int rightX = currXDecreased + ((currLastDiffX - currLastDiffY + 2) / 2);
+					int rightY = currYDecreased + ((currLastDiffY + currLastDiffX + 2) / 2);
+
+					PointI left = new (leftX, leftY);
+					PointI right = new (rightX, rightY);
+
+					int nextXAddition;
+					int nextYAddition;
+					if (bounds.ContainsPoint (leftX, leftY) && stencil[left]) {
 						// go left
-						next.X += curr.Y - last.Y;
-						next.Y -= curr.X - last.X;
-					} else if (bounds.ContainsPoint (right.X, right.Y) && stencil[right]) {
+						nextXAddition = currLastDiffY;
+						nextYAddition = -currLastDiffX;
+					} else if (bounds.ContainsPoint (rightX, rightY) && stencil[right]) {
 						// go straight
-						next.X += curr.X - last.X;
-						next.Y += curr.Y - last.Y;
+						nextXAddition = currLastDiffX;
+						nextYAddition = currLastDiffY;
 					} else {
 						// turn right
-						next.X -= curr.Y - last.Y;
-						next.Y += curr.X - last.X;
+						nextXAddition = -currLastDiffY;
+						nextYAddition = currLastDiffX;
 					}
 
-					if (Math.Sign (next.X - curr.X) != Math.Sign (curr.X - last.X) ||
-					    Math.Sign (next.Y - curr.Y) != Math.Sign (curr.Y - last.Y)) {
+					var nextX = curr.X + nextXAddition;
+					var nextY = curr.Y + nextYAddition;
+					PointI next = new (nextX, nextY);
+
+					// Mutation zone
+
+					if (Math.Sign (nextX - curr.X) != Math.Sign (currLastDiffX) ||
+					    Math.Sign (nextY - curr.Y) != Math.Sign (currLastDiffY)) {
 						pts.Add (curr);
 						++count;
 					}
 
 					last = curr;
 					curr = next;
+
+					// Continue?
 
 					if (next.X == start.X && next.Y == start.Y)
 						break;

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -302,7 +302,7 @@ namespace Pinta.Effects
 			g.LineTo (size - 1, 0);
 			g.Stroke ();
 
-			g.SetDash (new double[] { }, 0);
+			g.SetDash (Array.Empty<double> (), 0);
 		}
 
 		//cpx, cpyx - control point's x and y coordinates

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -1138,7 +1138,7 @@ namespace Pinta.Tools
 					}
 				}
 
-				g.SetDash (new double[] { }, 0.0);
+				g.SetDash (Array.Empty<double> (), 0.0);
 
 				//Draw anything extra (that not every shape has), like arrows.
 				DrawExtras (ref dirty, g, engine);

--- a/Pinta.Tools/Editable/Shapes/ShapeEngineCollection.cs
+++ b/Pinta.Tools/Editable/Shapes/ShapeEngineCollection.cs
@@ -105,7 +105,7 @@ namespace Pinta.Tools
 		public List<MoveHandle> ControlPointHandles = new ();
 
 		//A collection of calculated GeneratedPoints that make up the entirety of the shape being drawn.
-		public GeneratedPoint[] GeneratedPoints = new GeneratedPoint[0];
+		public GeneratedPoint[] GeneratedPoints = Array.Empty<GeneratedPoint> ();
 
 		//An organized collection of the GeneratedPoints's points for optimized nearest point detection.
 		public OrganizedPointCollection OrganizedPoints = new OrganizedPointCollection ();

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -343,7 +343,7 @@ namespace Mono.Options
 		public string[] GetValueSeparators ()
 		{
 			if (separators == null)
-				return new string[0];
+				return Array.Empty<string> ();
 			return (string[]) separators.Clone ();
 		}
 


### PR DESCRIPTION
This is just a demonstration of the way I want to refactor algorithms in order to make them more understandable and reduce redundant operations. I wish to discuss this approach in order to decide if refactoring other algorithms in this way can be done.

Here's a summary of the changes (what was happening before vs. what is happening now):

- Some operations were being performed more than once, which could be inefficient. I assigned the values of such operations to variables and then used the values in subsequent calculations. For instance, see `(curr.X - last.X)` in the previous code and how I assigned it to `currLastDiffX` in the new code.
- I reduced the scope of `left` and `right`. They were just being mutated at the beginning of each loop cycle and then their value used for the remaining of it, which could make programmers believe that there is more state change than there actually is.
- Some calculations relied on variable reassignment, which I tried to minimize as much as possible. In fact, I separated the code into a "calculation zone" and a "mutation zone". Inside the "calculation zone" there is not a single variable reassignment.

Additionally, I replaced creations of arrays of length `0` by `Array.Empty<T>()`, which expresses one's intent more clearly.