### PR TITLE
Added basic tests for `BitMask`

### DIFF
--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 
 namespace Pinta.Core
@@ -12,6 +13,12 @@ namespace Pinta.Core
 
 		public BitMask (int width, int height)
 		{
+			if (width < 0)
+				throw new ArgumentOutOfRangeException (nameof(width));
+
+			if (height < 0)
+				throw new ArgumentOutOfRangeException (nameof(height));
+
 			Width = width;
 			Height = height;
 

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -2,9 +2,11 @@ using System.Collections;
 
 namespace Pinta.Core
 {
-	// Represent a two dimensional matrix of bits used to store a
-	// true/false value for each pixel in an image.
-	public class BitMask
+	/// <summary>
+	/// Represents a two-dimensional matrix of bits used to store a
+	/// true/false value for each pixel in an image.
+	/// </summary>
+	public sealed class BitMask
 	{
 		private readonly BitArray array;
 

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -15,7 +15,6 @@ public sealed class BitMask
 	{
 		if (width < 0)
 			throw new ArgumentOutOfRangeException (nameof (width));
-
 		if (height < 0)
 			throw new ArgumentOutOfRangeException (nameof (height));
 
@@ -55,7 +54,6 @@ public sealed class BitMask
 	public void Invert (Scanline scan)
 	{
 		var x = scan.X;
-
 		while (x < scan.X + scan.Length) {
 			Invert (x, scan.Y);
 			++x;

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -14,10 +14,10 @@ public sealed class BitMask
 	public BitMask (int width, int height)
 	{
 		if (width < 0)
-			throw new ArgumentOutOfRangeException (nameof(width));
+			throw new ArgumentOutOfRangeException (nameof (width));
 
 		if (height < 0)
-			throw new ArgumentOutOfRangeException (nameof(height));
+			throw new ArgumentOutOfRangeException (nameof (height));
 
 		Width = width;
 		Height = height;

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -66,11 +66,9 @@ public sealed class BitMask
 
 	public void Set (RectangleI rect, bool newValue)
 	{
-		for (var y = rect.Y; y <= rect.Bottom; ++y) {
-			for (var x = rect.X; x <= rect.Right; ++x) {
+		for (var y = rect.Y; y <= rect.Bottom; ++y)
+			for (var x = rect.X; x <= rect.Right; ++x)
 				Set (x, y, newValue);
-			}
-		}
 	}
 
 	private int GetIndex (int x, int y) => (y * Width) + x;

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -1,78 +1,77 @@
 using System;
 using System.Collections;
 
-namespace Pinta.Core
+namespace Pinta.Core;
+
+/// <summary>
+/// Represents a two-dimensional matrix of bits used to store a
+/// true/false value for each pixel in an image.
+/// </summary>
+public sealed class BitMask
 {
-	/// <summary>
-	/// Represents a two-dimensional matrix of bits used to store a
-	/// true/false value for each pixel in an image.
-	/// </summary>
-	public sealed class BitMask
+	private readonly BitArray array;
+
+	public BitMask (int width, int height)
 	{
-		private readonly BitArray array;
+		if (width < 0)
+			throw new ArgumentOutOfRangeException (nameof(width));
 
-		public BitMask (int width, int height)
-		{
-			if (width < 0)
-				throw new ArgumentOutOfRangeException (nameof(width));
+		if (height < 0)
+			throw new ArgumentOutOfRangeException (nameof(height));
 
-			if (height < 0)
-				throw new ArgumentOutOfRangeException (nameof(height));
+		Width = width;
+		Height = height;
 
-			Width = width;
-			Height = height;
-
-			array = new BitArray (width * height);
-		}
-
-		public bool this[PointI pt] {
-			get => this[pt.X, pt.Y];
-			set => this[pt.X, pt.Y] = value;
-		}
-
-		public bool this[int x, int y] {
-			get => Get (x, y);
-			set => Set (x, y, value);
-		}
-
-		public int Width { get; }
-
-		public int Height { get; }
-
-		public bool IsEmpty => array.Length == 0;
-
-		public void Clear (bool newValue) => array.SetAll (newValue);
-
-		public bool Get (int x, int y) => array.Get (GetIndex (x, y));
-
-		public void Invert (int x, int y)
-		{
-			var index = GetIndex (x, y);
-
-			array[index] = !array[index];
-		}
-
-		public void Invert (Scanline scan)
-		{
-			var x = scan.X;
-
-			while (x < scan.X + scan.Length) {
-				Invert (x, scan.Y);
-				++x;
-			}
-		}
-
-		public void Set (int x, int y, bool newValue) => array[GetIndex (x, y)] = newValue;
-
-		public void Set (RectangleI rect, bool newValue)
-		{
-			for (var y = rect.Y; y <= rect.Bottom; ++y) {
-				for (var x = rect.X; x <= rect.Right; ++x) {
-					Set (x, y, newValue);
-				}
-			}
-		}
-
-		private int GetIndex (int x, int y) => (y * Width) + x;
+		array = new BitArray (width * height);
 	}
+
+	public bool this[PointI pt] {
+		get => this[pt.X, pt.Y];
+		set => this[pt.X, pt.Y] = value;
+	}
+
+	public bool this[int x, int y] {
+		get => Get (x, y);
+		set => Set (x, y, value);
+	}
+
+	public int Width { get; }
+
+	public int Height { get; }
+
+	public bool IsEmpty => array.Length == 0;
+
+	public void Clear (bool newValue) => array.SetAll (newValue);
+
+	public bool Get (int x, int y) => array.Get (GetIndex (x, y));
+
+	public void Invert (int x, int y)
+	{
+		var index = GetIndex (x, y);
+
+		array[index] = !array[index];
+	}
+
+	public void Invert (Scanline scan)
+	{
+		var x = scan.X;
+
+		while (x < scan.X + scan.Length) {
+			Invert (x, scan.Y);
+			++x;
+		}
+	}
+
+	public void Set (int x, int y, bool newValue) => array[GetIndex (x, y)] = newValue;
+
+	public void Set (RectangleI rect, bool newValue)
+	{
+		for (var y = rect.Y; y <= rect.Bottom; ++y) {
+			for (var x = rect.X; x <= rect.Right; ++x) {
+				Set (x, y, newValue);
+			}
+		}
+	}
+
+	private int GetIndex (int x, int y) => (y * Width) + x;
 }

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -103,23 +103,23 @@ internal sealed class BitMaskTest
 		}
 	}
 
-	static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new[]
+	static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new TestCaseData[]
 	{
-		new TestCaseData(0, 0),
-		new TestCaseData(0, 1),
-		new TestCaseData(1, 1),
-		new TestCaseData(1, 2),
-		new TestCaseData(1, -1),
-		new TestCaseData(1, int.MinValue),
-		new TestCaseData(1, int.MinValue + 1),
-		new TestCaseData(1, int.MaxValue),
-		new TestCaseData(1, int.MaxValue - 1),
-		new TestCaseData(2, 2),
+		new (0, 0),
+		new (0, 1),
+		new (1, 1),
+		new (1, 2),
+		new (1, -1),
+		new (1, int.MinValue),
+		new (1, int.MinValue + 1),
+		new (1, int.MaxValue),
+		new (1, int.MaxValue - 1),
+		new (2, 2),
 	};
 
-	static readonly IReadOnlyList<TestCaseData> within_bounds_access_cases = new[]
+	static readonly IReadOnlyList<TestCaseData> within_bounds_access_cases = new TestCaseData[]
 	{
-		new TestCaseData(DEFAULT_SIZE, DEFAULT_OFFSET),
-		new TestCaseData(2, 1),
+		new (DEFAULT_SIZE, DEFAULT_OFFSET),
+		new (2, 1),
 	};
 }

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests
+{
+	[TestFixture]
+	internal sealed class BitMaskTest
+	{
+		const int DEFAULT_SIZE = 1;
+		const int DEFAULT_OFFSET = 0;
+
+		const int DEFAULT_HEIGHT = DEFAULT_SIZE;
+		const int DEFAULT_HEIGHT_INDEX = DEFAULT_OFFSET;
+
+		const int DEFAULT_WIDTH = DEFAULT_SIZE;
+		const int DEFAULT_WIDTH_INDEX = DEFAULT_OFFSET;
+
+		[TestCase (-1)]
+		public void Constructor_RejectsInvalidWidth (int width)
+		{
+			Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (width, DEFAULT_HEIGHT));
+		}
+
+		[TestCase (-1)]
+		public void Constructor_RejectsInvalidHeight (int height)
+		{
+			Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (DEFAULT_WIDTH, height));
+		}
+
+		[TestCaseSource (nameof (out_of_bounds_access_cases))]
+		public void WidthAccessOutOfBoundsFails (int desiredWidth, int indexToAccess)
+		{
+			var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
+			var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
+			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
+			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
+		}
+
+		[TestCaseSource (nameof (within_bounds_access_cases))]
+		public void WidthAccessWithinBoundsSucceeds (int desiredWidth, int indexToAccess)
+		{
+			var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
+			var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
+			Assert.DoesNotThrow (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
+			Assert.DoesNotThrow (() => _ = mask[coordinates]);
+		}
+
+		[TestCaseSource (nameof (out_of_bounds_access_cases))]
+		public void HeightAccessOutOfBoundsFails (int desiredHeight, int indexToAccess)
+		{
+			var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
+			var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
+			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
+			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
+		}
+
+		[TestCaseSource (nameof (within_bounds_access_cases))]
+		public void HeightAccessWithinBoundsSucceeds (int desiredHeight, int indexToAccess)
+		{
+			var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
+			var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
+			Assert.DoesNotThrow (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
+			Assert.DoesNotThrow (() => _ = mask[coordinates]);
+		}
+
+		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+		public void BitInitializedToFalse (int maskWidth, int maskHeight, int bitToTestX, int bitToTestY)
+		{
+			var mask = new BitMask (maskWidth, maskHeight);
+			var bit = mask[bitToTestX, bitToTestY];
+			Assert.IsFalse (bit);
+		}
+
+		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+		public void BitInvertsWithXY (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
+		{
+			var mask = new BitMask (maskWidth, maskHeight);
+			mask.Invert (bitToInvertX, bitToInvertY);
+			var bit = mask[bitToInvertX, bitToInvertY];
+			Assert.IsTrue (bit);
+		}
+
+		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+		public void BitInvertsWithScanline (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
+		{
+			var mask = new BitMask (maskWidth, maskHeight);
+			var scanline = new Scanline (bitToInvertX, bitToInvertY, 1);
+			mask.Invert (scanline);
+			var bit = mask[bitToInvertX, bitToInvertY];
+			Assert.IsTrue (bit);
+		}
+
+		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX, new[] { true, false, true, false })]
+		public void BitGetsSetXY (int maskWidth, int maskHeight, int bitToSetX, int bitToSetY, bool[] valuesToSetAndTest)
+		{
+			var mask = new BitMask (maskWidth, maskHeight);
+			var coordinates = new PointI (bitToSetX, bitToSetY);
+			foreach (var value in valuesToSetAndTest) {
+				mask.Set(bitToSetX, bitToSetY, value);
+				Assert.AreEqual (value, mask[bitToSetX, bitToSetY]);
+				Assert.AreEqual (value, mask[coordinates]);
+			}
+		}
+
+		static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new[]
+		{
+			new TestCaseData(0, 0),
+			new TestCaseData(0, 1),
+			new TestCaseData(1, 1),
+			new TestCaseData(1, 2),
+			new TestCaseData(1, -1),
+			new TestCaseData(1, int.MinValue),
+			new TestCaseData(1, int.MinValue + 1),
+			new TestCaseData(1, int.MaxValue),
+			new TestCaseData(1, int.MaxValue - 1),
+			new TestCaseData(2, 2),
+		};
+
+		static readonly IReadOnlyList<TestCaseData> within_bounds_access_cases = new[]
+		{
+			new TestCaseData(DEFAULT_SIZE, DEFAULT_OFFSET),
+			new TestCaseData(2, 1),
+		};
+	}
+}

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -97,7 +97,7 @@ internal sealed class BitMaskTest
 		var mask = new BitMask (maskWidth, maskHeight);
 		var coordinates = new PointI (bitToSetX, bitToSetY);
 		foreach (var value in valuesToSetAndTest) {
-			mask.Set(bitToSetX, bitToSetY, value);
+			mask.Set (bitToSetX, bitToSetY, value);
 			Assert.AreEqual (value, mask[bitToSetX, bitToSetY]);
 			Assert.AreEqual (value, mask[coordinates]);
 		}

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -2,125 +2,124 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace Pinta.Core.Tests
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class BitMaskTest
 {
-	[TestFixture]
-	internal sealed class BitMaskTest
+	const int DEFAULT_SIZE = 1;
+	const int DEFAULT_OFFSET = 0;
+
+	const int DEFAULT_HEIGHT = DEFAULT_SIZE;
+	const int DEFAULT_HEIGHT_INDEX = DEFAULT_OFFSET;
+
+	const int DEFAULT_WIDTH = DEFAULT_SIZE;
+	const int DEFAULT_WIDTH_INDEX = DEFAULT_OFFSET;
+
+	[TestCase (-1)]
+	public void Constructor_RejectsInvalidWidth (int width)
 	{
-		const int DEFAULT_SIZE = 1;
-		const int DEFAULT_OFFSET = 0;
-
-		const int DEFAULT_HEIGHT = DEFAULT_SIZE;
-		const int DEFAULT_HEIGHT_INDEX = DEFAULT_OFFSET;
-
-		const int DEFAULT_WIDTH = DEFAULT_SIZE;
-		const int DEFAULT_WIDTH_INDEX = DEFAULT_OFFSET;
-
-		[TestCase (-1)]
-		public void Constructor_RejectsInvalidWidth (int width)
-		{
-			Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (width, DEFAULT_HEIGHT));
-		}
-
-		[TestCase (-1)]
-		public void Constructor_RejectsInvalidHeight (int height)
-		{
-			Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (DEFAULT_WIDTH, height));
-		}
-
-		[TestCaseSource (nameof (out_of_bounds_access_cases))]
-		public void WidthAccessOutOfBoundsFails (int desiredWidth, int indexToAccess)
-		{
-			var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
-			var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
-			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
-			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
-		}
-
-		[TestCaseSource (nameof (within_bounds_access_cases))]
-		public void WidthAccessWithinBoundsSucceeds (int desiredWidth, int indexToAccess)
-		{
-			var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
-			var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
-			Assert.DoesNotThrow (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
-			Assert.DoesNotThrow (() => _ = mask[coordinates]);
-		}
-
-		[TestCaseSource (nameof (out_of_bounds_access_cases))]
-		public void HeightAccessOutOfBoundsFails (int desiredHeight, int indexToAccess)
-		{
-			var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
-			var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
-			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
-			Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
-		}
-
-		[TestCaseSource (nameof (within_bounds_access_cases))]
-		public void HeightAccessWithinBoundsSucceeds (int desiredHeight, int indexToAccess)
-		{
-			var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
-			var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
-			Assert.DoesNotThrow (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
-			Assert.DoesNotThrow (() => _ = mask[coordinates]);
-		}
-
-		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
-		public void BitInitializedToFalse (int maskWidth, int maskHeight, int bitToTestX, int bitToTestY)
-		{
-			var mask = new BitMask (maskWidth, maskHeight);
-			var bit = mask[bitToTestX, bitToTestY];
-			Assert.IsFalse (bit);
-		}
-
-		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
-		public void BitInvertsWithXY (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
-		{
-			var mask = new BitMask (maskWidth, maskHeight);
-			mask.Invert (bitToInvertX, bitToInvertY);
-			var bit = mask[bitToInvertX, bitToInvertY];
-			Assert.IsTrue (bit);
-		}
-
-		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
-		public void BitInvertsWithScanline (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
-		{
-			var mask = new BitMask (maskWidth, maskHeight);
-			var scanline = new Scanline (bitToInvertX, bitToInvertY, 1);
-			mask.Invert (scanline);
-			var bit = mask[bitToInvertX, bitToInvertY];
-			Assert.IsTrue (bit);
-		}
-
-		[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX, new[] { true, false, true, false })]
-		public void BitGetsSetXY (int maskWidth, int maskHeight, int bitToSetX, int bitToSetY, bool[] valuesToSetAndTest)
-		{
-			var mask = new BitMask (maskWidth, maskHeight);
-			var coordinates = new PointI (bitToSetX, bitToSetY);
-			foreach (var value in valuesToSetAndTest) {
-				mask.Set(bitToSetX, bitToSetY, value);
-				Assert.AreEqual (value, mask[bitToSetX, bitToSetY]);
-				Assert.AreEqual (value, mask[coordinates]);
-			}
-		}
-
-		static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new[]
-		{
-			new TestCaseData(0, 0),
-			new TestCaseData(0, 1),
-			new TestCaseData(1, 1),
-			new TestCaseData(1, 2),
-			new TestCaseData(1, -1),
-			new TestCaseData(1, int.MinValue),
-			new TestCaseData(1, int.MinValue + 1),
-			new TestCaseData(1, int.MaxValue),
-			new TestCaseData(1, int.MaxValue - 1),
-			new TestCaseData(2, 2),
-		};
-
-		static readonly IReadOnlyList<TestCaseData> within_bounds_access_cases = new[]
-		{
-			new TestCaseData(DEFAULT_SIZE, DEFAULT_OFFSET),
-			new TestCaseData(2, 1),
-		};
+		Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (width, DEFAULT_HEIGHT));
 	}
+
+	[TestCase (-1)]
+	public void Constructor_RejectsInvalidHeight (int height)
+	{
+		Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (DEFAULT_WIDTH, height));
+	}
+
+	[TestCaseSource (nameof (out_of_bounds_access_cases))]
+	public void WidthAccessOutOfBoundsFails (int desiredWidth, int indexToAccess)
+	{
+		var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
+		var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
+	}
+
+	[TestCaseSource (nameof (within_bounds_access_cases))]
+	public void WidthAccessWithinBoundsSucceeds (int desiredWidth, int indexToAccess)
+	{
+		var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
+		var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
+		Assert.DoesNotThrow (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
+		Assert.DoesNotThrow (() => _ = mask[coordinates]);
+	}
+
+	[TestCaseSource (nameof (out_of_bounds_access_cases))]
+	public void HeightAccessOutOfBoundsFails (int desiredHeight, int indexToAccess)
+	{
+		var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
+		var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
+	}
+
+	[TestCaseSource (nameof (within_bounds_access_cases))]
+	public void HeightAccessWithinBoundsSucceeds (int desiredHeight, int indexToAccess)
+	{
+		var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
+		var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
+		Assert.DoesNotThrow (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
+		Assert.DoesNotThrow (() => _ = mask[coordinates]);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+	public void BitInitializedToFalse (int maskWidth, int maskHeight, int bitToTestX, int bitToTestY)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		var bit = mask[bitToTestX, bitToTestY];
+		Assert.IsFalse (bit);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+	public void BitInvertsWithXY (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		mask.Invert (bitToInvertX, bitToInvertY);
+		var bit = mask[bitToInvertX, bitToInvertY];
+		Assert.IsTrue (bit);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+	public void BitInvertsWithScanline (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		var scanline = new Scanline (bitToInvertX, bitToInvertY, 1);
+		mask.Invert (scanline);
+		var bit = mask[bitToInvertX, bitToInvertY];
+		Assert.IsTrue (bit);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX, new[] { true, false, true, false })]
+	public void BitGetsSetXY (int maskWidth, int maskHeight, int bitToSetX, int bitToSetY, bool[] valuesToSetAndTest)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		var coordinates = new PointI (bitToSetX, bitToSetY);
+		foreach (var value in valuesToSetAndTest) {
+			mask.Set(bitToSetX, bitToSetY, value);
+			Assert.AreEqual (value, mask[bitToSetX, bitToSetY]);
+			Assert.AreEqual (value, mask[coordinates]);
+		}
+	}
+
+	static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new[]
+	{
+		new TestCaseData(0, 0),
+		new TestCaseData(0, 1),
+		new TestCaseData(1, 1),
+		new TestCaseData(1, 2),
+		new TestCaseData(1, -1),
+		new TestCaseData(1, int.MinValue),
+		new TestCaseData(1, int.MinValue + 1),
+		new TestCaseData(1, int.MaxValue),
+		new TestCaseData(1, int.MaxValue - 1),
+		new TestCaseData(2, 2),
+	};
+
+	static readonly IReadOnlyList<TestCaseData> within_bounds_access_cases = new[]
+	{
+		new TestCaseData(DEFAULT_SIZE, DEFAULT_OFFSET),
+		new TestCaseData(2, 1),
+	};
 }


### PR DESCRIPTION
They don't cover all of its features yet, but it's a good start.

One of my goals is to be able to safely refactor algorithm code in the future (the tests would give us some peace of mind that the refactoring is functionally equivalent to the original). The specific algorithm that I want to refactor uses `BitMask`, so I'm adding tests to it first.

Also, I sealed the `BitMask` class and added argument checks.