### PR TITLE
Getters and methods that only access `readonly` members were made `readonly`

### DIFF
--- a/Pinta.Core/Classes/Point.cs
+++ b/Pinta.Core/Classes/Point.cs
@@ -42,7 +42,7 @@ namespace Pinta.Core
 		public int X;
 		public int Y;
 
-		public override string ToString () => $"{X}, {Y}";
+		public override readonly string ToString () => $"{X}, {Y}";
 	}
 
 	public record struct PointD
@@ -56,16 +56,16 @@ namespace Pinta.Core
 		public double X;
 		public double Y;
 
-		public override string ToString () => $"{X}, {Y}";
+		public override readonly string ToString () => $"{X}, {Y}";
 
-		public PointI ToInt () => new ((int) X, (int) Y);
+		public readonly PointI ToInt () => new ((int) X, (int) Y);
 
-		public double Distance (in PointD e)
+		public readonly double Distance (in PointD e)
 		{
 			return new PointD (X - e.X, Y - e.Y).Magnitude ();
 		}
 
-		public double Magnitude ()
+		public readonly double Magnitude ()
 		{
 			return Math.Sqrt (X * X + Y * Y);
 		}
@@ -73,7 +73,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns a new point, rounded to the nearest integer coordinates.
 		/// </summary>
-		public PointD Rounded () => new (Math.Round (X), Math.Round (Y));
+		public readonly PointD Rounded () => new (Math.Round (X), Math.Round (Y));
 
 		public static PointD operator + (in PointD a, in PointD b)
 		{
@@ -94,9 +94,9 @@ namespace Pinta.Core
 
 		public static readonly Size Empty;
 
-		public override string ToString () => $"{Width}, {Height}";
+		public override readonly string ToString () => $"{Width}, {Height}";
 
-		public bool IsEmpty => (Width == 0 && Height == 0);
+		public readonly bool IsEmpty => (Width == 0 && Height == 0);
 	}
 }
 

--- a/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
@@ -23,27 +23,27 @@ namespace Pinta.Core
 		}
 
 		public int Line {
-			get { return line; }
+			readonly get { return line; }
 			set { line = Math.Max (value, 0); }
 		}
 
 		public int Offset {
-			get { return offset; }
+			readonly get { return offset; }
 			set { offset = Math.Max (value, 0); }
 		}
 
 		#region Operators
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			return obj is TextPosition && this == (TextPosition) obj;
 		}
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			return new { line, offset }.GetHashCode ();
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return $"({line}, {offset})";
 		}
@@ -58,7 +58,7 @@ namespace Pinta.Core
 			return x.CompareTo (y) != 0;
 		}
 
