### PR TITLE
Added simple test to `OtherExtensions.ToReadOnlyCollection`

### DIFF
--- a/tests/Pinta.Core.Tests/OtherExtensionsTest.cs
+++ b/tests/Pinta.Core.Tests/OtherExtensionsTest.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class OtherExtensionsTest
+{
+	[Test]
+	public void ToReadOnlyCollection_SecondInvocationReturnsSelf ()
+	{
+		var source = Enumerable.Range (0, 10);
+		var materialized1 = source.ToReadOnlyCollection ();
+		var materialized2 = materialized1.ToReadOnlyCollection ();
+		Assert.AreSame (materialized1, materialized2);
+	}
+}


### PR DESCRIPTION
In a previous pull request, I added an extension method called `ToReadOnlyCollection`. One of the claims in the documentation comments is "[...] it creates a wrapped read-only copy of the values generated by the `IEnumerable<T>` argument [...] except if [...] the argument is an object that has been previously returned from this method, in which case the reference is returned as is."

Let's put that claim to the test