### PR TITLE
`EventArgs` classes in `Pinta.Core` were sealed, and unused setters removed

### DIFF
--- a/Pinta.Core/EventArgs/BrushEventArgs.cs
+++ b/Pinta.Core/EventArgs/BrushEventArgs.cs
@@ -26,16 +26,15 @@
 
 using System;
 
-namespace Pinta.Core
-{
-	public class BrushEventArgs : EventArgs
-	{
-		public BasePaintBrush Brush { get; set; }
+namespace Pinta.Core;
 
-		public BrushEventArgs (BasePaintBrush brush)
-		{
-			Brush = brush;
-		}
+public sealed class BrushEventArgs : EventArgs
+{
+	public BasePaintBrush Brush { get; }
+
+	public BrushEventArgs (BasePaintBrush brush)
+	{
+		Brush = brush;
 	}
 }
 

--- a/Pinta.Core/EventArgs/CanvasInvalidatedEventArgs.cs
+++ b/Pinta.Core/EventArgs/CanvasInvalidatedEventArgs.cs
@@ -26,22 +26,22 @@
 
 using System;
 
-namespace Pinta.Core
+namespace Pinta.Core;
+
+public sealed class CanvasInvalidatedEventArgs : EventArgs
 {
-	public class CanvasInvalidatedEventArgs : EventArgs
+	public bool EntireSurface { get; }
+	public RectangleI Rectangle { get; }
+
+	public CanvasInvalidatedEventArgs ()
 	{
-		public bool EntireSurface { get; set; }
-		public RectangleI Rectangle { get; set; }
+		EntireSurface = true;
+		Rectangle = default;
+	}
 
-		public CanvasInvalidatedEventArgs ()
-		{
-			EntireSurface = true;
-		}
-
-		public CanvasInvalidatedEventArgs (RectangleI rect)
-		{
-			EntireSurface = false;
-			Rectangle = rect;
-		}
+	public CanvasInvalidatedEventArgs (RectangleI rect)
+	{
+		EntireSurface = false;
+		Rectangle = rect;
 	}
 }

--- a/Pinta.Core/EventArgs/DocumentCancelEventArgs.cs
+++ b/Pinta.Core/EventArgs/DocumentCancelEventArgs.cs
@@ -28,9 +28,9 @@ using System.ComponentModel;
 
 namespace Pinta.Core;
 
-public class DocumentCancelEventArgs : CancelEventArgs
+public sealed class DocumentCancelEventArgs : CancelEventArgs
 {
-	public Document Document { get; set; }
+	public Document Document { get; }
 	public bool SaveAs { get; }
 
 	public DocumentCancelEventArgs (Document document, bool saveAs)

--- a/Pinta.Core/EventArgs/DocumentEventArgs.cs
+++ b/Pinta.Core/EventArgs/DocumentEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace Pinta.Core;
 
-public class DocumentEventArgs : EventArgs
+public sealed class DocumentEventArgs : EventArgs
 {
-	public Document Document { get; set; }
+	public Document Document { get; }
 
 	public DocumentEventArgs (Document document)
 	{

--- a/Pinta.Core/EventArgs/HistoryItemAddedEventArgs.cs
+++ b/Pinta.Core/EventArgs/HistoryItemAddedEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace Pinta.Core;
 
-public class HistoryItemAddedEventArgs : EventArgs
+public sealed class HistoryItemAddedEventArgs : EventArgs
 {
-	public BaseHistoryItem Item { get; set; }
+	public BaseHistoryItem Item { get; }
 
 	public HistoryItemAddedEventArgs (BaseHistoryItem item)
 	{

--- a/Pinta.Core/EventArgs/LivePreviewEndedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewEndedEventArgs.cs
@@ -32,15 +32,15 @@ public enum RenderStatus
 {
 	Completed,
 	Canceled,
-	Faulted
+	Faulted,
 }
 
-public class LivePreviewEndedEventArgs : EventArgs
+public sealed class LivePreviewEndedEventArgs : EventArgs
 {
 	public LivePreviewEndedEventArgs (RenderStatus status, Exception? exception)
 	{
-		this.Status = status;
-		this.Exception = exception;
+		Status = status;
+		Exception = exception;
 	}
 
 	public RenderStatus Status { get; }

--- a/Pinta.Core/EventArgs/LivePreviewRenderUpdatedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewRenderUpdatedEventArgs.cs
@@ -28,13 +28,12 @@ using System;
 
 namespace Pinta.Core;
 
-public class LivePreviewRenderUpdatedEventArgs : EventArgs
+public sealed class LivePreviewRenderUpdatedEventArgs : EventArgs
 {
-	public LivePreviewRenderUpdatedEventArgs (double progress,
-						   RectangleI bounds)
+	public LivePreviewRenderUpdatedEventArgs (double progress, RectangleI bounds)
 	{
-		this.Progress = progress;
-		this.Bounds = bounds;
+		Progress = progress;
+		Bounds = bounds;
 	}
 
 	public double Progress { get; }

--- a/Pinta.Core/EventArgs/LivePreviewStartedEventArgs.cs
+++ b/Pinta.Core/EventArgs/LivePreviewStartedEventArgs.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace Pinta.Core;
 
-public class LivePreviewStartedEventArgs : EventArgs
+public sealed class LivePreviewStartedEventArgs : EventArgs
 {
 	public LivePreviewStartedEventArgs ()
 	{

--- a/Pinta.Core/EventArgs/TextChangedEventArgs.cs
+++ b/Pinta.Core/EventArgs/TextChangedEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace Pinta.Core;
 
-public class TextChangedEventArgs : EventArgs
+public sealed class TextChangedEventArgs : EventArgs
 {
-	public string Text { get; set; }
+	public string Text { get; }
 
 	public TextChangedEventArgs (string text)
 	{

--- a/Pinta.Core/EventArgs/ToolEventArgs.cs
+++ b/Pinta.Core/EventArgs/ToolEventArgs.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace Pinta.Core;
 
-public class ToolEventArgs : EventArgs
+public sealed class ToolEventArgs : EventArgs
 {
 	public BaseTool Tool { get; }
 


### PR DESCRIPTION
Some setters were actually being used, so I left them