### PR TITLE
Added tests for `Scanline`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <!-- Dependencies used for unit tests -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.7" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Tmds.DBus" Version="0.15.0" />
 
     <!-- Dependencies used for unit tests -->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.6" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.7" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Pinta.Core/Actions/AdjustmentsActions.cs
+++ b/Pinta.Core/Actions/AdjustmentsActions.cs
@@ -24,25 +24,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
-namespace Pinta.Core
+namespace Pinta.Core;
+
+public sealed class AdjustmentsActions
 {
-	public class AdjustmentsActions
+	public Collection<Command> Actions { get; } = new ();
+
+	#region Public Methods
+	public void ToggleActionsSensitive (bool sensitive)
 	{
-		public List<Command> Actions { get; }
-
-		public AdjustmentsActions ()
-		{
-			Actions = new List<Command> ();
-		}
-
-		#region Public Methods
-		public void ToggleActionsSensitive (bool sensitive)
-		{
-			foreach (var a in Actions)
-				a.Sensitive = sensitive;
-		}
-		#endregion
+		foreach (var a in Actions)
+			a.Sensitive = sensitive;
 	}
+	#endregion
 }

--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -100,7 +100,7 @@ namespace Pinta.Core
 		public ToggledHandler? Toggled;
 
 		// TODO-GTK4 (bindings) - missing GLib.Variant bindings (https://github.com/gircore/gir.core/issues/843)
-		private static GLib.Variant CreateBoolVariant (bool v) => new GLib.Variant (GLib.Internal.Variant.NewBoolean (v));
+		private static GLib.Variant CreateBoolVariant (bool v) => new (GLib.Internal.Variant.NewBoolean (v));
 		private static bool GetBoolValue (GLib.Variant val) => GLib.Internal.Variant.GetBoolean (val.Handle);
 	}
 }