-		public int CompareTo (TextPosition other)
+		public readonly int CompareTo (TextPosition other)
 		{
 			if (line.CompareTo (other.line) != 0)
 				return line.CompareTo (other.line);

--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -48,17 +48,17 @@ namespace Pinta.Core
 		{
 		}
 
-		public RectangleI ToInt () => new ((int) Math.Floor (X), (int) Math.Floor (Y),
+		public readonly RectangleI ToInt () => new ((int) Math.Floor (X), (int) Math.Floor (Y),
 							      (int) Math.Ceiling (Width), (int) Math.Ceiling (Height));
 
-		public double Left => X;
-		public double Top => Y;
-		public double Right => X + Width - 1;
-		public double Bottom => Y + Height - 1;
+		public readonly double Left => X;
+		public readonly double Top => Y;
+		public readonly double Right => X + Width - 1;
+		public readonly double Bottom => Y + Height - 1;
 
-		public override string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
+		public override readonly string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
 
-		public bool ContainsPoint (double x, double y)
+		public readonly bool ContainsPoint (double x, double y)
 		{
 			if (x < this.X || x >= this.X + this.Width)
 				return false;
@@ -71,8 +71,8 @@ namespace Pinta.Core
 
 		public bool ContainsPoint (in PointD point) => ContainsPoint (point.X, point.Y);
 
-		public PointD Location () => new (X, Y);
-		public PointD GetCenter () => new (X + 0.5 * Width, Y + 0.5 * Height);
+		public readonly PointD Location () => new (X, Y);
+		public readonly PointD GetCenter () => new (X + 0.5 * Width, Y + 0.5 * Height);
 
 		public void Inflate (double width, double height)
 		{
@@ -82,14 +82,14 @@ namespace Pinta.Core
 			Height += height * 2;
 		}
 
-		public RectangleD Inflated (double width, double height)
+		public readonly RectangleD Inflated (double width, double height)
 		{
 			RectangleD copy = this;
 			copy.Inflate (width, height);
 			return copy;
 		}
 
-		public RectangleD Clamp ()
+		public readonly RectangleD Clamp ()
 		{
 			double x = this.X;
 			double y = this.Y;
@@ -140,19 +140,19 @@ namespace Pinta.Core
 		public static RectangleI FromLTRB (int left, int top, int right, int bottom)
 			=> new (left, top, right - left + 1, bottom - top + 1);
 
-		public RectangleD ToDouble () => new (X, Y, Width, Height);
+		public readonly RectangleD ToDouble () => new (X, Y, Width, Height);
 
-		public int Left => X;
-		public int Top => Y;
-		public int Right => X + Width - 1;
-		public int Bottom => Y + Height - 1;
+		public readonly int Left => X;
+		public readonly int Top => Y;
+		public readonly int Right => X + Width - 1;
+		public readonly int Bottom => Y + Height - 1;
 
-		public bool IsEmpty => (Width == 0) || (Height == 0);
+		public readonly bool IsEmpty => (Width == 0) || (Height == 0);
 
-		public PointI Location => new (X, Y);
-		public Size Size => new (Width, Height);
+		public readonly PointI Location => new (X, Y);
+		public readonly Size Size => new (Width, Height);
 
-		public override string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
+		public override readonly string ToString () => $"x:{X} y:{Y} w:{Width} h:{Height}";
 
 		public bool Contains (int x, int y)
 		{
@@ -161,7 +161,7 @@ namespace Pinta.Core
 
 		public bool Contains (in PointI pt) => Contains (pt.X, pt.Y);
 
-		public RectangleI Intersect (RectangleI r) => Intersect (this, r);
+		public readonly RectangleI Intersect (RectangleI r) => Intersect (this, r);
 
 		public static RectangleI Intersect (in RectangleI a, in RectangleI b)
 		{
@@ -176,7 +176,7 @@ namespace Pinta.Core
 			return FromLTRB (left, top, right, bottom);
 		}
 
-		public RectangleI Union (RectangleI r) => Union (this, r);
+		public readonly RectangleI Union (RectangleI r) => Union (this, r);
 
 		public static RectangleI Union (in RectangleI a, in RectangleI b)
 		{

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -21,8 +21,8 @@ namespace Pinta.Core
 		private readonly int denominator;
 		private readonly int numerator;
 
-		public int Denominator { get { return denominator; } }
-		public int Numerator { get { return numerator; } }
+		public readonly int Denominator { get { return denominator; } }
+		public readonly int Numerator { get { return numerator; } }
 		public double Ratio { get; }
 
 		public static readonly ScaleFactor OneToOne = new (1, 1);
@@ -109,7 +109,7 @@ namespace Pinta.Core
 			return (lhs.numerator * rhs.denominator) >= (rhs.numerator * lhs.denominator);
 		}
 
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			if (obj is ScaleFactor) {
 				ScaleFactor rhs = (ScaleFactor) obj;
@@ -119,7 +119,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			return numerator.GetHashCode () ^ denominator.GetHashCode ();
 		}
@@ -138,32 +138,32 @@ namespace Pinta.Core
 		//    }
 		//}
 
-		public int ScaleScalar (int x)
+		public readonly int ScaleScalar (int x)
 		{
 			return (int) (((long) x * numerator) / denominator);
 		}
 
-		public int UnscaleScalar (int x)
+		public readonly int UnscaleScalar (int x)
 		{
 			return (int) (((long) x * denominator) / numerator);
 		}
 
-		public float ScaleScalar (float x)
+		public readonly float ScaleScalar (float x)
 		{
 			return (x * (float) numerator) / (float) denominator;
 		}
 
-		public float UnscaleScalar (float x)
+		public readonly float UnscaleScalar (float x)
 		{
 			return (x * (float) denominator) / (float) numerator;
 		}
 
-		public double ScaleScalar (double x)
+		public readonly double ScaleScalar (double x)
 		{
 			return (x * (double) numerator) / (double) denominator;
 		}
 
-		public double UnscaleScalar (double x)
+		public readonly double UnscaleScalar (double x)
 		{
 			return (x * (double) denominator) / (double) numerator;
 		}
@@ -293,7 +293,7 @@ namespace Pinta.Core
 		/// Rounds the current scaling factor up to the next power of two.
 		/// </summary>
 		/// <returns>The new ScaleFactor value.</returns>
-		public ScaleFactor GetNextLarger ()
+		public readonly ScaleFactor GetNextLarger ()
 		{
 			double ratio = Ratio + 0.005;
 
@@ -312,7 +312,7 @@ namespace Pinta.Core
 			return ScaleFactor.FromDouble (scales[index]);
 		}
 
-		public ScaleFactor GetNextSmaller ()
+		public readonly ScaleFactor GetNextSmaller ()
 		{
 			double ratio = Ratio - 0.005;
 

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -57,7 +57,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public string ToHexString ()
+		public readonly string ToHexString ()
 		{
 			int rgbNumber = (this.R << 16) | (this.G << 8) | this.B;
 			string colorString = Convert.ToString (rgbNumber, 16);
@@ -106,7 +106,7 @@ namespace Pinta.Core
 		/// Gets the luminance intensity of the pixel based on the values of the red, green, and blue components. Alpha is ignored.
 		/// </summary>
 		/// <returns>A value in the range 0 to 1 inclusive.</returns>
-		public double GetIntensity ()
+		public readonly double GetIntensity ()
 		{
 			return ((0.114 * (double) B) + (0.587 * (double) G) + (0.299 * (double) R)) / 255.0;
 		}
@@ -115,7 +115,7 @@ namespace Pinta.Core
 		/// Gets the luminance intensity of the pixel based on the values of the red, green, and blue components. Alpha is ignored.
 		/// </summary>
 		/// <returns>A value in the range 0 to 255 inclusive.</returns>
-		public byte GetIntensityByte ()
+		public readonly byte GetIntensityByte ()
 		{
 			return (byte) ((7471 * B + 38470 * G + 19595 * R) >> 16);
 		}
@@ -124,7 +124,7 @@ namespace Pinta.Core
 		/// Returns the maximum value out of the B, G, and R values. Alpha is ignored.
 		/// </summary>
 		/// <returns></returns>
-		public byte GetMaxColorChannelValue ()
+		public readonly byte GetMaxColorChannelValue ()
 		{
 			return Math.Max (this.B, Math.Max (this.G, this.R));
 		}
@@ -133,7 +133,7 @@ namespace Pinta.Core
 		/// Returns the average of the B, G, and R values. Alpha is ignored.
 		/// </summary>
 		/// <returns></returns>
-		public byte GetAverageColorChannelValue ()
+		public readonly byte GetAverageColorChannelValue ()
 		{
 			return (byte) ((this.B + this.G + this.R) / 3);
 		}
@@ -157,7 +157,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Compares two ColorBgra instance to determine if they are equal.
 		/// </summary>
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 
 			if (obj != null && obj is ColorBgra && ((ColorBgra) obj).Bgra == this.Bgra) {
@@ -171,7 +171,7 @@ namespace Pinta.Core
 		/// Returns a hash code for this color value.
 		/// </summary>
 		/// <returns></returns>
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			unchecked {
 				return (int) Bgra;
@@ -181,7 +181,7 @@ namespace Pinta.Core
 		/// <summary>
 		/// Returns a new ColorBgra with the same color values but with a new alpha component value.
 		/// </summary>
-		public ColorBgra NewAlpha (byte newA)
+		public readonly ColorBgra NewAlpha (byte newA)
 		{
 			return ColorBgra.FromBgra (B, G, R, newA);
 		}
@@ -595,7 +595,7 @@ namespace Pinta.Core
 			return ColorBgra.FromBgra (b, g, r, a);
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return "B: " + B + ", G: " + G + ", R: " + R + ", A: " + A;
 		}
@@ -625,7 +625,7 @@ namespace Pinta.Core
 		/// http://cairographics.org/manual/cairo-Image-Surfaces.html#cairo-format-t
 		/// </summary>
 		/// <returns>A ColorBgra value in premultiplied alpha form</returns> 
-		public ColorBgra ToPremultipliedAlpha ()
+		public readonly ColorBgra ToPremultipliedAlpha ()
 		{
 			return ColorBgra.FromBgra ((byte) (B * A / 255), (byte) (G * A / 255), (byte) (R * A / 255), A);
 		}
@@ -660,7 +660,7 @@ namespace Pinta.Core
 		/// http://cairographics.org/manual/cairo-Image-Surfaces.html#cairo-format-t
 		/// </summary>
 		/// <returns>A ColorBgra value in straight alpha form</returns> 
-		public ColorBgra ToStraightAlpha ()
+		public readonly ColorBgra ToStraightAlpha ()
 		{
 			if (this.A > 0)
 				return ColorBgra.FromBgra ((byte) (B * 255 / A), (byte) (G * 255 / A), (byte) (R * 255 / A), A);

--- a/Pinta.Core/Effects/HsvColor.cs
+++ b/Pinta.Core/Effects/HsvColor.cs
@@ -36,12 +36,12 @@ namespace Pinta.Core
 			return !(lhs == rhs);
 		}
 
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			return obj is HsvColor hsv && this == hsv;
 		}
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			return (Hue + (Saturation << 8) + (Value << 16)).GetHashCode (); ;
 		}
@@ -77,7 +77,7 @@ namespace Pinta.Core
 		//            return Color.FromArgb(rgb.Red, rgb.Green, rgb.Blue);
 		//        }
 
-		public RgbColor ToRgb ()
+		public readonly RgbColor ToRgb ()
 		{
 			// HsvColor contains values scaled as in the color wheel:
 
@@ -171,7 +171,7 @@ namespace Pinta.Core
 			return new RgbColor ((int) (r * 255), (int) (g * 255), (int) (b * 255));
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return $"({Hue}, {Saturation}, {Value})";
 		}

--- a/Pinta.Core/Effects/RgbColor.cs
+++ b/Pinta.Core/Effects/RgbColor.cs
@@ -53,7 +53,7 @@ namespace Pinta.Core
 		//            return Color.FromArgb(Red, Green, Blue);
 		//        }
 
-		public HsvColor ToHsv ()
+		public readonly HsvColor ToHsv ()
 		{
 			// In this function, R, G, and B values must be scaled 
 			// to be between 0 and 1.
@@ -111,7 +111,7 @@ namespace Pinta.Core
 			return new HsvColor ((int) h, (int) (s * 100), (int) (v * 100));
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return $"({Red}, {Green}, {Blue})";
 		}

--- a/Pinta.Core/Effects/Scanline.cs
+++ b/Pinta.Core/Effects/Scanline.cs
@@ -19,14 +19,14 @@ namespace Pinta.Core
 
 		public readonly int Length => length;
 
-		public override int GetHashCode ()
+		public override readonly int GetHashCode ()
 		{
 			unchecked {
 				return length.GetHashCode () + x.GetHashCode () + y.GetHashCode ();
 			}
 		}
 
-		public override bool Equals (object? obj)
+		public override readonly bool Equals (object? obj)
 		{
 			if (obj is Scanline) {
 				Scanline rhs = (Scanline) obj;
@@ -46,7 +46,7 @@ namespace Pinta.Core
 			return !(lhs == rhs);
 		}
 
-		public override string ToString ()
+		public override readonly string ToString ()
 		{
 			return "(" + x + "," + y + "):[" + length.ToString () + "]";
 		}

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1096,7 +1096,7 @@ namespace Pinta.Core
 			public int Width;
 			public int Height;
 
-			public RectangleI ToRectangleI () => new (X, Y, Width, Height);
+			public readonly RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
 		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_create_rectangle")]

--- a/Pinta.Core/Extensions/PangoExtensions.cs
+++ b/Pinta.Core/Extensions/PangoExtensions.cs
@@ -107,7 +107,7 @@ namespace Pinta.Core
 			public int Width;
 			public int Height;
 
-			public RectangleI ToRectangleI () => new (X, Y, Width, Height);
+			public readonly RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
 		public static int UnitsToPixels (int units)

--- a/Pinta.Core/ImageFormats/TgaExporter.cs
+++ b/Pinta.Core/ImageFormats/TgaExporter.cs
@@ -61,7 +61,7 @@ namespace Pinta.Core
 			public byte pixelDepth;          // Pixel Depth
 			public byte imageDesc;           // Image Descriptor
 
-			public void WriteTo (BinaryWriter output)
+			public readonly void WriteTo (BinaryWriter output)
 			{
 				output.Write (this.idLength);
 				output.Write (this.cmapType);

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -497,21 +497,21 @@ namespace Pinta.MacInterop
 			this.attributes = CarbonHICommandAttributes.FromMenu;
 		}
 
-		public CarbonHICommandAttributes Attributes { get { return attributes; } }
-		public uint CommandID { get { return commandID; } }
-		public IntPtr ControlRef { get { return controlRef; } }
-		public IntPtr WindowRef { get { return windowRef; } }
-		public HIMenuItem MenuItem { get { return menuItem; } }
+		public readonly CarbonHICommandAttributes Attributes { get { return attributes; } }
+		public readonly uint CommandID { get { return commandID; } }
+		public readonly IntPtr ControlRef { get { return controlRef; } }
+		public readonly IntPtr WindowRef { get { return windowRef; } }
+		public readonly HIMenuItem MenuItem { get { return menuItem; } }
 
-		public bool IsFromMenu {
+		public readonly bool IsFromMenu {
 			get { return attributes == CarbonHICommandAttributes.FromMenu; }
 		}
 
-		public bool IsFromControl {
+		public readonly bool IsFromControl {
 			get { return attributes == CarbonHICommandAttributes.FromControl; }
 		}
 
-		public bool IsFromWindow {
+		public readonly bool IsFromWindow {
 			get { return attributes == CarbonHICommandAttributes.FromWindow; }
 		}
 	}
@@ -528,8 +528,8 @@ namespace Pinta.MacInterop
 			this.menuRef = menuRef;
 		}
 
-		public IntPtr MenuRef { get { return menuRef; } }
-		public ushort Index { get { return index; } }
+		public readonly IntPtr MenuRef { get { return menuRef; } }
+		public readonly ushort Index { get { return index; } }
 	}
 
 	//*NOT* flags
@@ -544,7 +544,7 @@ namespace Pinta.MacInterop
 	{
 		readonly int value;
 
-		public int Value {
+		public readonly int Value {
 			get { return value; }
 		}
 


### PR DESCRIPTION
This reassures us that the instance won't be modified by using them(at least at a shallow level)