### PR TITLE
Created a test for `OtherExtensions.CreatePolygonSet` with an empty stencil

### DIFF
--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -134,7 +134,7 @@ namespace Pinta.Core
 		/// </summary>
 		/// <param name="pintaPolygonSet">A Pinta Polygon set.</param>
 		/// <returns>A Clipper Polygon collection.</returns>
-		public static List<List<IntPoint>> ConvertToPolygons (PointI[][] pintaPolygonSet)
+		public static List<List<IntPoint>> ConvertToPolygons (IReadOnlyList<IReadOnlyList<PointI>> pintaPolygonSet)
 		{
 			List<List<IntPoint>> newPolygons = new List<List<IntPoint>> ();
 

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -92,7 +92,7 @@ namespace Pinta.Core
 			return false;
 		}
 
-		public static PointI[][] CreatePolygonSet (this BitMask stencil, RectangleD bounds, int translateX, int translateY)
+		public static IReadOnlyList<IReadOnlyList<PointI>> CreatePolygonSet (this BitMask stencil, RectangleD bounds, int translateX, int translateY)
 		{
 			if (stencil.IsEmpty)
 				return Array.Empty<PointI[]> ();
@@ -180,7 +180,7 @@ namespace Pinta.Core
 				polygons.Add (points);
 			}
 
-			return polygons.ToArray ();
+			return polygons;
 		}
 	}
 }

--- a/Pinta.Tools/Tools/FloodTool.cs
+++ b/Pinta.Tools/Tools/FloodTool.cs
@@ -34,6 +34,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using Gtk;
 using Pinta.Core;
 
@@ -117,7 +118,7 @@ namespace Pinta.Tools
 				settings.PutSetting (FILL_TOLERANCE_SETTING, (int) tolerance_slider.GetValue ());
 		}
 
-		protected virtual void OnFillRegionComputed (Document document, PointI[][] polygonSet) { }
+		protected virtual void OnFillRegionComputed (Document document, IReadOnlyList<IReadOnlyList<PointI>> polygonSet) { }
 		protected virtual void OnFillRegionComputed (Document document, BitMask stencil) { }
 
 		protected Label ModeLabel => mode_label ??= Label.New (string.Format (" {0}: ", Translations.GetString ("Flood Mode")));

--- a/Pinta.Tools/Tools/MagicWandTool.cs
+++ b/Pinta.Tools/Tools/MagicWandTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using Gtk;
 using Pinta.Core;
 
@@ -68,7 +69,7 @@ namespace Pinta.Tools
 			document.Selection.Visible = true;
 		}
 
-		protected override void OnFillRegionComputed (Document document, PointI[][] polygonSet)
+		protected override void OnFillRegionComputed (Document document, IReadOnlyList<IReadOnlyList<PointI>> polygonSet)
 		{
 			var undoAction = new SelectionHistoryItem (Icon, Name);
 			undoAction.TakeSnapshot ();

--- a/tests/Pinta.Core.Tests/OtherExtensionsTest.cs
+++ b/tests/Pinta.Core.Tests/OtherExtensionsTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
@@ -14,4 +15,16 @@ internal sealed class OtherExtensionsTest
 		var materialized2 = materialized1.ToReadOnlyCollection ();
 		Assert.AreSame (materialized1, materialized2);
 	}
+
+	[TestCaseSource (nameof (create_polygon_set_arguments_for_empty))]
+	public void EmptyStencilReturnsEmptyPolygonSet (RectangleD bounds, int translateX, int translateY)
+	{
+		var bitmask = new BitMask (0, 0);
+		var polygonSet = bitmask.CreatePolygonSet (bounds, translateX, translateY);
+		Assert.Zero (polygonSet.Count);
+	}
+
+	private static readonly IReadOnlyList<TestCaseData> create_polygon_set_arguments_for_empty = new TestCaseData[] {
+		new (new RectangleD(0, 0, 1, 1), 1, 1),
+	};
 }


### PR DESCRIPTION
There's still a ways to go, but this is the first test.

Also, changed return type of it from `PointI[][]` to `IReadOnlyList<IReadOnlyList<PointI>>`, which already helps us avoid one heap allocation (by removing one `.ToArray()` call), with more optimizations to come, little by little, as the test coverage is expanded and refactorings are made :)