--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -35,9 +35,7 @@ namespace Pinta.Core
 	public class Command
 	{
 		public Gio.SimpleAction Action { get; }
-		public string Name {
-			get { return Action.Name!; }
-		}
+		public string Name => Action.Name!;
 		public SignalHandler<SimpleAction, SimpleAction.ActivateSignalArgs>? Activated;
 		public void Activate ()
 		{
@@ -48,7 +46,7 @@ namespace Pinta.Core
 		public string? ShortLabel { get; set; }
 		public string? Tooltip { get; }
 		public string? IconName { get; }
-		public string FullName { get { return $"app.{Name}"; } }
+		public string FullName => $"app.{Name}";
 		public bool IsImportant { get; set; } = false;
 		public bool Sensitive { get { return Action.Enabled; } set { Action.Enabled = value; } }
 

--- a/Pinta.Core/Actions/EffectsActions.cs
+++ b/Pinta.Core/Actions/EffectsActions.cs
@@ -25,13 +25,14 @@
 // THE SOFTWARE.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Pinta.Core
 {
-	public class EffectsActions
+	public sealed class EffectsActions
 	{
 		public Dictionary<string, Gio.Menu> Menus { get; } = new ();
-		public List<Command> Actions { get; } = new ();
+		public Collection<Command> Actions { get; } = new ();
 
 		public EffectsActions ()
 		{

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -100,9 +100,7 @@ namespace Pinta.Core
 			timer_tick_id = 0;
 		}
 
-		internal bool IsRendering {
-			get { return is_rendering; }
-		}
+		internal bool IsRendering => is_rendering;
 
 		internal double Progress {
 			get {

--- a/Pinta.Core/Classes/BasePaintBrush.cs
+++ b/Pinta.Core/Classes/BasePaintBrush.cs
@@ -35,7 +35,7 @@ namespace Pinta.Core
 	[Mono.Addins.TypeExtensionPoint]
 	public abstract class BasePaintBrush
 	{
-		private static readonly Random random = new Random ();
+		private static readonly Random random = new ();
 
 		/// <summary>
 		/// The name of the brush.

--- a/Pinta.Core/Classes/BasePaintBrush.cs
+++ b/Pinta.Core/Classes/BasePaintBrush.cs
@@ -46,25 +46,19 @@ namespace Pinta.Core
 		/// Priority value for ordering brushes. If the priority is zero, then
 		/// alphabetical ordering is used.
 		/// </summary>
-		public virtual int Priority {
-			get { return 0; }
-		}
+		public virtual int Priority => 0;
 
 		/// <summary>
 		/// Random number generator. This can be used to implement brushes with
 		/// random effects.
 		/// </summary>
-		public Random Random {
-			get { return random; }
-		}
+		public Random Random => random;
 
 		/// <summary>
 		/// Used to multiply the alpha value of the stroke color by a
 		/// constant factor.
 		/// </summary>
-		public virtual double StrokeAlphaMultiplier {
-			get { return 1; }
-		}
+		public virtual double StrokeAlphaMultiplier => 1;
 
 		public virtual void DoMouseUp ()
 		{

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -357,7 +357,7 @@ namespace Pinta.Core
 			}
 		}
 
-		private ToolBoxButton CreateToolButton () => new ToolBoxButton (this);
+		private ToolBoxButton CreateToolButton () => new (this);
 		#endregion
 
 		#region Event Invokers

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -55,7 +55,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public DocumentSelection PreviousSelection = new DocumentSelection ();
+		public DocumentSelection PreviousSelection = new ();
 
 		public Document (Core.Size size)
 		{

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -113,7 +113,7 @@ namespace Pinta.Core
 		/// Pinta from a file, or if the user just clicked Save As.
 		public bool HasBeenSavedInSession { get; set; }
 
-		public DocumentHistory History { get { return Workspace.History; } }
+		public DocumentHistory History => Workspace.History;
 
 		public Core.Size ImageSize { get; set; }
 

--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -32,7 +32,7 @@ namespace Pinta.Core
 	public class DocumentHistory
 	{
 		private readonly Document document;
-		private readonly List<BaseHistoryItem> history = new List<BaseHistoryItem> ();
+		private readonly List<BaseHistoryItem> history = new ();
 		private int clean_pointer = -1;
 
 		public event EventHandler<HistoryItemAddedEventArgs>? HistoryItemAdded;

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -134,7 +134,7 @@ namespace Pinta.Core
 		/// </summary>
 		/// <param name="pintaPolygonSet">A Pinta Polygon set.</param>
 		/// <returns>A Clipper Polygon collection.</returns>
-		public static List<List<IntPoint>> ConvertToPolygons (PointI[][] pintaPolygonSet)
+		public static List<List<IntPoint>> ConvertToPolygons (IReadOnlyList<IReadOnlyList<PointI>> pintaPolygonSet)
 		{
 			List<List<IntPoint>> newPolygons = new List<List<IntPoint>> ();
 

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -36,8 +36,8 @@ namespace Pinta.Core
 	{
 		private Path? selection_path;
 
-		public List<List<IntPoint>> SelectionPolygons = new List<List<IntPoint>> ();
-		public Clipper SelectionClipper = new Clipper ();
+		public List<List<IntPoint>> SelectionPolygons = new ();
+		public Clipper SelectionClipper = new ();
 
 		public PointD Origin;
 		public PointD End;

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -100,7 +100,7 @@ namespace Pinta.Core
 		/// Offset to center the image view in the canvas widget.
 		/// (When zoomed out, the widget will have a larger allocated size than the image view size).
 		/// </summary>
-		public PointD Offset => new PointD (
+		public PointD Offset => new (
 			(Canvas.GetAllocatedWidth () - view_size.Width) / 2,
 			(Canvas.GetAllocatedHeight () - view_size.Height) / 2);
 

--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -50,11 +50,7 @@ namespace Pinta.Core
 				PaletteChanged (this, EventArgs.Empty);
 		}
 
-		public int Count {
-			get {
-				return colors.Count;
-			}
-		}
+		public int Count => colors.Count;
 
 		public Color this[int index] {
 			get {

--- a/Pinta.Core/Classes/Point.cs
+++ b/Pinta.Core/Classes/Point.cs
@@ -73,7 +73,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns a new point, rounded to the nearest integer coordinates.
 		/// </summary>
-		public PointD Rounded () => new PointD (Math.Round (X), Math.Round (Y));
+		public PointD Rounded () => new (Math.Round (X), Math.Round (Y));
 
 		public static PointD operator + (in PointD a, in PointD b)
 		{

--- a/Pinta.Core/Classes/Point.cs
+++ b/Pinta.Core/Classes/Point.cs
@@ -42,7 +42,7 @@ namespace Pinta.Core
 		public int X;
 		public int Y;
 
-		public override string ToString () => $"{X}, {Y}";
+		public override readonly string ToString () => $"{X}, {Y}";
 	}
 
 	public record struct PointD
@@ -56,16 +56,16 @@ namespace Pinta.Core
 		public double X;
 		public double Y;
 
-		public override string ToString () => $"{X}, {Y}";
+		public override readonly string ToString () => $"{X}, {Y}";
 
-		public PointI ToInt () => new ((int) X, (int) Y);
+		public readonly PointI ToInt () => new ((int) X, (int) Y);
 
-		public double Distance (in PointD e)
+		public readonly double Distance (in PointD e)
 		{
 			return new PointD (X - e.X, Y - e.Y).Magnitude ();
 		}
 
-		public double Magnitude ()
+		public readonly double Magnitude ()
 		{
 			return Math.Sqrt (X * X + Y * Y);
 		}
@@ -73,7 +73,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns a new point, rounded to the nearest integer coordinates.
 		/// </summary>
-		public PointD Rounded () => new (Math.Round (X), Math.Round (Y));
+		public readonly PointD Rounded () => new (Math.Round (X), Math.Round (Y));
 
 		public static PointD operator + (in PointD a, in PointD b)
 		{
@@ -94,9 +94,9 @@ namespace Pinta.Core
 
 		public static readonly Size Empty;
 
-		public override string ToString () => $"{Width}, {Height}";
+		public override readonly string ToString () => $"{Width}, {Height}";
 
-		public bool IsEmpty => (Width == 0 && Height == 0);
+		public readonly bool IsEmpty => (Width == 0 && Height == 0);
 	}
 }
 

--- a/Pinta.Core/Classes/Re-editable/ReEditableLayer.cs
+++ b/Pinta.Core/Classes/Re-editable/ReEditableLayer.cs
@@ -37,7 +37,7 @@ namespace Pinta.Core
 
 		private bool inTheLoop = false;
 
-		public bool InTheLoop { get { return inTheLoop; } }
+		public bool InTheLoop => inTheLoop;
 
 		public Layer Layer {
 			get {
@@ -53,11 +53,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public bool IsLayerSetup {
-			get {
-				return isLayerSetup;
-			}
-		}
+		public bool IsLayerSetup => isLayerSetup;
 
 		/// <summary>
 		/// Creates a new ReEditableLayer for drawing and editing on separately from the rest of the image.

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -29,8 +29,8 @@ namespace Pinta.Core
 		public TextAlignment Alignment { get; private set; }
 		public bool Underline { get; private set; }
 
-		public TextPosition CurrentPosition { get { return currentPos; } }
-		public int LineCount { get { return lines.Count; } }
+		public TextPosition CurrentPosition => currentPos;
+		public int LineCount => lines.Count;
 		public TextMode State;
 		public PointI Origin { get; set; }
 

--- a/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
@@ -46,7 +46,7 @@ namespace Pinta.Core
 		}
 
 		public Pango.Layout Layout { get; }
-		public int FontHeight { get { return GetCursorLocation ().Height; } }
+		public int FontHeight => GetCursorLocation ().Height;
 
 		public TextLayout ()
 		{

--- a/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
@@ -23,27 +23,27 @@ namespace Pinta.Core
 		}
 
 		public int Line {
-			get { return line; }
+			readonly get { return line; }
 			set { line = Math.Max (value, 0); }
 		}
 
 		public int Offset {
-			get { return offset; }
+			readonly get { return offset; }
 			set { offset = Math.Max (value, 0); }
 		}
 
 		#region Operators
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			return obj is TextPosition && this == (TextPosition) obj;
 		}
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			return new { line, offset }.GetHashCode ();
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return $"({line}, {offset})";
 		}
@@ -58,7 +58,7 @@ namespace Pinta.Core
 			return x.CompareTo (y) != 0;
 		}
 
-		public int CompareTo (TextPosition other)
+		public readonly int CompareTo (TextPosition other)
 		{
 			if (line.CompareTo (other.line) != 0)
 				return line.CompareTo (other.line);

--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -48,7 +48,7 @@ namespace Pinta.Core
 		{
 		}
 
-		public RectangleI ToInt () => new RectangleI ((int) Math.Floor (X), (int) Math.Floor (Y),
+		public RectangleI ToInt () => new ((int) Math.Floor (X), (int) Math.Floor (Y),
 							      (int) Math.Ceiling (Width), (int) Math.Ceiling (Height));
 
 		public double Left => X;
@@ -71,8 +71,8 @@ namespace Pinta.Core
 
 		public bool ContainsPoint (in PointD point) => ContainsPoint (point.X, point.Y);
 
-		public PointD Location () => new PointD (X, Y);
-		public PointD GetCenter () => new PointD (X + 0.5 * Width, Y + 0.5 * Height);
+		public PointD Location () => new (X, Y);
+		public PointD GetCenter () => new (X + 0.5 * Width, Y + 0.5 * Height);
 
 		public void Inflate (double width, double height)
 		{
@@ -138,9 +138,9 @@ namespace Pinta.Core
 		public static readonly RectangleI Zero;
 
 		public static RectangleI FromLTRB (int left, int top, int right, int bottom)
-			=> new RectangleI (left, top, right - left + 1, bottom - top + 1);
+			=> new (left, top, right - left + 1, bottom - top + 1);
 
-		public RectangleD ToDouble () => new RectangleD (X, Y, Width, Height);
+		public RectangleD ToDouble () => new (X, Y, Width, Height);
 
 		public int Left => X;
 		public int Top => Y;
@@ -149,8 +149,8 @@ namespace Pinta.Core
 
 		public bool IsEmpty => (Width == 0) || (Height == 0);
 
-		public PointI Location => new PointI (X, Y);
-		public Size Size => new Size (Width, Height);
+		public PointI Location => new (X, Y);
+		public Size Size => new (Width, Height);
 
 		public override string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
 

--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -48,17 +48,17 @@ namespace Pinta.Core
 		{
 		}
 
-		public RectangleI ToInt () => new ((int) Math.Floor (X), (int) Math.Floor (Y),
+		public readonly RectangleI ToInt () => new ((int) Math.Floor (X), (int) Math.Floor (Y),
 							      (int) Math.Ceiling (Width), (int) Math.Ceiling (Height));
 
-		public double Left => X;
-		public double Top => Y;
-		public double Right => X + Width - 1;
-		public double Bottom => Y + Height - 1;
+		public readonly double Left => X;
+		public readonly double Top => Y;
+		public readonly double Right => X + Width - 1;
+		public readonly double Bottom => Y + Height - 1;
 
-		public override string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
+		public override readonly string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
 
-		public bool ContainsPoint (double x, double y)
+		public readonly bool ContainsPoint (double x, double y)
 		{
 			if (x < this.X || x >= this.X + this.Width)
 				return false;
@@ -71,8 +71,8 @@ namespace Pinta.Core
 
 		public bool ContainsPoint (in PointD point) => ContainsPoint (point.X, point.Y);
 
-		public PointD Location () => new (X, Y);
-		public PointD GetCenter () => new (X + 0.5 * Width, Y + 0.5 * Height);
+		public readonly PointD Location () => new (X, Y);
+		public readonly PointD GetCenter () => new (X + 0.5 * Width, Y + 0.5 * Height);
 
 		public void Inflate (double width, double height)
 		{
@@ -82,14 +82,14 @@ namespace Pinta.Core
 			Height += height * 2;
 		}
 
-		public RectangleD Inflated (double width, double height)
+		public readonly RectangleD Inflated (double width, double height)
 		{
 			RectangleD copy = this;
 			copy.Inflate (width, height);
 			return copy;
 		}
 
-		public RectangleD Clamp ()
+		public readonly RectangleD Clamp ()
 		{
 			double x = this.X;
 			double y = this.Y;
@@ -140,19 +140,19 @@ namespace Pinta.Core
 		public static RectangleI FromLTRB (int left, int top, int right, int bottom)
 			=> new (left, top, right - left + 1, bottom - top + 1);
 
-		public RectangleD ToDouble () => new (X, Y, Width, Height);
+		public readonly RectangleD ToDouble () => new (X, Y, Width, Height);
 
-		public int Left => X;
-		public int Top => Y;
-		public int Right => X + Width - 1;
-		public int Bottom => Y + Height - 1;
+		public readonly int Left => X;
+		public readonly int Top => Y;
+		public readonly int Right => X + Width - 1;
+		public readonly int Bottom => Y + Height - 1;
 
-		public bool IsEmpty => (Width == 0) || (Height == 0);
+		public readonly bool IsEmpty => (Width == 0) || (Height == 0);
 
-		public PointI Location => new (X, Y);
-		public Size Size => new (Width, Height);
+		public readonly PointI Location => new (X, Y);
+		public readonly Size Size => new (Width, Height);
 
-		public override string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
+		public override readonly string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
 
 		public bool Contains (int x, int y)
 		{
@@ -161,7 +161,7 @@ namespace Pinta.Core
 
 		public bool Contains (in PointI pt) => Contains (pt.X, pt.Y);
 
-		public RectangleI Intersect (RectangleI r) => Intersect (this, r);
+		public readonly RectangleI Intersect (RectangleI r) => Intersect (this, r);
 
 		public static RectangleI Intersect (in RectangleI a, in RectangleI b)
 		{
@@ -176,7 +176,7 @@ namespace Pinta.Core
 			return FromLTRB (left, top, right, bottom);
 		}
 
-		public RectangleI Union (RectangleI r) => Union (this, r);
+		public readonly RectangleI Union (RectangleI r) => Union (this, r);
 
 		public static RectangleI Union (in RectangleI a, in RectangleI b)
 		{

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -21,8 +21,8 @@ namespace Pinta.Core
 		private readonly int denominator;
 		private readonly int numerator;
 
-		public readonly int Denominator { get { return denominator; } }
-		public readonly int Numerator { get { return numerator; } }
+		public readonly int Denominator => denominator;
+		public readonly int Numerator => numerator;
 		public double Ratio { get; }
 
 		public static readonly ScaleFactor OneToOne = new (1, 1);

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -21,8 +21,8 @@ namespace Pinta.Core
 		private readonly int denominator;
 		private readonly int numerator;
 
-		public int Denominator { get { return denominator; } }
-		public int Numerator { get { return numerator; } }
+		public readonly int Denominator { get { return denominator; } }
+		public readonly int Numerator { get { return numerator; } }
 		public double Ratio { get; }
 
 		public static readonly ScaleFactor OneToOne = new (1, 1);
@@ -109,7 +109,7 @@ namespace Pinta.Core
 			return (lhs.numerator * rhs.denominator) >= (rhs.numerator * lhs.denominator);
 		}
 
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			if (obj is ScaleFactor) {
 				ScaleFactor rhs = (ScaleFactor) obj;
@@ -119,7 +119,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			return numerator.GetHashCode () ^ denominator.GetHashCode ();
 		}
@@ -138,32 +138,32 @@ namespace Pinta.Core
 		//    }
 		//}
 
-		public int ScaleScalar (int x)
+		public readonly int ScaleScalar (int x)
 		{
 			return (int) (((long) x * numerator) / denominator);
 		}
 
-		public int UnscaleScalar (int x)
+		public readonly int UnscaleScalar (int x)
 		{
 			return (int) (((long) x * denominator) / numerator);
 		}
 
-		public float ScaleScalar (float x)
+		public readonly float ScaleScalar (float x)
 		{
 			return (x * (float) numerator) / (float) denominator;
 		}
 
-		public float UnscaleScalar (float x)
+		public readonly float UnscaleScalar (float x)
 		{
 			return (x * (float) denominator) / (float) numerator;
 		}
 
-		public double ScaleScalar (double x)
+		public readonly double ScaleScalar (double x)
 		{
 			return (x * (double) numerator) / (double) denominator;
 		}
 
-		public double UnscaleScalar (double x)
+		public readonly double UnscaleScalar (double x)
 		{
 			return (x * (double) denominator) / (double) numerator;
 		}
@@ -293,7 +293,7 @@ namespace Pinta.Core
 		/// Rounds the current scaling factor up to the next power of two.
 		/// </summary>
 		/// <returns>The new ScaleFactor value.</returns>
-		public ScaleFactor GetNextLarger ()
+		public readonly ScaleFactor GetNextLarger ()
 		{
 			double ratio = Ratio + 0.005;
 
@@ -312,7 +312,7 @@ namespace Pinta.Core
 			return ScaleFactor.FromDouble (scales[index]);
 		}
 
-		public ScaleFactor GetNextSmaller ()
+		public readonly ScaleFactor GetNextSmaller ()
 		{
 			double ratio = Ratio - 0.005;
 

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -25,9 +25,9 @@ namespace Pinta.Core
 		public int Numerator { get { return numerator; } }
 		public double Ratio { get; }
 
-		public static readonly ScaleFactor OneToOne = new ScaleFactor (1, 1);
-		public static readonly ScaleFactor MinValue = new ScaleFactor (1, 100);
-		public static readonly ScaleFactor MaxValue = new ScaleFactor (32, 1);
+		public static readonly ScaleFactor OneToOne = new (1, 1);
+		public static readonly ScaleFactor MinValue = new (1, 100);
+		public static readonly ScaleFactor MaxValue = new (32, 1);
 
 		private void Clamp ()
 		{

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -37,7 +37,7 @@ namespace Pinta.Core
 	public class UserLayer : Layer
 	{
 		//Special layers to be drawn on to keep things editable by drawing them separately from the UserLayers.
-		public List<ReEditableLayer> ReEditableLayers = new List<ReEditableLayer> ();
+		public List<ReEditableLayer> ReEditableLayers = new ();
 		public ReEditableLayer TextLayer;
 
 		//Call the base class constructor and setup the engines.

--- a/Pinta.Core/Effects/BaseEffect.cs
+++ b/Pinta.Core/Effects/BaseEffect.cs
@@ -50,22 +50,22 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns whether this effect can display a configuration dialog to the user. (Implemented by LaunchConfiguration ().)
 		/// </summary>
-		public virtual bool IsConfigurable { get { return false; } }
+		public virtual bool IsConfigurable => false;
 
 		/// <summary>
 		/// Returns the keyboard shortcut for this adjustment. Only affects adjustments, not effects. Default is no shortcut.
 		/// </summary>
-		public virtual string? AdjustmentMenuKey { get { return null; } }
+		public virtual string? AdjustmentMenuKey => null;
 
 		/// <summary>
 		/// Returns the modifier(s) to the keyboard shortcut. Only affects adjustments, not effects. Default is Primary+Shift.
 		/// </summary>
-		public virtual string AdjustmentMenuKeyModifiers { get { return "<Primary><Shift>"; } }
+		public virtual string AdjustmentMenuKeyModifiers => "<Primary><Shift>";
 
 		/// <summary>
 		/// Returns the menu category for an effect. Only affects effects, not adjustments. Default is "General".
 		/// </summary>
-		public virtual string EffectMenuCategory { get { return "General"; } }
+		public virtual string EffectMenuCategory => "General";
 
 		/// <summary>
 		/// The user configurable data this effect uses.
@@ -217,7 +217,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns true if the current values of this EffectData do not modify the image. Returns false if current values modify the image.
 		/// </summary>
-		public virtual bool IsDefault { get { return false; } }
+		public virtual bool IsDefault => false;
 	}
 
 	/// <summary>

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -1,69 +1,73 @@
+using System;
 using System.Collections;
 
-namespace Pinta.Core
+namespace Pinta.Core;
+
+/// <summary>
+/// Represents a two-dimensional matrix of bits used to store a
+/// true/false value for each pixel in an image.
+/// </summary>
+public sealed class BitMask
 {
-	// Represent a two dimensional matrix of bits used to store a
-	// true/false value for each pixel in an image.
-	public class BitMask
+	private readonly BitArray array;
+
+	public BitMask (int width, int height)
 	{
-		private readonly BitArray array;
+		if (width < 0)
+			throw new ArgumentOutOfRangeException (nameof (width));
+		if (height < 0)
+			throw new ArgumentOutOfRangeException (nameof (height));
 
-		public BitMask (int width, int height)
-		{
-			Width = width;
-			Height = height;
+		Width = width;
+		Height = height;
 
-			array = new BitArray (width * height);
-		}
-
-		public bool this[PointI pt] {
-			get => this[pt.X, pt.Y];
-			set => this[pt.X, pt.Y] = value;
-		}
-
-		public bool this[int x, int y] {
-			get => Get (x, y);
-			set => Set (x, y, value);
-		}
-
-		public int Width { get; }
-
-		public int Height { get; }
-
-		public bool IsEmpty => array.Length == 0;
-
-		public void Clear (bool newValue) => array.SetAll (newValue);
-
-		public bool Get (int x, int y) => array.Get (GetIndex (x, y));
-
-		public void Invert (int x, int y)
-		{
-			var index = GetIndex (x, y);
-
-			array[index] = !array[index];
-		}
-
-		public void Invert (Scanline scan)
-		{
-			var x = scan.X;
-
-			while (x < scan.X + scan.Length) {
-				Invert (x, scan.Y);
-				++x;
-			}
-		}
-
-		public void Set (int x, int y, bool newValue) => array[GetIndex (x, y)] = newValue;
-
-		public void Set (RectangleI rect, bool newValue)
-		{
-			for (var y = rect.Y; y <= rect.Bottom; ++y) {
-				for (var x = rect.X; x <= rect.Right; ++x) {
-					Set (x, y, newValue);
-				}
-			}
-		}
-
-		private int GetIndex (int x, int y) => (y * Width) + x;
+		array = new BitArray (width * height);
 	}
+
+	public bool this[PointI pt] {
+		get => this[pt.X, pt.Y];
+		set => this[pt.X, pt.Y] = value;
+	}
+
+	public bool this[int x, int y] {
+		get => Get (x, y);
+		set => Set (x, y, value);
+	}
+
+	public int Width { get; }
+
+	public int Height { get; }
+
+	public bool IsEmpty => array.Length == 0;
+
+	public void Clear (bool newValue) => array.SetAll (newValue);
+
+	public bool Get (int x, int y) => array.Get (GetIndex (x, y));
+
+	public void Invert (int x, int y)
+	{
+		var index = GetIndex (x, y);
+
+		array[index] = !array[index];
+	}
+
+	public void Invert (Scanline scan)
+	{
+		var x = scan.X;
+		while (x < scan.X + scan.Length) {
+			Invert (x, scan.Y);
+			++x;
+		}
+	}
+
+	public void Set (int x, int y, bool newValue) => array[GetIndex (x, y)] = newValue;
+
+	public void Set (RectangleI rect, bool newValue)
+	{
+		for (var y = rect.Y; y <= rect.Bottom; ++y)
+			for (var x = rect.X; x <= rect.Right; ++x)
+				Set (x, y, newValue);
+	}
+
+	private int GetIndex (int x, int y) => (y * Width) + x;
 }

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -69,5 +69,12 @@ public sealed class BitMask
 				Set (x, y, newValue);
 	}
 
-	private int GetIndex (int x, int y) => (y * Width) + x;
+	private int GetIndex (int x, int y)
+	{
+		if (x < 0)
+			throw new ArgumentOutOfRangeException (nameof (x));
+		if (y < 0)
+			throw new ArgumentOutOfRangeException (nameof (y));
+		return (y * Width) + x;
+	}
 }

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -671,16 +671,16 @@ namespace Pinta.Core
 		//// Colors: copied from System.Drawing.Color's list (don't worry I didn't type it in 
 		//// manually, I used a code generator w/ reflection ...)
 
-		public static ColorBgra Transparent { get { return ColorBgra.FromBgra (255, 255, 255, 0); } }
-		public static ColorBgra Zero { get { return (ColorBgra) 0; } }
+		public static ColorBgra Transparent => ColorBgra.FromBgra (255, 255, 255, 0);
+		public static ColorBgra Zero => (ColorBgra) 0;
 
-		public static ColorBgra Black { get { return ColorBgra.FromBgra (0, 0, 0, 255); } }
-		public static ColorBgra Blue { get { return ColorBgra.FromBgra (255, 0, 0, 255); } }
-		public static ColorBgra Cyan { get { return ColorBgra.FromBgra (255, 255, 0, 255); } }
-		public static ColorBgra Green { get { return ColorBgra.FromBgra (0, 128, 0, 255); } }
-		public static ColorBgra Magenta { get { return ColorBgra.FromBgra (255, 0, 255, 255); } }
-		public static ColorBgra Red { get { return ColorBgra.FromBgra (0, 0, 255, 255); } }
-		public static ColorBgra White { get { return ColorBgra.FromBgra (255, 255, 255, 255); } }
-		public static ColorBgra Yellow { get { return ColorBgra.FromBgra (0, 255, 255, 255); } }
+		public static ColorBgra Black => ColorBgra.FromBgra (0, 0, 0, 255);
+		public static ColorBgra Blue => ColorBgra.FromBgra (255, 0, 0, 255);
+		public static ColorBgra Cyan => ColorBgra.FromBgra (255, 255, 0, 255);
+		public static ColorBgra Green => ColorBgra.FromBgra (0, 128, 0, 255);
+		public static ColorBgra Magenta => ColorBgra.FromBgra (255, 0, 255, 255);
+		public static ColorBgra Red => ColorBgra.FromBgra (0, 0, 255, 255);
+		public static ColorBgra White => ColorBgra.FromBgra (255, 255, 255, 255);
+		public static ColorBgra Yellow => ColorBgra.FromBgra (0, 255, 255, 255);
 	}
 }

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -57,7 +57,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public string ToHexString ()
+		public readonly string ToHexString ()
 		{
 			int rgbNumber = (this.R << 16) | (this.G << 8) | this.B;
 			string colorString = Convert.ToString (rgbNumber, 16);
@@ -106,7 +106,7 @@ namespace Pinta.Core
 		/// Gets the luminance intensity of the pixel based on the values of the red, green, and blue components. Alpha is ignored.
 		/// </summary>
 		/// <returns>A value in the range 0 to 1 inclusive.</returns>
-		public double GetIntensity ()
+		public readonly double GetIntensity ()
 		{
 			return ((0.114 * (double) B) + (0.587 * (double) G) + (0.299 * (double) R)) / 255.0;
 		}
@@ -115,7 +115,7 @@ namespace Pinta.Core
 		/// Gets the luminance intensity of the pixel based on the values of the red, green, and blue components. Alpha is ignored.
 		/// </summary>
 		/// <returns>A value in the range 0 to 255 inclusive.</returns>
-		public byte GetIntensityByte ()
+		public readonly byte GetIntensityByte ()
 		{
 			return (byte) ((7471 * B + 38470 * G + 19595 * R) >> 16);
 		}
@@ -124,7 +124,7 @@ namespace Pinta.Core
 		/// Returns the maximum value out of the B, G, and R values. Alpha is ignored.
 		/// </summary>
 		/// <returns></returns>
-		public byte GetMaxColorChannelValue ()
+		public readonly byte GetMaxColorChannelValue ()
 		{
 			return Math.Max (this.B, Math.Max (this.G, this.R));
 		}
@@ -133,7 +133,7 @@ namespace Pinta.Core
 		/// Returns the average of the B, G, and R values. Alpha is ignored.
 		/// </summary>
 		/// <returns></returns>
-		public byte GetAverageColorChannelValue ()
+		public readonly byte GetAverageColorChannelValue ()
 		{
 			return (byte) ((this.B + this.G + this.R) / 3);
 		}
@@ -157,7 +157,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Compares two ColorBgra instance to determine if they are equal.
 		/// </summary>
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 
 			if (obj != null && obj is ColorBgra && ((ColorBgra) obj).Bgra == this.Bgra) {
@@ -171,7 +171,7 @@ namespace Pinta.Core
 		/// Returns a hash code for this color value.
 		/// </summary>
 		/// <returns></returns>
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			unchecked {
 				return (int) Bgra;
@@ -181,7 +181,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns a new ColorBgra with the same color values but with a new alpha component value.
 		/// </summary>
-		public ColorBgra NewAlpha (byte newA)
+		public readonly ColorBgra NewAlpha (byte newA)
 		{
 			return ColorBgra.FromBgra (B, G, R, newA);
 		}
@@ -595,7 +595,7 @@ namespace Pinta.Core
 			return ColorBgra.FromBgra (b, g, r, a);
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return "B: " + B + ", G: " + G + ", R: " + R + ", A: " + A;
 		}
@@ -625,7 +625,7 @@ namespace Pinta.Core
 		/// http://cairographics.org/manual/cairo-Image-Surfaces.html#cairo-format-t
 		/// </summary>
 		/// <returns>A ColorBgra value in premultiplied alpha form</returns> 
-		public ColorBgra ToPremultipliedAlpha ()
+		public readonly ColorBgra ToPremultipliedAlpha ()
 		{
 			return ColorBgra.FromBgra ((byte) (B * A / 255), (byte) (G * A / 255), (byte) (R * A / 255), A);
 		}
@@ -660,7 +660,7 @@ namespace Pinta.Core
 		/// http://cairographics.org/manual/cairo-Image-Surfaces.html#cairo-format-t
 		/// </summary>
 		/// <returns>A ColorBgra value in straight alpha form</returns> 
-		public ColorBgra ToStraightAlpha ()
+		public readonly ColorBgra ToStraightAlpha ()
 		{
 			if (this.A > 0)
 				return ColorBgra.FromBgra ((byte) (B * 255 / A), (byte) (G * 255 / A), (byte) (R * 255 / A), A);

--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -27,8 +27,7 @@ namespace Pinta.Core
 		private readonly ColorBgra[] lerp_colors;
 
 		public ColorBgra StartColor {
-			get { return this.start_color; }
-
+			get => this.start_color;
 			set {
 				if (this.start_color != value) {
 					this.start_color = value;
@@ -38,8 +37,7 @@ namespace Pinta.Core
 		}
 
 		public ColorBgra EndColor {
-			get { return this.end_color; }
-
+			get => this.end_color;
 			set {
 				if (this.end_color != value) {
 					this.end_color = value;
@@ -49,27 +47,23 @@ namespace Pinta.Core
 		}
 
 		public PointD StartPoint {
-			get { return this.start_point; }
-
-			set { this.start_point = value; }
+			get => this.start_point;
+			set => this.start_point = value;
 		}
 
 		public PointD EndPoint {
-			get { return this.end_point; }
-
-			set { this.end_point = value; }
+			get => this.end_point;
+			set => this.end_point = value;
 		}
 
 		public bool AlphaBlending {
-			get { return this.alpha_blending; }
-
-			set { this.alpha_blending = value; }
+			get => this.alpha_blending;
+			set => this.alpha_blending = value;
 		}
 
 		public bool AlphaOnly {
-			get { return this.alpha_only; }
-
-			set { this.alpha_only = value; }
+			get => this.alpha_only;
+			set => this.alpha_only = value;
 		}
 
 		public virtual void BeforeRender ()

--- a/Pinta.Core/Effects/GradientRenderers.cs
+++ b/Pinta.Core/Effects/GradientRenderers.cs
@@ -43,8 +43,8 @@ namespace Pinta.Core
 
 		public abstract class LinearStraight : LinearBase
 		{
-			private int _startY;
-			private int _startX;
+			private int start_y;
+			private int start_x;
 
 			protected internal LinearStraight (bool alphaOnly, BinaryPixelOp normalBlendOp)
 				: base (alphaOnly, normalBlendOp)
@@ -60,15 +60,15 @@ namespace Pinta.Core
 			{
 				base.BeforeRender ();
 
-				_startX = (int) StartPoint.X;
-				_startY = (int) StartPoint.Y;
+				start_x = (int) StartPoint.X;
+				start_y = (int) StartPoint.Y;
 
 			}
 
 			public override byte ComputeByteLerp (int x, int y)
 			{
-				var dx = x - _startX;
-				var dy = y - _startY;
+				var dx = x - start_x;
+				var dy = y - start_y;
 
 				var lerp = (dx * dtdx) + (dy * dtdy);
 
@@ -118,37 +118,37 @@ namespace Pinta.Core
 
 		public sealed class Radial : GradientRenderer
 		{
-			private double invDistanceScale;
+			private double inv_distance_scale;
 
 			public Radial (bool alphaOnly, BinaryPixelOp normalBlendOp) : base (alphaOnly, normalBlendOp)
 			{
 			}
 
-			int _startX, _startY;
+			int start_x, start_y;
 
 			public override void BeforeRender ()
 			{
 				var distanceScale = StartPoint.Distance (EndPoint);
 
-				_startX = (int) StartPoint.X;
-				_startY = (int) StartPoint.Y;
+				start_x = (int) StartPoint.X;
+				start_y = (int) StartPoint.Y;
 
 				if (distanceScale == 0)
-					invDistanceScale = 0;
+					inv_distance_scale = 0;
 				else
-					invDistanceScale = 1f / distanceScale;
+					inv_distance_scale = 1f / distanceScale;
 
 				base.BeforeRender ();
 			}
 
 			public override byte ComputeByteLerp (int x, int y)
 			{
-				var dx = x - _startX;
-				var dy = y - _startY;
+				var dx = x - start_x;
+				var dy = y - start_y;
 
 				var distance = Math.Sqrt (dx * dx + dy * dy);
 
-				var result = distance * invDistanceScale;
+				var result = distance * inv_distance_scale;
 				if (result < 0.0)
 					return 0;
 				return result > 1.0 ? (byte) 255 : (byte) (result * 255f);
@@ -157,8 +157,8 @@ namespace Pinta.Core
 
 		public sealed class Conical : GradientRenderer
 		{
-			private const double invPi = 1.0 / Math.PI;
-			private double tOffset;
+			private const double InvPi = 1.0 / Math.PI;
+			private double t_offset;
 
 			public Conical (bool alphaOnly, BinaryPixelOp normalBlendOp) : base (alphaOnly, normalBlendOp)
 			{
@@ -171,9 +171,9 @@ namespace Pinta.Core
 
 				var theta = Math.Atan2 (ay, ax);
 
-				var t = theta * invPi;
+				var t = theta * InvPi;
 
-				tOffset = -t;
+				t_offset = -t;
 				base.BeforeRender ();
 			}
 
@@ -184,9 +184,9 @@ namespace Pinta.Core
 
 				var theta = Math.Atan2 (ay, ax);
 
-				var t = theta * invPi;
+				var t = theta * InvPi;
 
-				return (byte) (BoundLerp (t + tOffset) * 255f);
+				return (byte) (BoundLerp (t + t_offset) * 255f);
 			}
 
 			public double BoundLerp (double t)

--- a/Pinta.Core/Effects/Histogram.cs
+++ b/Pinta.Core/Effects/Histogram.cs
@@ -33,17 +33,9 @@ namespace Pinta.Core
 			}
 		}
 
-		public int Channels {
-			get {
-				return this.histogram.Length;
-			}
-		}
+		public int Channels => this.histogram.Length;
 
-		public int Entries {
-			get {
-				return this.histogram[0].Length;
-			}
-		}
+		public int Entries => this.histogram[0].Length;
 
 		protected internal Histogram (int channels, int entries)
 		{

--- a/Pinta.Core/Effects/HsvColor.cs
+++ b/Pinta.Core/Effects/HsvColor.cs
@@ -36,12 +36,12 @@ namespace Pinta.Core
 			return !(lhs == rhs);
 		}
 
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			return obj is HsvColor hsv && this == hsv;
 		}
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			return (Hue + (Saturation << 8) + (Value << 16)).GetHashCode (); ;
 		}
@@ -77,7 +77,7 @@ namespace Pinta.Core
 		//            return Color.FromArgb(rgb.Red, rgb.Green, rgb.Blue);
 		//        }
 
-		public RgbColor ToRgb ()
+		public readonly RgbColor ToRgb ()
 		{
 			// HsvColor contains values scaled as in the color wheel:
 
@@ -171,7 +171,7 @@ namespace Pinta.Core
 			return new RgbColor ((int) (r * 255), (int) (g * 255), (int) (b * 255));
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return $"({Hue}, {Saturation}, {Value})";
 		}

--- a/Pinta.Core/Effects/RgbColor.cs
+++ b/Pinta.Core/Effects/RgbColor.cs
@@ -53,7 +53,7 @@ namespace Pinta.Core
 		//            return Color.FromArgb(Red, Green, Blue);
 		//        }
 
-		public HsvColor ToHsv ()
+		public readonly HsvColor ToHsv ()
 		{
 			// In this function, R, G, and B values must be scaled 
 			// to be between 0 and 1.
@@ -111,7 +111,7 @@ namespace Pinta.Core
 			return new HsvColor ((int) h, (int) (s * 100), (int) (v * 100));
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return $"({Red}, {Green}, {Blue})";
 		}

--- a/Pinta.Core/Effects/Scanline.cs
+++ b/Pinta.Core/Effects/Scanline.cs
@@ -13,23 +13,11 @@ namespace Pinta.Core
 		private readonly int y;
 		private readonly int length;
 
-		public int X {
-			get {
-				return x;
-			}
-		}
+		public readonly int X => x;
 
-		public int Y {
-			get {
-				return y;
-			}
-		}
+		public readonly int Y => y;
 
-		public int Length {
-			get {
-				return length;
-			}
-		}
+		public readonly int Length => length;
 
 		public override int GetHashCode ()
 		{

--- a/Pinta.Core/Effects/Scanline.cs
+++ b/Pinta.Core/Effects/Scanline.cs
@@ -19,14 +19,14 @@ namespace Pinta.Core
 
 		public readonly int Length => length;
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			unchecked {
 				return length.GetHashCode () + x.GetHashCode () + y.GetHashCode ();
 			}
 		}
 
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			if (obj is Scanline) {
 				Scanline rhs = (Scanline) obj;
@@ -46,7 +46,7 @@ namespace Pinta.Core
 			return !(lhs == rhs);
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return "(" + x + "," + y + "):[" + length.ToString () + "]";
 		}

--- a/Pinta.Core/Effects/SplineInterpolator.cs
+++ b/Pinta.Core/Effects/SplineInterpolator.cs
@@ -11,7 +11,7 @@ namespace Pinta.Core
 {
 	public sealed class SplineInterpolator
 	{
-		private readonly SortedList<double, double> points = new SortedList<double, double> ();
+		private readonly SortedList<double, double> points = new ();
 		private double[]? y2;
 
 		public int Count {

--- a/Pinta.Core/Effects/SplineInterpolator.cs
+++ b/Pinta.Core/Effects/SplineInterpolator.cs
@@ -14,11 +14,7 @@ namespace Pinta.Core
 		private readonly SortedList<double, double> points = new ();
 		private double[]? y2;
 
-		public int Count {
-			get {
-				return this.points.Count;
-			}
-		}
+		public int Count => this.points.Count;
 
 		public void Add (double x, double y)
 		{

--- a/Pinta.Core/Effects/UserBlendOps.cs
+++ b/Pinta.Core/Effects/UserBlendOps.cs
@@ -23,7 +23,7 @@ namespace Pinta.Core
 	/// </summary>
 	public sealed partial class UserBlendOps
 	{
-		private static readonly Dictionary<string, BlendMode> blend_modes = new Dictionary<string, BlendMode> ();
+		private static readonly Dictionary<string, BlendMode> blend_modes = new ();
 
 		static UserBlendOps ()
 		{

--- a/Pinta.Core/EventArgs/BrushEventArgs.cs
+++ b/Pinta.Core/EventArgs/BrushEventArgs.cs
@@ -26,16 +26,15 @@
 
 using System;
 
-namespace Pinta.Core
-{
-	public class BrushEventArgs : EventArgs
-	{
-		public BasePaintBrush Brush { get; set; }
+namespace Pinta.Core;
 
-		public BrushEventArgs (BasePaintBrush brush)
-		{
-			Brush = brush;
-		}
+public sealed class BrushEventArgs : EventArgs
+{
+	public BasePaintBrush Brush { get; }
+
+	public BrushEventArgs (BasePaintBrush brush)
+	{
+		Brush = brush;
 	}
 }
 

--- a/Pinta.Core/EventArgs/CanvasInvalidatedEventArgs.cs
+++ b/Pinta.Core/EventArgs/CanvasInvalidatedEventArgs.cs
@@ -26,22 +26,22 @@
 
 using System;
 
-namespace Pinta.Core
+namespace Pinta.Core;
+
+public sealed class CanvasInvalidatedEventArgs : EventArgs
 {
-	public class CanvasInvalidatedEventArgs : EventArgs
+	public bool EntireSurface { get; }
+	public RectangleI Rectangle { get; }
+
+	public CanvasInvalidatedEventArgs ()
 	{
-		public bool EntireSurface { get; set; }
-		public RectangleI Rectangle { get; set; }
+		EntireSurface = true;
+		Rectangle = default;
+	}
 
-		public CanvasInvalidatedEventArgs ()
-		{
-			EntireSurface = true;
-		}
-
-		public CanvasInvalidatedEventArgs (RectangleI rect)
-		{
-			EntireSurface = false;
-			Rectangle = rect;
-		}
+	public CanvasInvalidatedEventArgs (RectangleI rect)
+	{
+		EntireSurface = false;
+		Rectangle = rect;
 	}
 }

--- a/Pinta.Core/EventArgs/DocumentCancelEventArgs.cs
+++ b/Pinta.Core/EventArgs/DocumentCancelEventArgs.cs
@@ -28,9 +28,9 @@ using System.ComponentModel;
 
 namespace Pinta.Core;
 
-public class DocumentCancelEventArgs : CancelEventArgs
+public sealed class DocumentCancelEventArgs : CancelEventArgs
 {
-	public Document Document { get; set; }
+	public Document Document { get; }
 	public bool SaveAs { get; }
 
 	public DocumentCancelEventArgs (Document document, bool saveAs)

--- a/Pinta.Core/EventArgs/DocumentEventArgs.cs
+++ b/Pinta.Core/EventArgs/DocumentEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace Pinta.Core;
 
-public class DocumentEventArgs : EventArgs
+public sealed class DocumentEventArgs : EventArgs
 {
-	public Document Document { get; set; }
+	public Document Document { get; }
 
 	public DocumentEventArgs (Document document)
 	{

--- a/Pinta.Core/EventArgs/HistoryItemAddedEventArgs.cs
+++ b/Pinta.Core/EventArgs/HistoryItemAddedEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace Pinta.Core;
 
-public class HistoryItemAddedEventArgs : EventArgs
+public sealed class HistoryItemAddedEventArgs : EventArgs
 {
-	public BaseHistoryItem Item { get; set; }
+	public BaseHistoryItem Item { get; }
 
 	public HistoryItemAddedEventArgs (BaseHistoryItem item)
 	{

--- a/Pinta.Core/EventArgs/LivePreviewEndedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewEndedEventArgs.cs
@@ -32,15 +32,15 @@ public enum RenderStatus
 {
 	Completed,
 	Canceled,
-	Faulted
+	Faulted,
 }
 
-public class LivePreviewEndedEventArgs : EventArgs
+public sealed class LivePreviewEndedEventArgs : EventArgs
 {
 	public LivePreviewEndedEventArgs (RenderStatus status, Exception? exception)
 	{
-		this.Status = status;
-		this.Exception = exception;
+		Status = status;
+		Exception = exception;
 	}
 
 	public RenderStatus Status { get; }

--- a/Pinta.Core/EventArgs/LivePreviewRenderUpdatedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewRenderUpdatedEventArgs.cs
@@ -28,13 +28,12 @@ using System;
 
 namespace Pinta.Core;
 
-public class LivePreviewRenderUpdatedEventArgs : EventArgs
+public sealed class LivePreviewRenderUpdatedEventArgs : EventArgs
 {
-	public LivePreviewRenderUpdatedEventArgs (double progress,
-						   RectangleI bounds)
+	public LivePreviewRenderUpdatedEventArgs (double progress, RectangleI bounds)
 	{
-		this.Progress = progress;
-		this.Bounds = bounds;
+		Progress = progress;
+		Bounds = bounds;
 	}
 
 	public double Progress { get; }

--- a/Pinta.Core/EventArgs/LivePreviewStartedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewStartedEventArgs.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace Pinta.Core;
 
-public class LivePreviewStartedEventArgs : EventArgs
+public sealed class LivePreviewStartedEventArgs : EventArgs
 {
 	public LivePreviewStartedEventArgs ()
 	{

--- a/Pinta.Core/EventArgs/TextChangedEventArgs.cs
+++ b/Pinta.Core/EventArgs/TextChangedEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace Pinta.Core;
 
-public class TextChangedEventArgs : EventArgs
+public sealed class TextChangedEventArgs : EventArgs
 {
-	public string Text { get; set; }
+	public string Text { get; }
 
 	public TextChangedEventArgs (string text)
 	{

--- a/Pinta.Core/EventArgs/ToolEventArgs.cs
+++ b/Pinta.Core/EventArgs/ToolEventArgs.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace Pinta.Core;
 
-public class ToolEventArgs : EventArgs
+public sealed class ToolEventArgs : EventArgs
 {
 	public BaseTool Tool { get; }
 

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1096,7 +1096,7 @@ namespace Pinta.Core
 			public int Width;
 			public int Height;
 
-			public RectangleI ToRectangleI () => new (X, Y, Width, Height);
+			public readonly RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
 		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_create_rectangle")]

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1096,7 +1096,7 @@ namespace Pinta.Core
 			public int Width;
 			public int Height;
 
-			public RectangleI ToRectangleI () => new RectangleI (X, Y, Width, Height);
+			public RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
 		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_create_rectangle")]

--- a/Pinta.Core/Extensions/GioStream.cs
+++ b/Pinta.Core/Extensions/GioStream.cs
@@ -71,17 +71,11 @@ namespace Pinta.Core
 			can_seek = stream is Gio.Seekable s && s.CanSeek ();
 		}
 
-		public override bool CanSeek {
-			get { return can_seek; }
-		}
+		public override bool CanSeek => can_seek;
 
-		public override bool CanRead {
-			get { return can_read; }
-		}
+		public override bool CanRead => can_read;
 
-		public override bool CanWrite {
-			get { return can_write; }
-		}
+		public override bool CanWrite => can_write;
 
 		public override long Length {
 			get {

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -92,7 +92,7 @@ namespace Pinta.Core
 			return false;
 		}
 
-		public static PointI[][] CreatePolygonSet (this BitMask stencil, RectangleD bounds, int translateX, int translateY)
+		public static IReadOnlyList<IReadOnlyList<PointI>> CreatePolygonSet (this BitMask stencil, RectangleD bounds, int translateX, int translateY)
 		{
 			if (stencil.IsEmpty)
 				return Array.Empty<PointI[]> ();
@@ -180,7 +180,7 @@ namespace Pinta.Core
 				polygons.Add (points);
 			}
 
-			return polygons.ToArray ();
+			return polygons;
 		}
 	}
 }

--- a/Pinta.Core/Extensions/PangoExtensions.cs
+++ b/Pinta.Core/Extensions/PangoExtensions.cs
@@ -107,7 +107,7 @@ namespace Pinta.Core
 			public int Width;
 			public int Height;
 
-			public RectangleI ToRectangleI () => new (X, Y, Width, Height);
+			public readonly RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
 		public static int UnitsToPixels (int units)

--- a/Pinta.Core/Extensions/PangoExtensions.cs
+++ b/Pinta.Core/Extensions/PangoExtensions.cs
@@ -45,10 +45,10 @@ namespace Pinta.Core
 		}
 
 		public static FontDescription CreateFontDescription ()
-			=> new FontDescription (Pango.Internal.FontDescription.New ());
+			=> new (Pango.Internal.FontDescription.New ());
 
 		public static FontDescription Copy (this FontDescription desc)
-			=> new FontDescription (Pango.Internal.FontDescription.Copy (desc.Handle));
+			=> new (Pango.Internal.FontDescription.Copy (desc.Handle));
 
 		public static int GetSize (this FontDescription desc)
 			=> Pango.Internal.FontDescription.GetSize (desc.Handle);
@@ -107,7 +107,7 @@ namespace Pinta.Core
 			public int Width;
 			public int Height;
 
-			public RectangleI ToRectangleI () => new RectangleI (X, Y, Width, Height);
+			public RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
 		public static int UnitsToPixels (int units)

--- a/Pinta.Core/HistoryItems/BaseHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/BaseHistoryItem.cs
@@ -34,7 +34,7 @@ namespace Pinta.Core
 		public string? Text { get; set; }
 		public HistoryItemState State { get; set; }
 		public uint Id;
-		public virtual bool CausesDirty { get { return true; } }
+		public virtual bool CausesDirty => true;
 
 		public BaseHistoryItem ()
 		{

--- a/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core
 {
 	public class CompoundHistoryItem : BaseHistoryItem
 	{
-		protected List<BaseHistoryItem> history_stack = new List<BaseHistoryItem> ();
+		protected List<BaseHistoryItem> history_stack = new ();
 		private List<ImageSurface>? snapshots;
 
 		public CompoundHistoryItem () : base ()

--- a/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
@@ -34,7 +34,7 @@ namespace Pinta.Core
 		private ImageSurface? old_surface;
 		private Matrix old_transform = CairoExtensions.CreateIdentityMatrix ();
 
-		public override bool CausesDirty { get { return false; } }
+		public override bool CausesDirty => false;
 
 		public FinishPixelsHistoryItem ()
 		{

--- a/Pinta.Core/HistoryItems/PasteHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/PasteHistoryItem.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core
 		private readonly Cairo.ImageSurface paste_image;
 		private DocumentSelection old_selection;
 
-		public override bool CausesDirty { get { return true; } }
+		public override bool CausesDirty => true;
 
 		public PasteHistoryItem (Cairo.ImageSurface pasteImage, DocumentSelection oldSelection)
 		{

--- a/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
@@ -33,7 +33,7 @@ namespace Pinta.Core
 
 		private bool hide_tool_layer;
 
-		public override bool CausesDirty { get { return false; } }
+		public override bool CausesDirty => false;
 
 		public SelectionHistoryItem (string icon, string text) : base (icon, text)
 		{

--- a/Pinta.Core/ImageFormats/TgaExporter.cs
+++ b/Pinta.Core/ImageFormats/TgaExporter.cs
@@ -61,7 +61,7 @@ namespace Pinta.Core
 			public byte pixelDepth;          // Pixel Depth
 			public byte imageDesc;           // Image Descriptor
 
-			public void WriteTo (BinaryWriter output)
+			public readonly void WriteTo (BinaryWriter output)
 			{
 				output.Write (this.idLength);
 				output.Write (this.cmapType);

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -50,7 +50,7 @@ namespace Pinta.Core
 		public Box ToolBox { get; private set; } = null!;
 		public Box StatusBar { get; private set; } = null!;
 
-		public IProgressDialog ProgressDialog { get { return progress_dialog; } }
+		public IProgressDialog ProgressDialog => progress_dialog;
 		public Gio.Menu AdjustmentsMenu { get; private set; } = null!;
 		public Gio.Menu EffectsMenu { get; private set; } = null!;
 

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -76,7 +76,7 @@ namespace Pinta.Core
 			RegisterFormat (new FormatDescriptor ("OpenRaster", new string[] { "ora", "ORA" }, new string[] { "image/openraster" }, oraHandler, oraHandler));
 		}
 
-		public IEnumerable<FormatDescriptor> Formats { get { return formats; } }
+		public IEnumerable<FormatDescriptor> Formats => formats;
 
 		/// <summary>
 		/// Registers a new file format.

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -60,9 +60,9 @@ namespace Pinta.Core
 			RenderUpdated += LivePreview_RenderUpdated;
 		}
 
-		public bool IsEnabled { get { return live_preview_enabled; } }
-		public Cairo.ImageSurface LivePreviewSurface { get { return live_preview_surface; } }
-		public RectangleI RenderBounds { get { return render_bounds; } }
+		public bool IsEnabled => live_preview_enabled;
+		public Cairo.ImageSurface LivePreviewSurface => live_preview_surface;
+		public RectangleI RenderBounds => render_bounds;
 
 		public event EventHandler<LivePreviewStartedEventArgs>? Started;
 		public event EventHandler<LivePreviewRenderUpdatedEventArgs>? RenderUpdated;

--- a/Pinta.Core/Managers/PaintBrushManager.cs
+++ b/Pinta.Core/Managers/PaintBrushManager.cs
@@ -37,7 +37,7 @@ namespace Pinta.Core
 
 	public class PaintBrushManager : IPaintBrushService
 	{
-		private readonly List<BasePaintBrush> paint_brushes = new List<BasePaintBrush> ();
+		private readonly List<BasePaintBrush> paint_brushes = new ();
 
 		public event EventHandler<BrushEventArgs>? BrushAdded;
 		public event EventHandler<BrushEventArgs>? BrushRemoved;

--- a/Pinta.Core/Managers/PaletteFormatManager.cs
+++ b/Pinta.Core/Managers/PaletteFormatManager.cs
@@ -47,7 +47,7 @@ namespace Pinta.Core
 			formats.Add (new PaletteDescriptor ("PaintShop Pro", new string[] { "pal", "PAL" }, pspHandler, pspHandler));
 		}
 
-		public IEnumerable<PaletteDescriptor> Formats { get { return formats; } }
+		public IEnumerable<PaletteDescriptor> Formats => formats;
 
 		public PaletteDescriptor? GetFormatByFilename (string fileName)
 		{

--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -50,7 +50,7 @@ namespace Pinta.Core
 		private const string SECONDARY_COLOR_SETTINGS_KEY = "secondary-color";
 		private const string RECENT_COLORS_SETTINGS_KEY = "recently-used-colors";
 
-		private readonly List<Color> recently_used = new List<Color> (MAX_RECENT_COLORS);
+		private readonly List<Color> recently_used = new (MAX_RECENT_COLORS);
 
 		public Color PrimaryColor {
 			get => primary;

--- a/Pinta.Core/Managers/ServiceManager.cs
+++ b/Pinta.Core/Managers/ServiceManager.cs
@@ -38,7 +38,7 @@ namespace Pinta.Core
 
 	public class ServiceManager : IServiceManager
 	{
-		private readonly Dictionary<Type, object> services = new Dictionary<Type, object> ();
+		private readonly Dictionary<Type, object> services = new ();
 
 		public T AddService<T> (T implementation) where T : class
 		{

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -35,7 +35,7 @@ namespace Pinta.Core
 		private static readonly OS operating_system;
 
 		public int RenderThreads { get; set; }
-		public OS OperatingSystem { get { return operating_system; } }
+		public OS OperatingSystem => operating_system;
 
 		public SystemManager ()
 		{

--- a/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
@@ -32,32 +32,28 @@ using Cairo;
 
 namespace Pinta.Core
 {
-	public class PaintDotNetPalette : IPaletteLoader, IPaletteSaver
+	public sealed class PaintDotNetPalette : IPaletteLoader, IPaletteSaver
 	{
 		public List<Color> Load (Gio.File file)
 		{
 			List<Color> colors = new List<Color> ();
 			using var stream = new GioStream (file.Read (null));
-			StreamReader reader = new StreamReader (stream);
+			using var reader = new StreamReader (stream);
 
-			try {
-				string? line = reader.ReadLine ();
-				do {
-					if (line is null || line.IndexOf (';') == 0)
-						continue;
+			string? line = reader.ReadLine ();
+			do {
+				if (line is null || line.IndexOf (';') == 0)
+					continue;
 
-					uint color = uint.Parse (line.Substring (0, 8), NumberStyles.HexNumber);
-					double b = (color & 0xff) / 255f;
-					double g = ((color >> 8) & 0xff) / 255f;
-					double r = ((color >> 16) & 0xff) / 255f;
-					double a = (color >> 24) / 255f;
-					colors.Add (new Color (r, g, b, a));
-				} while ((line = reader.ReadLine ()) != null);
+				uint color = uint.Parse (line.Substring (0, 8), NumberStyles.HexNumber);
+				double b = (color & 0xff) / 255f;
+				double g = ((color >> 8) & 0xff) / 255f;
+				double r = ((color >> 16) & 0xff) / 255f;
+				double a = (color >> 24) / 255f;
+				colors.Add (new Color (r, g, b, a));
+			} while ((line = reader.ReadLine ()) != null);
 
-				return colors;
-			} finally {
-				reader.Close ();
-			}
+			return colors;
 		}
 
 		public void Save (List<Color> colors, Gio.File file)

--- a/Pinta.Core/PaletteFormats/PaletteDescriptor.cs
+++ b/Pinta.Core/PaletteFormats/PaletteDescriptor.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 using Gtk;
 
@@ -31,7 +33,7 @@ namespace Pinta.Core
 {
 	public sealed class PaletteDescriptor
 	{
-		public string[] Extensions { get; }
+		public ReadOnlyCollection<string> Extensions { get; }
 
 		public IPaletteLoader Loader { get; }
 
@@ -39,16 +41,16 @@ namespace Pinta.Core
 
 		public FileFilter Filter { get; }
 
-		public PaletteDescriptor (string displayPrefix, string[] extensions, IPaletteLoader loader, IPaletteSaver saver)
+		public PaletteDescriptor (string displayPrefix, IEnumerable<string> extensions, IPaletteLoader loader, IPaletteSaver saver)
 		{
-			this.Extensions = extensions;
+			this.Extensions = extensions.ToReadOnlyCollection ();
 			this.Loader = loader;
 			this.Saver = saver;
 
 			var ff = FileFilter.New ();
 			StringBuilder formatNames = new StringBuilder ();
 
-			foreach (string ext in extensions) {
+			foreach (string ext in Extensions) {
 				if (formatNames.Length > 0)
 					formatNames.Append (", ");
 

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Pinta.Docking/Dock.cs
+++ b/Pinta.Docking/Dock.cs
@@ -32,7 +32,7 @@ namespace Pinta.Docking;
 /// </summary>
 public class Dock : Box
 {
-	private readonly DockPanel right_panel = new DockPanel ();
+	private readonly DockPanel right_panel = new ();
 	private readonly Paned pane = Paned.New (Orientation.Horizontal);
 
 	public Dock ()

--- a/Pinta.Docking/DockNotebook.cs
+++ b/Pinta.Docking/DockNotebook.cs
@@ -107,7 +107,7 @@ namespace Pinta.Docking
 		/// <summary>
 		/// The items currently in the notebook.
 		/// </summary>
-		public IEnumerable<IDockNotebookItem> Items { get { return items; } }
+		public IEnumerable<IDockNotebookItem> Items => items;
 
 		/// <summary>
 		/// Whether to show the tab bar.

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -98,7 +98,7 @@ namespace Pinta.Docking
 		/// <summary>
 		/// List of the items in this panel, which may be minimized or maximized.
 		/// </summary>
-		private readonly List<DockPanelItem> items = new List<DockPanelItem> ();
+		private readonly List<DockPanelItem> items = new ();
 
 		public DockPanel ()
 		{

--- a/Pinta.Effects/Adjustments/AutoLevelEffect.cs
+++ b/Pinta.Effects/Adjustments/AutoLevelEffect.cs
@@ -16,17 +16,11 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOps.Level? op;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsAutoLevel; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsAutoLevel;
 
-		public override string Name {
-			get { return Translations.GetString ("Auto Level"); }
-		}
+		public override string Name => Translations.GetString ("Auto Level");
 
-		public override string AdjustmentMenuKey {
-			get { return "L"; }
-		}
+		public override string AdjustmentMenuKey => "L";
 
 		public override void Render (ImageSurface src, ImageSurface dest, RectangleI[] rois)
 		{

--- a/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
+++ b/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
@@ -16,17 +16,11 @@ namespace Pinta.Effects
 	{
 		readonly UnaryPixelOp op = new UnaryPixelOps.Desaturate ();
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsBlackAndWhite; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsBlackAndWhite;
 
-		public override string Name {
-			get { return Translations.GetString ("Black and White"); }
-		}
+		public override string Name => Translations.GetString ("Black and White");
 
-		public override string AdjustmentMenuKey {
-			get { return "G"; }
-		}
+		public override string AdjustmentMenuKey => "G";
 
 		public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
 		{

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -20,23 +20,15 @@ namespace Pinta.Effects
 		private byte[]? rgb_table;
 		private bool table_calculated;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsBrightnessContrast; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsBrightnessContrast;
 
-		public override string Name {
-			get { return Translations.GetString ("Brightness / Contrast"); }
-		}
+		public override string Name => Translations.GetString ("Brightness / Contrast");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "B"; }
-		}
+		public override string AdjustmentMenuKey => "B";
 
-		public BrightnessContrastData Data { get { return (BrightnessContrastData) EffectData!; } } // NRT - Set in constructor
+		public BrightnessContrastData Data => (BrightnessContrastData) EffectData!;  // NRT - Set in constructor
 
 		public BrightnessContrastEffect ()
 		{
@@ -168,9 +160,7 @@ namespace Pinta.Effects
 			}
 
 			[Skip]
-			public override bool IsDefault {
-				get { return Brightness == 0 && Contrast == 0; }
-			}
+			public override bool IsDefault => Brightness == 0 && Contrast == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -18,23 +18,15 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOp? op = null;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsCurves; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsCurves;
 
-		public override string Name {
-			get { return Translations.GetString ("Curves"); }
-		}
+		public override string Name => Translations.GetString ("Curves");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "M"; }
-		}
+		public override string AdjustmentMenuKey => "M";
 
-		public CurvesData Data { get { return (CurvesData) EffectData!; } } // NRT - Set in constructor
+		public CurvesData Data => (CurvesData) EffectData!;  // NRT - Set in constructor
 
 		public CurvesEffect ()
 		{

--- a/Pinta.Effects/Adjustments/HueSaturationEffect.cs
+++ b/Pinta.Effects/Adjustments/HueSaturationEffect.cs
@@ -17,21 +17,13 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOp? op;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsHueSaturation; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsHueSaturation;
 
-		public override string Name {
-			get { return Translations.GetString ("Hue / Saturation"); }
-		}
+		public override string Name => Translations.GetString ("Hue / Saturation");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "U"; }
-		}
+		public override string AdjustmentMenuKey => "U";
 
 		public HueSaturationEffect ()
 		{
@@ -59,7 +51,7 @@ namespace Pinta.Effects
 			op.Apply (dest, src, rois);
 		}
 
-		private HueSaturationData Data { get { return (HueSaturationData) EffectData!; } } // NRT - Set in constructor
+		private HueSaturationData Data => (HueSaturationData) EffectData!;  // NRT - Set in constructor
 
 		private class HueSaturationData : EffectData
 		{
@@ -73,9 +65,7 @@ namespace Pinta.Effects
 			public int Lightness = 0;
 
 			[Skip]
-			public override bool IsDefault {
-				get { return Hue == 0 && Saturation == 100 && Lightness == 0; }
-			}
+			public override bool IsDefault => Hue == 0 && Saturation == 100 && Lightness == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Adjustments/InvertColorsEffect.cs
+++ b/Pinta.Effects/Adjustments/InvertColorsEffect.cs
@@ -16,17 +16,11 @@ namespace Pinta.Effects
 	{
 		readonly UnaryPixelOp op = new UnaryPixelOps.Invert ();
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsInvertColors; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsInvertColors;
 
-		public override string Name {
-			get { return Translations.GetString ("Invert Colors"); }
-		}
+		public override string Name => Translations.GetString ("Invert Colors");
 
-		public override string AdjustmentMenuKey {
-			get { return "I"; }
-		}
+		public override string AdjustmentMenuKey => "I";
 
 		public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
 		{

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -14,27 +14,17 @@ namespace Pinta.Effects
 {
 	public class LevelsEffect : BaseEffect
 	{
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsLevels; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsLevels;
 
-		public override string Name {
-			get { return Translations.GetString ("Levels"); }
-		}
+		public override string Name => Translations.GetString ("Levels");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "L"; }
-		}
+		public override string AdjustmentMenuKey => "L";
 
-		public override string AdjustmentMenuKeyModifiers {
-			get { return "<Primary>"; }
-		}
+		public override string AdjustmentMenuKeyModifiers => "<Primary>";
 
-		public LevelsData Data { get { return (LevelsData) EffectData!; } } // NRT - Set in constructor
+		public LevelsData Data => (LevelsData) EffectData!;  // NRT - Set in constructor
 
 		public LevelsEffect ()
 		{

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -16,23 +16,15 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOps.PosterizePixel? op = null;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsPosterize; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsPosterize;
 
-		public override string Name {
-			get { return Translations.GetString ("Posterize"); }
-		}
+		public override string Name => Translations.GetString ("Posterize");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "P"; }
-		}
+		public override string AdjustmentMenuKey => "P";
 
-		public PosterizeData Data { get { return (PosterizeData) EffectData!; } } // NRT - Set in constructor
+		public PosterizeData Data => (PosterizeData) EffectData!;  // NRT - Set in constructor
 
 		public PosterizeEffect ()
 		{

--- a/Pinta.Effects/Adjustments/SepiaEffect.cs
+++ b/Pinta.Effects/Adjustments/SepiaEffect.cs
@@ -17,17 +17,11 @@ namespace Pinta.Effects
 		readonly UnaryPixelOp desat = new UnaryPixelOps.Desaturate ();
 		readonly UnaryPixelOp level = new UnaryPixelOps.Desaturate ();
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsSepia; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsSepia;
 
-		public override string Name {
-			get { return Translations.GetString ("Sepia"); }
-		}
+		public override string Name => Translations.GetString ("Sepia");
 
-		public override string AdjustmentMenuKey {
-			get { return "E"; }
-		}
+		public override string AdjustmentMenuKey => "E";
 
 		public SepiaEffect ()
 		{

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -78,13 +78,9 @@ namespace Pinta.Effects
 			}
 		}
 
-		public ColorTransferMode Mode {
-			get {
-				return (combo_map.Active == 0) ?
+		public ColorTransferMode Mode => (combo_map.Active == 0) ?
 						ColorTransferMode.Rgb :
 						ColorTransferMode.Luminosity;
-			}
-		}
 
 		public CurvesData EffectData { get; }
 

--- a/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
@@ -39,17 +39,11 @@ namespace Pinta.Effects
 		private HScaleSpinButtonWidget blue_spinbox;
 		private CheckButton link_button;
 
-		public int Red {
-			get { return red_spinbox.ValueAsInt; }
-		}
+		public int Red => red_spinbox.ValueAsInt;
 
-		public int Green {
-			get { return green_spinbox.ValueAsInt; }
-		}
+		public int Green => green_spinbox.ValueAsInt;
 
-		public int Blue {
-			get { return blue_spinbox.ValueAsInt; }
-		}
+		public int Blue => blue_spinbox.ValueAsInt;
 
 		public PosterizeData? EffectData { get; set; }
 

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -54,7 +54,7 @@ namespace Pinta.Effects
 
 		#region Algorithm Code Ported From PDN
 		[ThreadStatic]
-		private static Random thread_rand = new Random ();
+		private static Random thread_rand = new ();
 		private const int TableSize = 16384;
 		private static int[] lookup;
 

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -23,19 +23,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsNoiseAddNoise;
 
-		public override string Name {
-			get { return Translations.GetString ("Add Noise"); }
-		}
+		public override string Name => Translations.GetString ("Add Noise");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Noise"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Noise");
 
-		public NoiseData Data { get { return (NoiseData) EffectData!; } } // NRT - Set in constructor
+		public NoiseData Data => (NoiseData) EffectData!;  // NRT - Set in constructor
 
 		static AddNoiseEffect ()
 		{

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortBulge;
 
-		public override string Name {
-			get { return Translations.GetString ("Bulge"); }
-		}
+		public override string Name => Translations.GetString ("Bulge");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public BulgeData Data {
-			get { return (BulgeData) EffectData!; } // NRT - Set in constructor
-		}
+		public BulgeData Data => (BulgeData) EffectData!;
 
 		public BulgeEffect ()
 		{
@@ -99,9 +91,7 @@ namespace Pinta.Effects
 			public Core.PointD Offset = new (0.0, 0.0);
 
 			[Skip]
-			public override bool IsDefault {
-				get { return Amount == 0; }
-			}
+			public override bool IsDefault => Amount == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -23,19 +23,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderClouds;
 
-		public override string Name {
-			get { return Translations.GetString ("Clouds"); }
-		}
+		public override string Name => Translations.GetString ("Clouds");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Render"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Render");
 
-		public CloudsData Data { get { return (CloudsData) EffectData!; } } // NRT - Set in constructor
+		public CloudsData Data => (CloudsData) EffectData!;  // NRT - Set in constructor
 
 		public CloudsEffect ()
 		{
@@ -192,7 +186,7 @@ namespace Pinta.Effects
 		public class CloudsData : EffectData
 		{
 			[Skip]
-			public override bool IsDefault { get { return Power == 0; } }
+			public override bool IsDefault => Power == 0;
 
 			[Caption ("Scale"), MinimumValue (2), MaximumValue (1000)]
 			public int Scale = 250;

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -19,7 +19,7 @@ namespace Pinta.Effects
 	{
 		// This is so that repetition of the effect with CTRL+F actually shows up differently.
 		private readonly byte instance_seed = unchecked((byte) DateTime.Now.Ticks);
-		private static readonly object render_lock = new object ();
+		private static readonly object render_lock = new ();
 
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderClouds;
 

--- a/Pinta.Effects/Effects/EdgeDetectEffect.cs
+++ b/Pinta.Effects/Effects/EdgeDetectEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeEdgeDetect;
 
-		public override string Name {
-			get { return Translations.GetString ("Edge Detect"); }
-		}
+		public override string Name => Translations.GetString ("Edge Detect");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
-		public EdgeDetectData Data { get { return (EdgeDetectData) EffectData!; } } // NRT - Set in constructor
+		public EdgeDetectData Data => (EdgeDetectData) EffectData!;  // NRT - Set in constructor
 
 		public EdgeDetectEffect ()
 		{

--- a/Pinta.Effects/Effects/EmbossEffect.cs
+++ b/Pinta.Effects/Effects/EmbossEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeEmboss;
 
-		public override string Name {
-			get { return Translations.GetString ("Emboss"); }
-		}
+		public override string Name => Translations.GetString ("Emboss");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
-		public EmbossData Data {
-			get { return (EmbossData) EffectData!; } // NRT - Set in constructor
-		}
+		public EmbossData Data => (EmbossData) EffectData!;
 
 		public EmbossEffect ()
 		{

--- a/Pinta.Effects/Effects/FragmentEffect.cs
+++ b/Pinta.Effects/Effects/FragmentEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursFragment;
 
-		public override string Name {
-			get { return Translations.GetString ("Fragment"); }
-		}
+		public override string Name => Translations.GetString ("Fragment");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public FragmentData Data { get { return (FragmentData) EffectData!; } } // NRT - Set in constructor
+		public FragmentData Data => (FragmentData) EffectData!;  // NRT - Set in constructor
 
 		public FragmentEffect ()
 		{

--- a/Pinta.Effects/Effects/FrostedGlassEffect.cs
+++ b/Pinta.Effects/Effects/FrostedGlassEffect.cs
@@ -34,7 +34,7 @@ namespace Pinta.Effects
 			get { return (FrostedGlassData) EffectData!; } // NRT - Set in constructor
 		}
 
-		private readonly Random random = new Random ();
+		private readonly Random random = new ();
 
 		public FrostedGlassEffect ()
 		{

--- a/Pinta.Effects/Effects/FrostedGlassEffect.cs
+++ b/Pinta.Effects/Effects/FrostedGlassEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortFrostedGlass;
 
-		public override string Name {
-			get { return Translations.GetString ("Frosted Glass"); }
-		}
+		public override string Name => Translations.GetString ("Frosted Glass");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public FrostedGlassData Data {
-			get { return (FrostedGlassData) EffectData!; } // NRT - Set in constructor
-		}
+		public FrostedGlassData Data => (FrostedGlassData) EffectData!;
 
 		private readonly Random random = new ();
 

--- a/Pinta.Effects/Effects/GaussianBlurEffect.cs
+++ b/Pinta.Effects/Effects/GaussianBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursGaussianBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Gaussian Blur"); }
-		}
+		public override string Name => Translations.GetString ("Gaussian Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public GaussianBlurData Data { get { return (GaussianBlurData) EffectData!; } } // NRT - Set in constructor
+		public GaussianBlurData Data => (GaussianBlurData) EffectData!;  // NRT - Set in constructor
 
 		public GaussianBlurEffect ()
 		{
@@ -242,7 +236,7 @@ namespace Pinta.Effects
 			public int Radius = 2;
 
 			[Skip]
-			public override bool IsDefault { get { return Radius == 0; } }
+			public override bool IsDefault => Radius == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/GlowEffect.cs
+++ b/Pinta.Effects/Effects/GlowEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoGlow;
 
-		public override string Name {
-			get { return Translations.GetString ("Glow"); }
-		}
+		public override string Name => Translations.GetString ("Glow");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public GlowData Data { get { return (GlowData) EffectData!; } } // NRT - Set in constructor
+		public GlowData Data => (GlowData) EffectData!;  // NRT - Set in constructor
 
 		public GlowEffect ()
 		{

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -25,19 +25,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsArtisticInkSketch;
 
-		public override string Name {
-			get { return Translations.GetString ("Ink Sketch"); }
-		}
+		public override string Name => Translations.GetString ("Ink Sketch");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Artistic"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Artistic");
 
-		public InkSketchData Data { get { return (InkSketchData) EffectData!; } } // NRT - Set in constructor
+		public InkSketchData Data => (InkSketchData) EffectData!;  // NRT - Set in constructor
 
 		public InkSketchEffect ()
 		{

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderJuliaFractal;
 
-		public override string Name {
-			get { return Translations.GetString ("Julia Fractal"); }
-		}
+		public override string Name => Translations.GetString ("Julia Fractal");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Render"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Render");
 
-		public JuliaFractalData Data { get { return (JuliaFractalData) EffectData!; } } // NRT - Set in constructor
+		public JuliaFractalData Data => (JuliaFractalData) EffectData!;  // NRT - Set in constructor
 
 		public JuliaFractalEffect ()
 		{

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderMandelbrotFractal;
 
-		public override string Name {
-			get { return Translations.GetString ("Mandelbrot Fractal"); }
-		}
+		public override string Name => Translations.GetString ("Mandelbrot Fractal");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Render"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Render");
 
-		public MandelbrotFractalData Data { get { return (MandelbrotFractalData) EffectData!; } } // NRT - Set in constructor
+		public MandelbrotFractalData Data => (MandelbrotFractalData) EffectData!;  // NRT - Set in constructor
 
 		public MandelbrotFractalEffect ()
 		{

--- a/Pinta.Effects/Effects/MedianEffect.cs
+++ b/Pinta.Effects/Effects/MedianEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsNoiseMedian;
 
-		public override string Name {
-			get { return Translations.GetString ("Median"); }
-		}
+		public override string Name => Translations.GetString ("Median");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Noise"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Noise");
 
-		public MedianData Data { get { return (MedianData) EffectData!; } } // NRT - Set in constructor
+		public MedianData Data => (MedianData) EffectData!;  // NRT - Set in constructor
 
 		public MedianEffect ()
 		{
@@ -71,7 +65,7 @@ namespace Pinta.Effects
 			public int Percentile = 50;
 
 			[Skip]
-			public override bool IsDefault { get { return Radius == 0; } }
+			public override bool IsDefault => Radius == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/MotionBlurEffect.cs
+++ b/Pinta.Effects/Effects/MotionBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursMotionBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Motion Blur"); }
-		}
+		public override string Name => Translations.GetString ("Motion Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public MotionBlurData Data { get { return (MotionBlurData) EffectData!; } } // NRT - Set in constructor
+		public MotionBlurData Data => (MotionBlurData) EffectData!;  // NRT - Set in constructor
 
 		public MotionBlurEffect ()
 		{
@@ -103,7 +97,7 @@ namespace Pinta.Effects
 		public class MotionBlurData : EffectData
 		{
 			[Skip]
-			public override bool IsDefault { get { return Distance == 0; } }
+			public override bool IsDefault => Distance == 0;
 
 			[Caption ("Angle")]
 			public double Angle = 25;

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsArtisticOilPainting;
 
-		public override string Name {
-			get { return Translations.GetString ("Oil Painting"); }
-		}
+		public override string Name => Translations.GetString ("Oil Painting");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Artistic"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Artistic");
 
-		public OilPaintingData Data { get { return (OilPaintingData) EffectData!; } } // NRT - Set in constructor
+		public OilPaintingData Data => (OilPaintingData) EffectData!;  // NRT - Set in constructor
 
 		public OilPaintingEffect ()
 		{

--- a/Pinta.Effects/Effects/OutlineEffect.cs
+++ b/Pinta.Effects/Effects/OutlineEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeOutline;
 
-		public override string Name {
-			get { return Translations.GetString ("Outline"); }
-		}
+		public override string Name => Translations.GetString ("Outline");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
-		public OutlineData Data { get { return (OutlineData) EffectData!; } } // NRT - Set in constructor
+		public OutlineData Data => (OutlineData) EffectData!;  // NRT - Set in constructor
 
 		public OutlineEffect ()
 		{
@@ -143,7 +137,7 @@ namespace Pinta.Effects
 			public int Intensity = 50;
 
 			[Skip]
-			public override bool IsDefault { get { return Thickness == 0; } }
+			public override bool IsDefault => Thickness == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/PencilSketchEffect.cs
+++ b/Pinta.Effects/Effects/PencilSketchEffect.cs
@@ -23,19 +23,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsArtisticPencilSketch;
 
-		public override string Name {
-			get { return Translations.GetString ("Pencil Sketch"); }
-		}
+		public override string Name => Translations.GetString ("Pencil Sketch");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Artistic"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Artistic");
 
-		public PencilSketchData Data { get { return (PencilSketchData) EffectData!; } } // NRT - Set in constructor
+		public PencilSketchData Data => (PencilSketchData) EffectData!;  // NRT - Set in constructor
 
 		public PencilSketchEffect ()
 		{

--- a/Pinta.Effects/Effects/PixelateEffect.cs
+++ b/Pinta.Effects/Effects/PixelateEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortPixelate;
 
-		public override string Name {
-			get { return Translations.GetString ("Pixelate"); }
-		}
+		public override string Name => Translations.GetString ("Pixelate");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public PixelateData Data {
-			get { return (PixelateData) EffectData!; } // NRT - Set in constructor
-		}
+		public PixelateData Data => (PixelateData) EffectData!;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
 		public PixelateEffect ()
 		{

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -16,21 +16,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortPolarInversion;
 
-		public override string Name {
-			get { return Translations.GetString ("Polar Inversion"); }
-		}
+		public override string Name => Translations.GetString ("Polar Inversion");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public new PolarInversionData Data {
-			get { return (PolarInversionData) EffectData!; } // NRT - Set in constructor
-		}
+		public new PolarInversionData Data => (PolarInversionData) EffectData!;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
 		public PolarInversionEffect ()
 		{

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -8,7 +8,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Runtime.InteropServices;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -158,7 +157,7 @@ namespace Pinta.Effects
 			public Double Angle = 2;
 
 			[Caption ("Offset")]
-			public PointD Offset = new PointD (0, 0);
+			public PointD Offset = new (0, 0);
 
 			[Caption ("Quality"), MinimumValue (1), MaximumValue (5)]
 			[Hint ("Use low quality for previews, small images, and small angles.  Use high quality for final quality, large images, and large angles.")]

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursRadialBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Radial Blur"); }
-		}
+		public override string Name => Translations.GetString ("Radial Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public RadialBlurData Data { get { return (RadialBlurData) EffectData!; } } // NRT - Set in constructor
+		public RadialBlurData Data => (RadialBlurData) EffectData!;  // NRT - Set in constructor
 
 		public RadialBlurEffect ()
 		{
@@ -164,7 +158,7 @@ namespace Pinta.Effects
 			public int Quality = 2;
 
 			[Skip]
-			public override bool IsDefault { get { return Angle == 0; } }
+			public override bool IsDefault => Angle == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
+++ b/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
@@ -19,19 +19,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoRedEyeRemove;
 
-		public override string Name {
-			get { return Translations.GetString ("Red Eye Removal"); }
-		}
+		public override string Name => Translations.GetString ("Red Eye Removal");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public RedEyeRemoveData Data { get { return (RedEyeRemoveData) EffectData!; } } // NRT - Set in constructor
+		public RedEyeRemoveData Data => (RedEyeRemoveData) EffectData!;  // NRT - Set in constructor
 
 		public RedEyeRemoveEffect ()
 		{

--- a/Pinta.Effects/Effects/ReduceNoiseEffect.cs
+++ b/Pinta.Effects/Effects/ReduceNoiseEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsNoiseReduceNoise;
 
-		public override string Name {
-			get { return Translations.GetString ("Reduce Noise"); }
-		}
+		public override string Name => Translations.GetString ("Reduce Noise");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Noise"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Noise");
 
-		public ReduceNoiseData Data { get { return (ReduceNoiseData) EffectData!; } } // NRT - Set in constructor
+		public ReduceNoiseData Data => (ReduceNoiseData) EffectData!;  // NRT - Set in constructor
 
 		public ReduceNoiseEffect ()
 		{

--- a/Pinta.Effects/Effects/ReliefEffect.cs
+++ b/Pinta.Effects/Effects/ReliefEffect.cs
@@ -20,17 +20,11 @@ namespace Pinta.Effects
 			EffectData = new ReliefData ();
 		}
 
-		public ReliefData Data {
-			get { return (ReliefData) EffectData!; } // NRT - Set in constructor
-		}
+		public ReliefData Data => (ReliefData) EffectData!;
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
 		public override void LaunchConfiguration ()
 		{
@@ -39,9 +33,7 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeRelief;
 
-		public override string Name {
-			get { return Translations.GetString ("Relief"); }
-		}
+		public override string Name => Translations.GetString ("Relief");
 
 		#region Algorithm Code Ported From PDN
 		public override void Render (Cairo.ImageSurface src, Cairo.ImageSurface dst, Core.RectangleI[] rois)

--- a/Pinta.Effects/Effects/SharpenEffect.cs
+++ b/Pinta.Effects/Effects/SharpenEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoSharpen;
 
-		public override string Name {
-			get { return Translations.GetString ("Sharpen"); }
-		}
+		public override string Name => Translations.GetString ("Sharpen");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public SharpenData Data { get { return (SharpenData) EffectData!; } } // NRT - Set in constructor
+		public SharpenData Data => (SharpenData) EffectData!;  // NRT - Set in constructor
 
 		public SharpenEffect ()
 		{

--- a/Pinta.Effects/Effects/SoftenPortraitEffect.cs
+++ b/Pinta.Effects/Effects/SoftenPortraitEffect.cs
@@ -49,19 +49,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoSoftenPortrait;
 
-		public override string Name {
-			get { return Translations.GetString ("Soften Portrait"); }
-		}
+		public override string Name => Translations.GetString ("Soften Portrait");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public SoftenPortraitData Data { get { return (SoftenPortraitData) EffectData!; } } // NRT - Set in constructor
+		public SoftenPortraitData Data => (SoftenPortraitData) EffectData!;  // NRT - Set in constructor
 
 		public SoftenPortraitEffect ()
 		{

--- a/Pinta.Effects/Effects/TileEffect.cs
+++ b/Pinta.Effects/Effects/TileEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortTile;
 
-		public override string Name {
-			get { return Translations.GetString ("Tile Reflection"); }
-		}
+		public override string Name => Translations.GetString ("Tile Reflection");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public TileData Data {
-			get { return (TileData) EffectData!; } // NRT - Set in constructor
-		}
+		public TileData Data => (TileData) EffectData!;
 
 		public TileEffect ()
 		{

--- a/Pinta.Effects/Effects/TwistEffect.cs
+++ b/Pinta.Effects/Effects/TwistEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortTwist;
 
-		public override string Name {
-			get { return Translations.GetString ("Twist"); }
-		}
+		public override string Name => Translations.GetString ("Twist");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public TwistData Data { get { return (TwistData) EffectData!; } } // NRT - Set in constructor
+		public TwistData Data => (TwistData) EffectData!;  // NRT - Set in constructor
 
 		public TwistEffect ()
 		{

--- a/Pinta.Effects/Effects/UnfocusEffect.cs
+++ b/Pinta.Effects/Effects/UnfocusEffect.cs
@@ -20,19 +20,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursUnfocus;
 
-		public override string Name {
-			get { return Translations.GetString ("Unfocus"); }
-		}
+		public override string Name => Translations.GetString ("Unfocus");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public UnfocusData Data { get { return (UnfocusData) EffectData!; } } // NRT - Set in constructor
+		public UnfocusData Data => (UnfocusData) EffectData!;  // NRT - Set in constructor
 
 		public UnfocusEffect ()
 		{
@@ -96,7 +90,7 @@ namespace Pinta.Effects
 			public int Radius = 4;
 
 			[Skip]
-			public override bool IsDefault { get { return Radius == 0; } }
+			public override bool IsDefault => Radius == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/WarpEffect.cs
+++ b/Pinta.Effects/Effects/WarpEffect.cs
@@ -35,9 +35,7 @@ namespace Pinta.Effects
 	public abstract class WarpEffect : BaseEffect
 	{
 
-		public WarpData Data {
-			get { return (WarpData) EffectData!; } // NRT - Set in constructor
-		}
+		public WarpData Data => (WarpData) EffectData!;
 
 		public WarpEffect ()
 		{
@@ -52,8 +50,8 @@ namespace Pinta.Effects
 		private double default_radius = 0;
 		private double default_radius_2 = 0;
 
-		protected double DefaultRadius { get { return this.default_radius; } }
-		protected double DefaultRadius2 { get { return this.default_radius_2; } }
+		protected double DefaultRadius => this.default_radius;
+		protected double DefaultRadius2 => this.default_radius_2;
 
 		#region Algorithm Code Ported From PDN
 		public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursZoomBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Zoom Blur"); }
-		}
+		public override string Name => Translations.GetString ("Zoom Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public ZoomBlurData Data { get { return (ZoomBlurData) EffectData!; } } // NRT - Set in constructor
+		public ZoomBlurData Data => (ZoomBlurData) EffectData!;  // NRT - Set in constructor
 
 		public ZoomBlurEffect ()
 		{
@@ -132,7 +126,7 @@ namespace Pinta.Effects
 			public Core.PointI Offset = new (0, 0);
 
 			[Skip]
-			public override bool IsDefault { get { return Amount == 0; } }
+			public override bool IsDefault => Amount == 0;
 		}
 	}
 }

--- a/Pinta.Gui.Addins/InstallDialog.cs
+++ b/Pinta.Gui.Addins/InstallDialog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,7 +11,7 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Addins;
 
-internal class InstallDialog : Adw.Window
+internal sealed class InstallDialog : Adw.Window
 {
 	private readonly SetupService service;
 	private readonly PackageCollection packages_to_install = new ();
@@ -310,28 +311,35 @@ internal class InstallDialog : Adw.Window
 	}
 }
 
-internal class InstallErrorReporter : IErrorReporter
+internal sealed class InstallErrorReporter : IErrorReporter
 {
-	public List<string> Errors { get; private init; } = new ();
-	public List<string> Warnings { get; private init; } = new ();
+	private readonly List<string> errors;
+	public ReadOnlyCollection<string> Errors { get; }
+
+	private readonly List<string> warnings;
+	public ReadOnlyCollection<string> Warnings { get; }
 
 	public InstallErrorReporter ()
 	{
+		errors = new List<string> ();
+		Errors = new ReadOnlyCollection<string> (errors);
+		warnings = new List<string> ();
+		Warnings = new ReadOnlyCollection<string> (warnings);
 	}
 
 	public void ReportError (string message, Exception exception)
 	{
-		Errors.Add (message);
+		errors.Add (message);
 	}
 
 	public void ReportWarning (string message)
 	{
-		Warnings.Add (message);
+		warnings.Add (message);
 	}
 
 	public void Clear ()
 	{
-		Errors.Clear ();
-		Warnings.Clear ();
+		errors.Clear ();
+		warnings.Clear ();
 	}
 }

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -41,7 +41,7 @@ namespace Pinta.Gui.Widgets
 {
 	public class SimpleEffectDialog : Gtk.Dialog
 	{
-		readonly Random random = new Random ();
+		readonly Random random = new ();
 
 		const uint event_delay_millis = 100;
 		uint event_delay_timeout_id;

--- a/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
@@ -116,7 +116,7 @@ namespace Pinta.Gui.Widgets
 			}
 		}
 
-		private RectangleD GetAllocation () => new RectangleD (0, 0, GetAllocatedWidth (), GetAllocatedHeight ());
+		private RectangleD GetAllocation () => new (0, 0, GetAllocatedWidth (), GetAllocatedHeight ());
 
 		private double GetYFromValue (double val)
 		{

--- a/Pinta.Gui.Widgets/Widgets/PointPickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/PointPickerWidget.cs
@@ -65,7 +65,7 @@ namespace Pinta.Gui.Widgets
 		public PointI DefaultPoint { get; set; }
 
 		public PointI Point {
-			get => new PointI (spin_x.GetValueAsInt (), spin_y.GetValueAsInt ());
+			get => new (spin_x.GetValueAsInt (), spin_y.GetValueAsInt ());
 			set {
 				if (value.X != spin_x.GetValueAsInt () || value.Y != spin_y.GetValueAsInt ()) {
 					spin_x.Value = value.X;
@@ -87,7 +87,7 @@ namespace Pinta.Gui.Widgets
 		}
 
 		public PointD Offset
-			=> new PointD ((spin_x.Value * 2.0 / PintaCore.Workspace.ImageSize.Width) - 1.0, (spin_y.Value * 2.0 / PintaCore.Workspace.ImageSize.Height) - 1.0);
+			=> new ((spin_x.Value * 2.0 / PintaCore.Workspace.ImageSize.Width) - 1.0, (spin_y.Value * 2.0 / PintaCore.Workspace.ImageSize.Height) - 1.0);
 
 		private void HandlePointpickergraphic1PositionChanged (object? sender, EventArgs e)
 		{

--- a/Pinta.Tools/Brushes/CircleBrush.cs
+++ b/Pinta.Tools/Brushes/CircleBrush.cs
@@ -33,13 +33,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class CircleBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Circles"); }
-		}
+		public override string Name => Translations.GetString ("Circles");
 
-		public override double StrokeAlphaMultiplier {
-			get { return 0.05; }
-		}
+		public override double StrokeAlphaMultiplier => 0.05;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/GridBrush.cs
+++ b/Pinta.Tools/Brushes/GridBrush.cs
@@ -33,13 +33,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class GridBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Grid"); }
-		}
+		public override string Name => Translations.GetString ("Grid");
 
-		public override double StrokeAlphaMultiplier {
-			get { return 0.05; }
-		}
+		public override double StrokeAlphaMultiplier => 0.05;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -32,13 +32,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class PlainBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Normal"); }
-		}
+		public override string Name => Translations.GetString ("Normal");
 
-		public override int Priority {
-			get { return -100; }
-		}
+		public override int Priority => -100;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/SplatterBrush.cs
+++ b/Pinta.Tools/Brushes/SplatterBrush.cs
@@ -33,13 +33,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class SplatterBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Splatter"); }
-		}
+		public override string Name => Translations.GetString ("Splatter");
 
-		public override double StrokeAlphaMultiplier {
-			get { return 0.5; }
-		}
+		public override double StrokeAlphaMultiplier => 0.5;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -35,9 +35,7 @@ namespace Pinta.Tools.Brushes
 	{
 		private static readonly double theta = Math.PI / 2;
 
-		public override string Name {
-			get { return Translations.GetString ("Squares"); }
-		}
+		public override string Name => Translations.GetString ("Squares");
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
@@ -46,8 +46,8 @@ namespace Pinta.Tools
 		private SpinButton? arrow_length_offset;
 		private Label? arrow_length_offset_label;
 
-		private readonly Arrow previous_settings_1 = new Arrow ();
-		private readonly Arrow previous_settings_2 = new Arrow ();
+		private readonly Arrow previous_settings_1 = new ();
+		private readonly Arrow previous_settings_2 = new ();
 
 		// NRT - These are all set by HandleBuildToolBar
 		private ISettingsService settings = null!;

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -46,7 +46,7 @@ namespace Pinta.Tools
 			RoundedLineSeries
 		}
 
-		public static Dictionary<ShapeTypes, ShapeTool> CorrespondingTools = new Dictionary<ShapeTypes, ShapeTool> ();
+		public static Dictionary<ShapeTypes, ShapeTool> CorrespondingTools = new ();
 
 		protected abstract string ShapeName { get; }
 
@@ -80,7 +80,7 @@ namespace Pinta.Tools
 		protected ToolBarDropDownButton shape_type_button = null!;
 		protected Gtk.Separator shape_type_sep = null!;
 
-		protected DashPatternBox dash_pattern_box = new DashPatternBox ();
+		protected DashPatternBox dash_pattern_box = new ();
 		private string prev_dash_pattern = "-";
 
 		private bool prev_antialiasing = true;
@@ -180,13 +180,13 @@ namespace Pinta.Tools
 		private readonly Gdk.Cursor grab_cursor = Gdk.Cursor.NewFromName (Pinta.Resources.StandardCursors.Grab, null);
 
 		protected bool changing_tension = false;
-		protected PointD last_mouse_pos = new PointD (0d, 0d);
+		protected PointD last_mouse_pos = new (0d, 0d);
 
 		//Helps to keep track of the first modification on a shape after the mouse is clicked, to prevent unnecessary history items.
 		protected bool clicked_without_modifying = false;
 
 		//Stores the editable shape data.
-		public static ShapeEngineCollection SEngines = new ShapeEngineCollection ();
+		public static ShapeEngineCollection SEngines = new ();
 
 		#region ToolbarEventHandlers
 

--- a/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
@@ -35,7 +35,7 @@ namespace Pinta.Tools
 {
 	public class EllipseEditEngine : BaseEditEngine
 	{
-		protected override string ShapeName { get { return Translations.GetString ("Ellipse"); } }
+		protected override string ShapeName => Translations.GetString ("Ellipse");
 
 		public EllipseEditEngine (ShapeTool owner)
 		    : base (owner)

--- a/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
@@ -35,11 +35,7 @@ namespace Pinta.Tools
 {
 	public class LineCurveEditEngine : ArrowedEditEngine
 	{
-		protected override string ShapeName {
-			get {
-				return Translations.GetString ("Open Curve Shape");
-			}
-		}
+		protected override string ShapeName => Translations.GetString ("Open Curve Shape");
 
 		public LineCurveEditEngine (ShapeTool passedOwner) : base (passedOwner)
 		{

--- a/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
@@ -35,11 +35,7 @@ namespace Pinta.Tools
 {
 	public class RectangleEditEngine : BaseEditEngine
 	{
-		protected override string ShapeName {
-			get {
-				return Translations.GetString ("Closed Curve Shape");
-			}
-		}
+		protected override string ShapeName => Translations.GetString ("Closed Curve Shape");
 
 		public RectangleEditEngine (ShapeTool passedOwner) : base (passedOwner)
 		{

--- a/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
@@ -35,11 +35,7 @@ namespace Pinta.Tools
 {
 	public class RoundedLineEditEngine : BaseEditEngine
 	{
-		protected override string ShapeName {
-			get {
-				return Translations.GetString ("Rounded Line Shape");
-			}
-		}
+		protected override string ShapeName => Translations.GetString ("Rounded Line Shape");
 
 		public const double DefaultRadius = 20d;
 

--- a/Pinta.Tools/Editable/Shapes/LineCurveSeriesEngine.cs
+++ b/Pinta.Tools/Editable/Shapes/LineCurveSeriesEngine.cs
@@ -32,7 +32,7 @@ namespace Pinta.Tools
 {
 	public class LineCurveSeriesEngine : ShapeEngine
 	{
-		public Arrow Arrow1 = new Arrow (), Arrow2 = new Arrow ();
+		public Arrow Arrow1 = new (), Arrow2 = new ();
 
 		/// <summary>
 		/// Create a new LineCurveSeriesEngine.

--- a/Pinta.Tools/Editable/Shapes/ShapeEngineCollection.cs
+++ b/Pinta.Tools/Editable/Shapes/ShapeEngineCollection.cs
@@ -100,14 +100,14 @@ namespace Pinta.Tools
 	public abstract class ShapeEngine
 	{
 		//A collection of the original ControlPoints that the shape is based on and that the user interacts with.
-		public List<ControlPoint> ControlPoints = new List<ControlPoint> ();
+		public List<ControlPoint> ControlPoints = new ();
 		public List<MoveHandle> ControlPointHandles = new ();
 
 		//A collection of calculated GeneratedPoints that make up the entirety of the shape being drawn.
 		public GeneratedPoint[] GeneratedPoints = Array.Empty<GeneratedPoint> ();
 
 		//An organized collection of the GeneratedPoints's points for optimized nearest point detection.
-		public OrganizedPointCollection OrganizedPoints = new OrganizedPointCollection ();
+		public OrganizedPointCollection OrganizedPoints = new ();
 
 		private readonly UserLayer parent_layer;
 		public ReEditableLayer DrawingLayer;

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -45,7 +45,7 @@ namespace Pinta.Tools
 		// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
 		public override string StatusBarText => Translations.GetString ("{0} + left click to set origin, left click to paint.", GtkExtensions.CtrlLabel ());
 		public override bool CursorChangesOnZoom => true;
-		public override Key ShortcutKey { get { return Key.L; } }
+		public override Key ShortcutKey => Key.L;
 		public override int Priority => 47;
 		protected override bool ShowAntialiasingButton => true;
 

--- a/Pinta.Tools/Tools/FloodTool.cs
+++ b/Pinta.Tools/Tools/FloodTool.cs
@@ -34,6 +34,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using Gtk;
 using Pinta.Core;
 
@@ -117,7 +118,7 @@ namespace Pinta.Tools
 				settings.PutSetting (FILL_TOLERANCE_SETTING, (int) tolerance_slider.GetValue ());
 		}
 
-		protected virtual void OnFillRegionComputed (Document document, PointI[][] polygonSet) { }
+		protected virtual void OnFillRegionComputed (Document document, IReadOnlyList<IReadOnlyList<PointI>> polygonSet) { }
 		protected virtual void OnFillRegionComputed (Document document, BitMask stencil) { }
 
 		protected Label ModeLabel => mode_label ??= Label.New (string.Format (" {0}: ", Translations.GetString ("Flood Mode")));

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -38,7 +38,7 @@ namespace Pinta.Tools
 		private Color fill_color;
 		private Color outline_color;
 
-		private readonly DashPatternBox dash_p_box = new DashPatternBox ();
+		private readonly DashPatternBox dash_p_box = new ();
 
 		private string dash_pattern = "-";
 

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -42,7 +42,7 @@ public class LassoSelectTool : BaseTool
 	private SelectionHistoryItem? hist;
 
 	private Path? path;
-	private readonly List<IntPoint> lasso_polygon = new List<IntPoint> ();
+	private readonly List<IntPoint> lasso_polygon = new ();
 
 	public LassoSelectTool (IServiceManager services) : base (services)
 	{

--- a/Pinta.Tools/Tools/MagicWandTool.cs
+++ b/Pinta.Tools/Tools/MagicWandTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using Gtk;
 using Pinta.Core;
 
@@ -68,7 +69,7 @@ namespace Pinta.Tools
 			document.Selection.Visible = true;
 		}
 
-		protected override void OnFillRegionComputed (Document document, PointI[][] polygonSet)
+		protected override void OnFillRegionComputed (Document document, IReadOnlyList<IReadOnlyList<PointI>> polygonSet)
 		{
 			var undoAction = new SelectionHistoryItem (Icon, Name);
 			undoAction.TakeSnapshot ();

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -50,8 +50,8 @@ namespace Pinta.Tools
 		private int? active_handle;
 		private string? active_cursor_name;
 
-		public override Gdk.Key ShortcutKey { get { return Gdk.Key.S; } }
-		protected override bool ShowAntialiasingButton { get { return false; } }
+		public override Gdk.Key ShortcutKey => Gdk.Key.S;
+		protected override bool ShowAntialiasingButton => false;
 		public override IEnumerable<MoveHandle> Handles => handles;
 
 		public SelectTool (IServiceManager services) : base (services)

--- a/Pinta.Tools/Tools/ShapeTool.cs
+++ b/Pinta.Tools/Tools/ShapeTool.cs
@@ -43,10 +43,9 @@ namespace Pinta.Tools
 		public virtual BaseEditEngine.ShapeTypes ShapeType => BaseEditEngine.ShapeTypes.ClosedLineCurveSeries;
 		public override bool IsEditableShapeTool => true;
 
-		public override string StatusBarText {
-			get {
+		public override string StatusBarText =>
 				// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
-				return Translations.GetString ("Left click to draw a shape with the primary color." +
+				Translations.GetString ("Left click to draw a shape with the primary color." +
 				    "\nLeft click on a shape to add a control point." +
 				    "\nLeft click on a control point and drag to move it." +
 				    "\nRight click on a control point and drag to change its tension." +
@@ -58,8 +57,6 @@ namespace Pinta.Tools
 				    "\nHold {0} while pressing Space to create the control point at the exact same position." +
 				    "\nHold {0} while left clicking on a control point to create a new shape at the exact same position." +
 				    "\nPress Enter to finalize the shape.", GtkExtensions.CtrlLabel ());
-			}
-		}
 
 		protected abstract BaseEditEngine CreateEditEngine ();
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -81,15 +81,13 @@ namespace Pinta.Tools
 		//Whether or not the previous TextTool mouse cursor shown was the normal one.
 		private bool previous_mouse_cursor_normal = true;
 
-		public override string Name { get { return Translations.GetString ("Text"); } }
-		private string FinalizeName { get { return Translations.GetString ("Text - Finalize"); } }
-		public override string Icon { get { return Pinta.Resources.Icons.ToolText; } }
-		public override Gdk.Key ShortcutKey { get { return Gdk.Key.T; } }
-		public override int Priority { get { return 35; } }
+		public override string Name => Translations.GetString ("Text");
+		private string FinalizeName => Translations.GetString ("Text - Finalize");
+		public override string Icon => Pinta.Resources.Icons.ToolText;
+		public override Gdk.Key ShortcutKey => Gdk.Key.T;
+		public override int Priority => 35;
 
-		public override string StatusBarText {
-			get { return Translations.GetString ("Left click to place cursor, then type desired text. Text color is primary color."); }
-		}
+		public override string StatusBarText => Translations.GetString ("Left click to place cursor, then type desired text. Text color is primary color.");
 
 		public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Text.png"), 16, 16, null);
 		public Gdk.Cursor InvalidEditCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon (Pinta.Resources.Icons.EditSelectionErase), 0, 0, null);
@@ -407,9 +405,9 @@ namespace Pinta.Tools
 
 		private int OutlineWidth => outline_width.GetValueAsInt ();
 
-		protected bool StrokeText { get { return (fill_button.SelectedItem.GetTagOrDefault (0) >= 1 && fill_button.SelectedItem.GetTagOrDefault (0) != 3); } }
-		protected bool FillText { get { return fill_button.SelectedItem.GetTagOrDefault (0) <= 1 || fill_button.SelectedItem.GetTagOrDefault (0) == 3; } }
-		protected bool BackgroundFill { get { return fill_button.SelectedItem.GetTagOrDefault (0) == 3; } }
+		protected bool StrokeText => (fill_button.SelectedItem.GetTagOrDefault (0) >= 1 && fill_button.SelectedItem.GetTagOrDefault (0) != 3);
+		protected bool FillText => fill_button.SelectedItem.GetTagOrDefault (0) <= 1 || fill_button.SelectedItem.GetTagOrDefault (0) == 3;
+		protected bool BackgroundFill => fill_button.SelectedItem.GetTagOrDefault (0) == 3;
 		#endregion
 
 		#region Activation/Deactivation

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -121,11 +121,7 @@ namespace Pinta.Actions
 			[Caption ("Zoom"), MinimumValue (0), MaximumValue (16)]
 			public double Zoom = 1.0;
 
-			public override bool IsDefault {
-				get {
-					return Angle == 0 && Pan.X == 0.0 && Pan.Y == 0.0 && Zoom == 1.0;
-				}
-			}
+			public override bool IsDefault => Angle == 0 && Pan.X == 0.0 && Pan.Y == 0.0 && Zoom == 1.0;
 		}
 	}
 }

--- a/Pinta/Dialogs/LayerPropertiesDialog.cs
+++ b/Pinta/Dialogs/LayerPropertiesDialog.cs
@@ -92,26 +92,14 @@ namespace Pinta
 			opacitySpinner.SetActivatesDefault (true);
 		}
 
-		public bool AreLayerPropertiesUpdated {
-			get {
-				return initial_properties.Opacity != opacity
+		public bool AreLayerPropertiesUpdated => initial_properties.Opacity != opacity
 					|| initial_properties.Hidden != hidden
 					|| initial_properties.Name != name
 					|| initial_properties.BlendMode != blendmode;
-			}
-		}
 
-		public LayerProperties InitialLayerProperties {
-			get {
-				return initial_properties;
-			}
-		}
+		public LayerProperties InitialLayerProperties => initial_properties;
 
-		public LayerProperties UpdatedLayerProperties {
-			get {
-				return new LayerProperties (name, hidden, opacity, blendmode);
-			}
-		}
+		public LayerProperties UpdatedLayerProperties => new LayerProperties (name, hidden, opacity, blendmode);
 
 		#region Private Methods
 		private void OnLayerNameChanged (object? sender, EventArgs e)

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -107,9 +107,9 @@ namespace Pinta
 			preview.Update (NewImageSize, NewImageBackground);
 		}
 
-		public int NewImageWidth { get { return int.Parse (width_entry.Buffer!.Text!); } }
-		public int NewImageHeight { get { return int.Parse (height_entry.Buffer!.Text!); } }
-		public Size NewImageSize { get { return new Size (NewImageWidth, NewImageHeight); } }
+		public int NewImageWidth => int.Parse (width_entry.Buffer!.Text!);
+		public int NewImageHeight => int.Parse (height_entry.Buffer!.Text!);
+		public Size NewImageSize => new Size (NewImageWidth, NewImageHeight);
 
 		public enum BackgroundType
 		{

--- a/Pinta/DocumentViewContent.cs
+++ b/Pinta/DocumentViewContent.cs
@@ -49,6 +49,6 @@ namespace Pinta
 
 		public string Label => Document.DisplayName + (Document.IsDirty ? "*" : string.Empty);
 
-		public Gtk.Widget Widget { get { return canvas_window; } }
+		public Gtk.Widget Widget => canvas_window;
 	}
 }

--- a/Pinta/MacInterop/ApplicationEvents.cs
+++ b/Pinta/MacInterop/ApplicationEvents.cs
@@ -30,7 +30,7 @@ namespace Pinta.MacInterop
 {
 	public static class ApplicationEvents
 	{
-		static readonly object lockObj = new object ();
+		static readonly object lockObj = new ();
 
 		#region Quit
 

--- a/Pinta/MacInterop/ApplicationEvents.cs
+++ b/Pinta/MacInterop/ApplicationEvents.cs
@@ -193,11 +193,7 @@ namespace Pinta.MacInterop
 	{
 		public bool Handled { get; set; }
 
-		internal CarbonEventHandlerStatus HandledStatus {
-			get {
-				return Handled ? CarbonEventHandlerStatus.Handled : CarbonEventHandlerStatus.NotHandled;
-			}
-		}
+		internal CarbonEventHandlerStatus HandledStatus => Handled ? CarbonEventHandlerStatus.Handled : CarbonEventHandlerStatus.NotHandled;
 	}
 
 	public class ApplicationQuitEventArgs : ApplicationEventArgs

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -497,23 +497,17 @@ namespace Pinta.MacInterop
 			this.attributes = CarbonHICommandAttributes.FromMenu;
 		}
 
-		public readonly CarbonHICommandAttributes Attributes { get { return attributes; } }
-		public readonly uint CommandID { get { return commandID; } }
-		public readonly IntPtr ControlRef { get { return controlRef; } }
-		public readonly IntPtr WindowRef { get { return windowRef; } }
-		public readonly HIMenuItem MenuItem { get { return menuItem; } }
+		public readonly CarbonHICommandAttributes Attributes => attributes;
+		public readonly uint CommandID => commandID;
+		public readonly IntPtr ControlRef => controlRef;
+		public readonly IntPtr WindowRef => windowRef;
+		public readonly HIMenuItem MenuItem => menuItem;
 
-		public readonly bool IsFromMenu {
-			get { return attributes == CarbonHICommandAttributes.FromMenu; }
-		}
+		public readonly bool IsFromMenu => attributes == CarbonHICommandAttributes.FromMenu;
 
-		public readonly bool IsFromControl {
-			get { return attributes == CarbonHICommandAttributes.FromControl; }
-		}
+		public readonly bool IsFromControl => attributes == CarbonHICommandAttributes.FromControl;
 
-		public readonly bool IsFromWindow {
-			get { return attributes == CarbonHICommandAttributes.FromWindow; }
-		}
+		public readonly bool IsFromWindow => attributes == CarbonHICommandAttributes.FromWindow;
 	}
 
 	[StructLayout (LayoutKind.Sequential, Pack = 2)]
@@ -528,8 +522,8 @@ namespace Pinta.MacInterop
 			this.menuRef = menuRef;
 		}
 
-		public readonly IntPtr MenuRef { get { return menuRef; } }
-		public readonly ushort Index { get { return index; } }
+		public readonly IntPtr MenuRef => menuRef;
+		public readonly ushort Index => index;
 	}
 
 	//*NOT* flags
@@ -544,9 +538,7 @@ namespace Pinta.MacInterop
 	{
 		readonly int value;
 
-		public readonly int Value {
-			get { return value; }
-		}
+		public readonly int Value => value;
 
 		public OSType (int value)
 		{

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -497,21 +497,21 @@ namespace Pinta.MacInterop
 			this.attributes = CarbonHICommandAttributes.FromMenu;
 		}
 
-		public CarbonHICommandAttributes Attributes { get { return attributes; } }
-		public uint CommandID { get { return commandID; } }
-		public IntPtr ControlRef { get { return controlRef; } }
-		public IntPtr WindowRef { get { return windowRef; } }
-		public HIMenuItem MenuItem { get { return menuItem; } }
+		public readonly CarbonHICommandAttributes Attributes { get { return attributes; } }
+		public readonly uint CommandID { get { return commandID; } }
+		public readonly IntPtr ControlRef { get { return controlRef; } }
+		public readonly IntPtr WindowRef { get { return windowRef; } }
+		public readonly HIMenuItem MenuItem { get { return menuItem; } }
 
-		public bool IsFromMenu {
+		public readonly bool IsFromMenu {
 			get { return attributes == CarbonHICommandAttributes.FromMenu; }
 		}
 
-		public bool IsFromControl {
+		public readonly bool IsFromControl {
 			get { return attributes == CarbonHICommandAttributes.FromControl; }
 		}
 
-		public bool IsFromWindow {
+		public readonly bool IsFromWindow {
 			get { return attributes == CarbonHICommandAttributes.FromWindow; }
 		}
 	}
@@ -528,8 +528,8 @@ namespace Pinta.MacInterop
 			this.menuRef = menuRef;
 		}
 
-		public IntPtr MenuRef { get { return menuRef; } }
-		public ushort Index { get { return index; } }
+		public readonly IntPtr MenuRef { get { return menuRef; } }
+		public readonly ushort Index { get { return index; } }
 	}
 
 	//*NOT* flags
@@ -544,7 +544,7 @@ namespace Pinta.MacInterop
 	{
 		readonly int value;
 
-		public int Value {
+		public readonly int Value {
 			get { return value; }
 		}
 

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -164,8 +164,8 @@ namespace Mono.Options
 
 		#region ICollection
 		void ICollection.CopyTo (Array array, int index) { (values as ICollection).CopyTo (array, index); }
-		bool ICollection.IsSynchronized { get { return (values as ICollection).IsSynchronized; } }
-		object ICollection.SyncRoot { get { return (values as ICollection).SyncRoot; } }
+		bool ICollection.IsSynchronized => (values as ICollection).IsSynchronized;
+		object ICollection.SyncRoot => (values as ICollection).SyncRoot;
 		#endregion
 
 		#region ICollection<T>
@@ -174,8 +174,8 @@ namespace Mono.Options
 		public bool Contains (string item) { return values.Contains (item); }
 		public void CopyTo (string[] array, int arrayIndex) { values.CopyTo (array, arrayIndex); }
 		public bool Remove (string item) { return values.Remove (item); }
-		public int Count { get { return values.Count; } }
-		public bool IsReadOnly { get { return false; } }
+		public int Count => values.Count;
+		public bool IsReadOnly => false;
 		#endregion
 
 		#region IEnumerable
@@ -193,7 +193,7 @@ namespace Mono.Options
 		void IList.Insert (int index, object value) { (values as IList).Insert (index, value); }
 		void IList.Remove (object value) { (values as IList).Remove (value); }
 		void IList.RemoveAt (int index) { (values as IList).RemoveAt (index); }
-		bool IList.IsFixedSize { get { return false; } }
+		bool IList.IsFixedSize => false;
 		object IList.this[int index] { get { return this[index]; } set { (values as IList)[index] = value; } }
 		#endregion
 
@@ -271,13 +271,9 @@ namespace Mono.Options
 			set { index = value; }
 		}
 
-		public OptionSet OptionSet {
-			get { return set; }
-		}
+		public OptionSet OptionSet => set;
 
-		public OptionValueCollection OptionValues {
-			get { return c; }
-		}
+		public OptionValueCollection OptionValues => c;
 	}
 
 	public enum OptionValueType
@@ -330,10 +326,10 @@ namespace Mono.Options
 						nameof (prototype));
 		}
 
-		public string Prototype { get { return prototype; } }
-		public string Description { get { return description; } }
-		public OptionValueType OptionValueType { get { return type; } }
-		public int MaxValueCount { get { return count; } }
+		public string Prototype => prototype;
+		public string Description => description;
+		public OptionValueType OptionValueType => type;
+		public int MaxValueCount => count;
 
 		public string[] GetNames ()
 		{
@@ -369,8 +365,8 @@ namespace Mono.Options
 			return t;
 		}
 
-		internal string[] Names { get { return names; } }
-		internal string[] ValueSeparators { get { return separators; } }
+		internal string[] Names => names;
+		internal string[] ValueSeparators => separators;
 
 		static readonly char[] NameTerminator = new char[] { '=', ':' };
 
@@ -490,9 +486,7 @@ namespace Mono.Options
 			this.option = info.GetString ("OptionName");
 		}
 
-		public string OptionName {
-			get { return this.option; }
-		}
+		public string OptionName => this.option;
 
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
@@ -517,9 +511,7 @@ namespace Mono.Options
 
 		readonly Converter<string, string> localizer;
 
-		public Converter<string, string> MessageLocalizer {
-			get { return localizer; }
-		}
+		public Converter<string, string> MessageLocalizer => localizer;
 
 		protected override string GetKeyForItem (Option item)
 		{

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -154,7 +154,7 @@ namespace Mono.Options
 	public class OptionValueCollection : IList, IList<string>
 	{
 
-		readonly List<string> values = new List<string> ();
+		readonly List<string> values = new ();
 		readonly OptionContext c;
 
 		internal OptionValueCollection (OptionContext c)
@@ -753,7 +753,7 @@ namespace Mono.Options
 			return false;
 		}
 
-		private readonly Regex ValueOption = new Regex (
+		private readonly Regex ValueOption = new (
 			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
 		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -103,6 +103,44 @@ internal sealed class BitMaskTest
 		}
 	}
 
+	[TestCaseSource (nameof (invalid_indexing))]
+	public void RejectsInvalidIndexing_PairIndexer (int width, int height, int x, int y)
+	{
+		var bitmask = new BitMask (width, height);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = bitmask[x, y]);
+	}
+
+	[TestCaseSource (nameof (invalid_indexing))]
+	public void RejectsInvalidIndexing_PointIndexer (int width, int height, int x, int y)
+	{
+		var bitmask = new BitMask (width, height);
+		var point = new PointI (x, y);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = bitmask[point]);
+	}
+
+	[TestCaseSource (nameof (invalid_indexing))]
+	public void RejectsInvalidIndexing_GetMethod (int width, int height, int x, int y)
+	{
+		var bitmask = new BitMask (width, height);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = bitmask.Get (x, y));
+	}
+
+	[TestCaseSource (nameof (invalid_indexing))]
+	public void RejectsInvalidIndexing_Invert (int width, int height, int x, int y)
+	{
+		var bitmask = new BitMask (width, height);
+		Assert.Throws<ArgumentOutOfRangeException> (() => bitmask.Invert (x, y));
+	}
+
+	[TestCaseSource (nameof (invalid_indexing))]
+	public void RejectsInvalidIndexing_SetPair (int width, int height, int x, int y)
+	{
+		var bitmask1 = new BitMask (width, height);
+		var bitmask2 = new BitMask (width, height);
+		Assert.Throws<ArgumentOutOfRangeException> (() => bitmask1.Set (x, y, true));
+		Assert.Throws<ArgumentOutOfRangeException> (() => bitmask2.Set (x, y, false));
+	}
+
 	static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new TestCaseData[]
 	{
 		new (0, 0),
@@ -121,5 +159,12 @@ internal sealed class BitMaskTest
 	{
 		new (DEFAULT_SIZE, DEFAULT_OFFSET),
 		new (2, 1),
+	};
+
+	static readonly IReadOnlyList<TestCaseData> invalid_indexing = new TestCaseData[]
+	{
+		new (DEFAULT_WIDTH, DEFAULT_HEIGHT, -1, 0),
+		new (DEFAULT_WIDTH, DEFAULT_HEIGHT, 0, -1),
+		new (DEFAULT_WIDTH, DEFAULT_HEIGHT, -1, -1),
 	};
 }

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class BitMaskTest
+{
+	const int DEFAULT_SIZE = 1;
+	const int DEFAULT_OFFSET = 0;
+
+	const int DEFAULT_HEIGHT = DEFAULT_SIZE;
+	const int DEFAULT_HEIGHT_INDEX = DEFAULT_OFFSET;
+
+	const int DEFAULT_WIDTH = DEFAULT_SIZE;
+	const int DEFAULT_WIDTH_INDEX = DEFAULT_OFFSET;
+
+	[TestCase (-1)]
+	public void Constructor_RejectsInvalidWidth (int width)
+	{
+		Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (width, DEFAULT_HEIGHT));
+	}
+
+	[TestCase (-1)]
+	public void Constructor_RejectsInvalidHeight (int height)
+	{
+		Assert.Throws<ArgumentOutOfRangeException> (() => new BitMask (DEFAULT_WIDTH, height));
+	}
+
+	[TestCaseSource (nameof (out_of_bounds_access_cases))]
+	public void WidthAccessOutOfBoundsFails (int desiredWidth, int indexToAccess)
+	{
+		var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
+		var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
+	}
+
+	[TestCaseSource (nameof (within_bounds_access_cases))]
+	public void WidthAccessWithinBoundsSucceeds (int desiredWidth, int indexToAccess)
+	{
+		var mask = new BitMask (desiredWidth, DEFAULT_HEIGHT);
+		var coordinates = new PointI (indexToAccess, DEFAULT_HEIGHT_INDEX);
+		Assert.DoesNotThrow (() => _ = mask[indexToAccess, DEFAULT_HEIGHT_INDEX]);
+		Assert.DoesNotThrow (() => _ = mask[coordinates]);
+	}
+
+	[TestCaseSource (nameof (out_of_bounds_access_cases))]
+	public void HeightAccessOutOfBoundsFails (int desiredHeight, int indexToAccess)
+	{
+		var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
+		var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = mask[coordinates]);
+	}
+
+	[TestCaseSource (nameof (within_bounds_access_cases))]
+	public void HeightAccessWithinBoundsSucceeds (int desiredHeight, int indexToAccess)
+	{
+		var mask = new BitMask (DEFAULT_WIDTH, desiredHeight);
+		var coordinates = new PointI (DEFAULT_WIDTH_INDEX, indexToAccess);
+		Assert.DoesNotThrow (() => _ = mask[DEFAULT_WIDTH_INDEX, indexToAccess]);
+		Assert.DoesNotThrow (() => _ = mask[coordinates]);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+	public void BitInitializedToFalse (int maskWidth, int maskHeight, int bitToTestX, int bitToTestY)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		var bit = mask[bitToTestX, bitToTestY];
+		Assert.IsFalse (bit);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+	public void BitInvertsWithXY (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		mask.Invert (bitToInvertX, bitToInvertY);
+		var bit = mask[bitToInvertX, bitToInvertY];
+		Assert.IsTrue (bit);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)]
+	public void BitInvertsWithScanline (int maskWidth, int maskHeight, int bitToInvertX, int bitToInvertY)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		var scanline = new Scanline (bitToInvertX, bitToInvertY, 1);
+		mask.Invert (scanline);
+		var bit = mask[bitToInvertX, bitToInvertY];
+		Assert.IsTrue (bit);
+	}
+
+	[TestCase (DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX, new[] { true, false, true, false })]
+	public void BitGetsSetXY (int maskWidth, int maskHeight, int bitToSetX, int bitToSetY, bool[] valuesToSetAndTest)
+	{
+		var mask = new BitMask (maskWidth, maskHeight);
+		var coordinates = new PointI (bitToSetX, bitToSetY);
+		foreach (var value in valuesToSetAndTest) {
+			mask.Set (bitToSetX, bitToSetY, value);
+			Assert.AreEqual (value, mask[bitToSetX, bitToSetY]);
+			Assert.AreEqual (value, mask[coordinates]);
+		}
+	}
+
+	static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new TestCaseData[]
+	{
+		new (0, 0),
+		new (0, 1),
+		new (1, 1),
+		new (1, 2),
+		new (1, -1),
+		new (1, int.MinValue),
+		new (1, int.MinValue + 1),
+		new (1, int.MaxValue),
+		new (1, int.MaxValue - 1),
+		new (2, 2),
+	};
+
+	static readonly IReadOnlyList<TestCaseData> within_bounds_access_cases = new TestCaseData[]
+	{
+		new (DEFAULT_SIZE, DEFAULT_OFFSET),
+		new (2, 1),
+	};
+}

--- a/tests/Pinta.Core.Tests/OtherExtensionsTest.cs
+++ b/tests/Pinta.Core.Tests/OtherExtensionsTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
@@ -14,4 +15,16 @@ internal sealed class OtherExtensionsTest
 		var materialized2 = materialized1.ToReadOnlyCollection ();
 		Assert.AreSame (materialized1, materialized2);
 	}
+
+	[TestCaseSource (nameof (create_polygon_set_arguments_for_empty))]
+	public void EmptyStencilReturnsEmptyPolygonSet (RectangleD bounds, int translateX, int translateY)
+	{
+		var bitmask = new BitMask (0, 0);
+		var polygonSet = bitmask.CreatePolygonSet (bounds, translateX, translateY);
+		Assert.Zero (polygonSet.Count);
+	}
+
+	private static readonly IReadOnlyList<TestCaseData> create_polygon_set_arguments_for_empty = new TestCaseData[] {
+		new (new RectangleD(0, 0, 1, 1), 1, 1),
+	};
 }

--- a/tests/Pinta.Core.Tests/ScanlineTest.cs
+++ b/tests/Pinta.Core.Tests/ScanlineTest.cs
@@ -31,7 +31,7 @@ internal sealed class ScanlineTest
 		Assert.IsTrue (comparison);
 	}
 
-	[TestCaseSource (nameof (sample_unequal))]
+	[TestCaseSource (nameof (unequal_values))]
 	public void EqualsOperator_FalseWithUnequal (int x1, int y1, int length1, int x2, int y2, int length2)
 	{
 		var scanline1 = new Scanline (x1, y1, length1);
@@ -49,13 +49,38 @@ internal sealed class ScanlineTest
 		Assert.IsFalse (comparison);
 	}
 
-	[TestCaseSource (nameof (sample_unequal))]
+	[TestCaseSource (nameof (unequal_values))]
 	public void NotEqualsOperator_TrueWithUnequal (int x1, int y1, int length1, int x2, int y2, int length2)
 	{
 		var scanline1 = new Scanline (x1, y1, length1);
 		var scanline2 = new Scanline (x2, y2, length2);
 		bool comparison = scanline1 != scanline2;
 		Assert.IsTrue (comparison);
+	}
+
+	[TestCaseSource (nameof (sample_initializations))]
+	public void EqualsMethod_TrueWithEqual (int x, int y, int length)
+	{
+		var scanline1 = new Scanline (x, y, length);
+		var scanline2 = new Scanline (x, y, length);
+		bool comparison = scanline1.Equals (scanline2);
+		Assert.IsTrue (comparison);
+	}
+
+	[TestCaseSource (nameof (unequal_types_scanline))]
+	public void EqualsMethod_FalseWithUnequalTypes (Scanline scanline, object? other)
+	{
+		bool comparison = scanline.Equals (other);
+		Assert.IsFalse (comparison);
+	}
+
+	[TestCaseSource (nameof (unequal_values))]
+	public void EqualsMethod_FalseWithUnequalValues (int x1, int y1, int length1, int x2, int y2, int length2)
+	{
+		var scanline1 = new Scanline (x1, y1, length1);
+		var scanline2 = new Scanline (x2, y2, length2);
+		bool comparison = scanline1.Equals (scanline2);
+		Assert.IsFalse (comparison);
 	}
 
 	[TestCaseSource (nameof (overflowing_hash_code_cases))]
@@ -71,13 +96,20 @@ internal sealed class ScanlineTest
 		Assert.DoesNotThrow (() => _ = scanline.GetHashCode ());
 	}
 
+	static readonly IReadOnlyList<TestCaseData> unequal_types_scanline = new TestCaseData[] {
+		new (new Scanline(1, 1, 1), "This is not a scanline"),
+		new (new Scanline(1, 1, 1), null),
+		new (new Scanline(1, 1, 1), new [] { 1, 1, 1 }),
+		new (new Scanline(1, 1, 1), 111),
+	};
+
 	static readonly IReadOnlyList<TestCaseData> sample_initializations = new TestCaseData[] {
 		new (1, 2, 3),
 		new (3, 1, 2),
 		new (2, 3, 1),
 	};
 
-	static readonly IReadOnlyList<TestCaseData> sample_unequal = new TestCaseData[] {
+	static readonly IReadOnlyList<TestCaseData> unequal_values = new TestCaseData[] {
 		new (
 			1, 1, 1,
 			2, 2, 2),
@@ -90,6 +122,18 @@ internal sealed class ScanlineTest
 		new (
 			1, 1, 1,
 			2, 1, 1),
+		new (
+			2, 2, 2,
+			1, 1, 1),
+		new (
+			1, 1, 2,
+			1, 1, 1),
+		new (
+			1, 2, 1,
+			1, 1, 1),
+		new (
+			2, 1, 1,
+			1, 1, 1),
 	};
 
 	static readonly IReadOnlyList<TestCaseData> overflowing_hash_code_cases = new TestCaseData[] {

--- a/tests/Pinta.Core.Tests/ScanlineTest.cs
+++ b/tests/Pinta.Core.Tests/ScanlineTest.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class ScanlineTest
+{
+	// Perhaps most (all?) of these tests can be removed if Scanline is
+	// made into a record struct (a feature offered by C#10+)
+
+	[TestCaseSource (nameof (sample_initializations))]
+	public void MembersInitializingCorrectly (int x, int y, int length)
+	{
+		var scanline = new Scanline (
+			x: x,
+			y: y,
+			length: length
+		);
+		Assert.AreEqual (scanline.X, x);
+		Assert.AreEqual (scanline.Y, y);
+		Assert.AreEqual (scanline.Length, length);
+	}
+
+	[TestCaseSource (nameof (sample_initializations))]
+	public void EqualsOperator_TrueWithEqual (int x, int y, int length)
+	{
+		var scanline1 = new Scanline (x, y, length);
+		var scanline2 = new Scanline (x, y, length);
+		bool comparison = scanline1 == scanline2;
+		Assert.IsTrue (comparison);
+	}
+
+	[TestCaseSource (nameof (sample_unequal))]
+	public void EqualsOperator_FalseWithUnequal (int x1, int y1, int length1, int x2, int y2, int length2)
+	{
+		var scanline1 = new Scanline (x1, y1, length1);
+		var scanline2 = new Scanline (x2, y2, length2);
+		bool comparison = scanline1 == scanline2;
+		Assert.IsFalse (comparison);
+	}
+
+	[TestCaseSource (nameof (sample_initializations))]
+	public void NotEqualsOperator_FalseWithEqual (int x, int y, int length)
+	{
+		var scanline1 = new Scanline (x, y, length);
+		var scanline2 = new Scanline (x, y, length);
+		bool comparison = scanline1 != scanline2;
+		Assert.IsFalse (comparison);
+	}
+
+	[TestCaseSource (nameof (sample_unequal))]
+	public void NotEqualsOperator_TrueWithUnequal (int x1, int y1, int length1, int x2, int y2, int length2)
+	{
+		var scanline1 = new Scanline (x1, y1, length1);
+		var scanline2 = new Scanline (x2, y2, length2);
+		bool comparison = scanline1 != scanline2;
+		Assert.IsTrue (comparison);
+	}
+
+	[TestCaseSource (nameof (overflowing_hash_code_cases))]
+	public void HashCode_DoesNotOverflow (int x, int y, int length)
+	{
+		// At the time of writing this code:
+		// - The hash of an int is the int itself.
+		// - The hash of Scanline is the overflow-unchecked addition
+		//   of the hash of all its members.
+		// If any of the above changes, I recommend preserving the existing test cases
+		// _and_ adding other test cases that may be of interest.
+		var scanline = new Scanline (x, y, length);
+		Assert.DoesNotThrow (() => _ = scanline.GetHashCode ());
+	}
+
+	static readonly IReadOnlyList<TestCaseData> sample_initializations = new TestCaseData[] {
+		new (1, 2, 3),
+		new (3, 1, 2),
+		new (2, 3, 1),
+	};
+
+	static readonly IReadOnlyList<TestCaseData> sample_unequal = new TestCaseData[] {
+		new (
+			1, 1, 1,
+			2, 2, 2),
+		new (
+			1, 1, 1,
+			1, 1, 2),
+		new (
+			1, 1, 1,
+			1, 2, 1),
+		new (
+			1, 1, 1,
+			2, 1, 1),
+	};
+
+	static readonly IReadOnlyList<TestCaseData> overflowing_hash_code_cases = new TestCaseData[] {
+		new (int.MaxValue, 1, 1),
+		new (1, int.MaxValue, 1),
+		new (1, 1, int.MaxValue),
+		new (int.MaxValue / 2, int.MaxValue / 2, int.MaxValue / 2),
+	};
+}

--- a/tests/PintaBenchmarks/CanvasRendererBenchmarks.cs
+++ b/tests/PintaBenchmarks/CanvasRendererBenchmarks.cs
@@ -19,8 +19,8 @@ public class CanvasRendererBenchmarks
 	private readonly Size dest_size_zoom_in;
 	private readonly Size dest_size_zoom_out;
 
-	private readonly List<Layer> layers = new List<Layer> ();
-	private readonly List<Layer> ten_laters = new List<Layer> ();
+	private readonly List<Layer> layers = new ();
+	private readonly List<Layer> ten_laters = new ();
 
 	public CanvasRendererBenchmarks ()
 	{


### PR DESCRIPTION
There isn't much that can fail in `Scanline`. I would rather (due to the simplicity of the `struct` being tested) take this as an inspiration or reference for writing further tests, and understanding the kind of questions one should ask.

For example, should the constructor accept negative `x` or `y` arguments? What about a negative `length`? Also, does a length of `0` mean anything? Let's remember that all structs have a parameterless constructor by definition, and all members are zero-ed by default when it is used. As I understand this `struct`, creating an instance with a length of zero would mean that, wherever it's applied, the effect will essentially be a no-op. Is the code that uses this `struct` actually doing that? If not, perhaps the default `length` should be 1 (this isn't possible with older versions of C# or .NET (I don't know if this is at the language level or the runtime level), but newer versions allow parameterless `struct` constructors to have a body). If we know that this will be changed in a future version of C#, we could create a GitHub issue and address it when the time comes. I'm noticing that GitHub issues aren't enabled in this repo, but I suggest that the feature gets enabled. 

---

P.S. There seems to be a bug in my local setup that shows an extra test case coming out of nowhere, and appearing as "not run", but it doesn't seem to be a problem with the tests themselves:

https://stackoverflow.com/questions/64121974/nunit-with-testcasesource-discovers-extra-unsourced-test-in-vs2019

![image](https://github.com/PintaProject/Pinta/assets/17771375/23ec805d-def6-49db-90e6-a9dae88bfc1d)
