### PR TITLE
Modernized getter syntax in `Pinta` and `Pinta.Core`

### DIFF
--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -35,9 +35,7 @@ namespace Pinta.Core
 	public class Command
 	{
 		public Gio.SimpleAction Action { get; }
-		public string Name {
-			get { return Action.Name!; }
-		}
+		public string Name => Action.Name!;
 		public SignalHandler<SimpleAction, SimpleAction.ActivateSignalArgs>? Activated;
 		public void Activate ()
 		{
@@ -48,7 +46,7 @@ namespace Pinta.Core
 		public string? ShortLabel { get; set; }
 		public string? Tooltip { get; }
 		public string? IconName { get; }
-		public string FullName { get { return $"app.{Name}"; } }
+		public string FullName => $"app.{Name}";
 		public bool IsImportant { get; set; } = false;
 		public bool Sensitive { get { return Action.Enabled; } set { Action.Enabled = value; } }
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -100,9 +100,7 @@ namespace Pinta.Core
 			timer_tick_id = 0;
 		}
 
-		internal bool IsRendering {
-			get { return is_rendering; }
-		}
+		internal bool IsRendering => is_rendering;
 
 		internal double Progress {
 			get {

--- a/Pinta.Core/Classes/BasePaintBrush.cs
+++ b/Pinta.Core/Classes/BasePaintBrush.cs
@@ -46,25 +46,19 @@ namespace Pinta.Core
 		/// Priority value for ordering brushes. If the priority is zero, then
 		/// alphabetical ordering is used.
 		/// </summary>
-		public virtual int Priority {
-			get { return 0; }
-		}
+		public virtual int Priority => 0;
 
 		/// <summary>
 		/// Random number generator. This can be used to implement brushes with
 		/// random effects.
 		/// </summary>
-		public Random Random {
-			get { return random; }
-		}
+		public Random Random => random;
 
 		/// <summary>
 		/// Used to multiply the alpha value of the stroke color by a
 		/// constant factor.
 		/// </summary>
-		public virtual double StrokeAlphaMultiplier {
-			get { return 1; }
-		}
+		public virtual double StrokeAlphaMultiplier => 1;
 
 		public virtual void DoMouseUp ()
 		{

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -113,7 +113,7 @@ namespace Pinta.Core
 		/// Pinta from a file, or if the user just clicked Save As.
 		public bool HasBeenSavedInSession { get; set; }
 
-		public DocumentHistory History { get { return Workspace.History; } }
+		public DocumentHistory History => Workspace.History;
 
 		public Core.Size ImageSize { get; set; }
 

--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -50,11 +50,7 @@ namespace Pinta.Core
 				PaletteChanged (this, EventArgs.Empty);
 		}
 
-		public int Count {
-			get {
-				return colors.Count;
-			}
-		}
+		public int Count => colors.Count;
 
 		public Color this[int index] {
 			get {

--- a/Pinta.Core/Classes/Re-editable/ReEditableLayer.cs
+++ b/Pinta.Core/Classes/Re-editable/ReEditableLayer.cs
@@ -37,7 +37,7 @@ namespace Pinta.Core
 
 		private bool inTheLoop = false;
 
-		public bool InTheLoop { get { return inTheLoop; } }
+		public bool InTheLoop => inTheLoop;
 
 		public Layer Layer {
 			get {
@@ -53,11 +53,7 @@ namespace Pinta.Core
 			}
 		}
 
-		public bool IsLayerSetup {
-			get {
-				return isLayerSetup;
-			}
-		}
+		public bool IsLayerSetup => isLayerSetup;
 
 		/// <summary>
 		/// Creates a new ReEditableLayer for drawing and editing on separately from the rest of the image.

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -29,8 +29,8 @@ namespace Pinta.Core
 		public TextAlignment Alignment { get; private set; }
 		public bool Underline { get; private set; }
 
-		public TextPosition CurrentPosition { get { return currentPos; } }
-		public int LineCount { get { return lines.Count; } }
+		public TextPosition CurrentPosition => currentPos;
+		public int LineCount => lines.Count;
 		public TextMode State;
 		public PointI Origin { get; set; }
 

--- a/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextLayout.cs
@@ -46,7 +46,7 @@ namespace Pinta.Core
 		}
 
 		public Pango.Layout Layout { get; }
-		public int FontHeight { get { return GetCursorLocation ().Height; } }
+		public int FontHeight => GetCursorLocation ().Height;
 
 		public TextLayout ()
 		{

--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -21,8 +21,8 @@ namespace Pinta.Core
 		private readonly int denominator;
 		private readonly int numerator;
 
-		public readonly int Denominator { get { return denominator; } }
-		public readonly int Numerator { get { return numerator; } }
+		public readonly int Denominator => denominator;
+		public readonly int Numerator => numerator;
 		public double Ratio { get; }
 
 		public static readonly ScaleFactor OneToOne = new (1, 1);

--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -671,16 +671,16 @@ namespace Pinta.Core
 		//// Colors: copied from System.Drawing.Color's list (don't worry I didn't type it in 
 		//// manually, I used a code generator w/ reflection ...)
 
-		public static ColorBgra Transparent { get { return ColorBgra.FromBgra (255, 255, 255, 0); } }
-		public static ColorBgra Zero { get { return (ColorBgra) 0; } }
+		public static ColorBgra Transparent => ColorBgra.FromBgra (255, 255, 255, 0);
+		public static ColorBgra Zero => (ColorBgra) 0;
 
-		public static ColorBgra Black { get { return ColorBgra.FromBgra (0, 0, 0, 255); } }
-		public static ColorBgra Blue { get { return ColorBgra.FromBgra (255, 0, 0, 255); } }
-		public static ColorBgra Cyan { get { return ColorBgra.FromBgra (255, 255, 0, 255); } }
-		public static ColorBgra Green { get { return ColorBgra.FromBgra (0, 128, 0, 255); } }
-		public static ColorBgra Magenta { get { return ColorBgra.FromBgra (255, 0, 255, 255); } }
-		public static ColorBgra Red { get { return ColorBgra.FromBgra (0, 0, 255, 255); } }
-		public static ColorBgra White { get { return ColorBgra.FromBgra (255, 255, 255, 255); } }
-		public static ColorBgra Yellow { get { return ColorBgra.FromBgra (0, 255, 255, 255); } }
+		public static ColorBgra Black => ColorBgra.FromBgra (0, 0, 0, 255);
+		public static ColorBgra Blue => ColorBgra.FromBgra (255, 0, 0, 255);
+		public static ColorBgra Cyan => ColorBgra.FromBgra (255, 255, 0, 255);
+		public static ColorBgra Green => ColorBgra.FromBgra (0, 128, 0, 255);
+		public static ColorBgra Magenta => ColorBgra.FromBgra (255, 0, 255, 255);
+		public static ColorBgra Red => ColorBgra.FromBgra (0, 0, 255, 255);
+		public static ColorBgra White => ColorBgra.FromBgra (255, 255, 255, 255);
+		public static ColorBgra Yellow => ColorBgra.FromBgra (0, 255, 255, 255);
 	}
 }

--- a/Pinta.Core/Effects/SplineInterpolator.cs
+++ b/Pinta.Core/Effects/SplineInterpolator.cs
@@ -14,11 +14,7 @@ namespace Pinta.Core
 		private readonly SortedList<double, double> points = new ();
 		private double[]? y2;
 
-		public int Count {
-			get {
-				return this.points.Count;
-			}
-		}
+		public int Count => this.points.Count;
 
 		public void Add (double x, double y)
 		{

--- a/Pinta.Core/Extensions/GioStream.cs
+++ b/Pinta.Core/Extensions/GioStream.cs
@@ -71,17 +71,11 @@ namespace Pinta.Core
 			can_seek = stream is Gio.Seekable s && s.CanSeek ();
 		}
 
-		public override bool CanSeek {
-			get { return can_seek; }
-		}
+		public override bool CanSeek => can_seek;
 
-		public override bool CanRead {
-			get { return can_read; }
-		}
+		public override bool CanRead => can_read;
 
-		public override bool CanWrite {
-			get { return can_write; }
-		}
+		public override bool CanWrite => can_write;
 
 		public override long Length {
 			get {

--- a/Pinta.Core/HistoryItems/BaseHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/BaseHistoryItem.cs
@@ -34,7 +34,7 @@ namespace Pinta.Core
 		public string? Text { get; set; }
 		public HistoryItemState State { get; set; }
 		public uint Id;
-		public virtual bool CausesDirty { get { return true; } }
+		public virtual bool CausesDirty => true;
 
 		public BaseHistoryItem ()
 		{

--- a/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/FinishPixelsHistoryItem.cs
@@ -34,7 +34,7 @@ namespace Pinta.Core
 		private ImageSurface? old_surface;
 		private Matrix old_transform = CairoExtensions.CreateIdentityMatrix ();
 
-		public override bool CausesDirty { get { return false; } }
+		public override bool CausesDirty => false;
 
 		public FinishPixelsHistoryItem ()
 		{

--- a/Pinta.Core/HistoryItems/PasteHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/PasteHistoryItem.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core
 		private readonly Cairo.ImageSurface paste_image;
 		private DocumentSelection old_selection;
 
-		public override bool CausesDirty { get { return true; } }
+		public override bool CausesDirty => true;
 
 		public PasteHistoryItem (Cairo.ImageSurface pasteImage, DocumentSelection oldSelection)
 		{

--- a/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/SelectionHistoryItem.cs
@@ -33,7 +33,7 @@ namespace Pinta.Core
 
 		private bool hide_tool_layer;
 
-		public override bool CausesDirty { get { return false; } }
+		public override bool CausesDirty => false;
 
 		public SelectionHistoryItem (string icon, string text) : base (icon, text)
 		{

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -50,7 +50,7 @@ namespace Pinta.Core
 		public Box ToolBox { get; private set; } = null!;
 		public Box StatusBar { get; private set; } = null!;
 
-		public IProgressDialog ProgressDialog { get { return progress_dialog; } }
+		public IProgressDialog ProgressDialog => progress_dialog;
 		public Gio.Menu AdjustmentsMenu { get; private set; } = null!;
 		public Gio.Menu EffectsMenu { get; private set; } = null!;
 

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -76,7 +76,7 @@ namespace Pinta.Core
 			RegisterFormat (new FormatDescriptor ("OpenRaster", new string[] { "ora", "ORA" }, new string[] { "image/openraster" }, oraHandler, oraHandler));
 		}
 
-		public IEnumerable<FormatDescriptor> Formats { get { return formats; } }
+		public IEnumerable<FormatDescriptor> Formats => formats;
 
 		/// <summary>
 		/// Registers a new file format.

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -60,9 +60,9 @@ namespace Pinta.Core
 			RenderUpdated += LivePreview_RenderUpdated;
 		}
 
-		public bool IsEnabled { get { return live_preview_enabled; } }
-		public Cairo.ImageSurface LivePreviewSurface { get { return live_preview_surface; } }
-		public RectangleI RenderBounds { get { return render_bounds; } }
+		public bool IsEnabled => live_preview_enabled;
+		public Cairo.ImageSurface LivePreviewSurface => live_preview_surface;
+		public RectangleI RenderBounds => render_bounds;
 
 		public event EventHandler<LivePreviewStartedEventArgs>? Started;
 		public event EventHandler<LivePreviewRenderUpdatedEventArgs>? RenderUpdated;

--- a/Pinta.Core/Managers/PaletteFormatManager.cs
+++ b/Pinta.Core/Managers/PaletteFormatManager.cs
@@ -47,7 +47,7 @@ namespace Pinta.Core
 			formats.Add (new PaletteDescriptor ("PaintShop Pro", new string[] { "pal", "PAL" }, pspHandler, pspHandler));
 		}
 
-		public IEnumerable<PaletteDescriptor> Formats { get { return formats; } }
+		public IEnumerable<PaletteDescriptor> Formats => formats;
 
 		public PaletteDescriptor? GetFormatByFilename (string fileName)
 		{

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -35,7 +35,7 @@ namespace Pinta.Core
 		private static readonly OS operating_system;
 
 		public int RenderThreads { get; set; }
-		public OS OperatingSystem { get { return operating_system; } }
+		public OS OperatingSystem => operating_system;
 
 		public SystemManager ()
 		{

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -121,11 +121,7 @@ namespace Pinta.Actions
 			[Caption ("Zoom"), MinimumValue (0), MaximumValue (16)]
 			public double Zoom = 1.0;
 
-			public override bool IsDefault {
-				get {
-					return Angle == 0 && Pan.X == 0.0 && Pan.Y == 0.0 && Zoom == 1.0;
-				}
-			}
+			public override bool IsDefault => Angle == 0 && Pan.X == 0.0 && Pan.Y == 0.0 && Zoom == 1.0;
 		}
 	}
 }

--- a/Pinta/Dialogs/LayerPropertiesDialog.cs
+++ b/Pinta/Dialogs/LayerPropertiesDialog.cs
@@ -92,26 +92,14 @@ namespace Pinta
 			opacitySpinner.SetActivatesDefault (true);
 		}
 
-		public bool AreLayerPropertiesUpdated {
-			get {
-				return initial_properties.Opacity != opacity
+		public bool AreLayerPropertiesUpdated => initial_properties.Opacity != opacity
 					|| initial_properties.Hidden != hidden
 					|| initial_properties.Name != name
 					|| initial_properties.BlendMode != blendmode;
-			}
-		}
 
-		public LayerProperties InitialLayerProperties {
-			get {
-				return initial_properties;
-			}
-		}
+		public LayerProperties InitialLayerProperties => initial_properties;
 
-		public LayerProperties UpdatedLayerProperties {
-			get {
-				return new LayerProperties (name, hidden, opacity, blendmode);
-			}
-		}
+		public LayerProperties UpdatedLayerProperties => new LayerProperties (name, hidden, opacity, blendmode);
 
 		#region Private Methods
 		private void OnLayerNameChanged (object? sender, EventArgs e)

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -107,9 +107,9 @@ namespace Pinta
 			preview.Update (NewImageSize, NewImageBackground);
 		}
 
-		public int NewImageWidth { get { return int.Parse (width_entry.Buffer!.Text!); } }
-		public int NewImageHeight { get { return int.Parse (height_entry.Buffer!.Text!); } }
-		public Size NewImageSize { get { return new Size (NewImageWidth, NewImageHeight); } }
+		public int NewImageWidth => int.Parse (width_entry.Buffer!.Text!);
+		public int NewImageHeight => int.Parse (height_entry.Buffer!.Text!);
+		public Size NewImageSize => new Size (NewImageWidth, NewImageHeight);
 
 		public enum BackgroundType
 		{

--- a/Pinta/DocumentViewContent.cs
+++ b/Pinta/DocumentViewContent.cs
@@ -49,6 +49,6 @@ namespace Pinta
 
 		public string Label => Document.DisplayName + (Document.IsDirty ? "*" : string.Empty);
 
-		public Gtk.Widget Widget { get { return canvas_window; } }
+		public Gtk.Widget Widget => canvas_window;
 	}
 }

--- a/Pinta/MacInterop/ApplicationEvents.cs
+++ b/Pinta/MacInterop/ApplicationEvents.cs
@@ -193,11 +193,7 @@ namespace Pinta.MacInterop
 	{
 		public bool Handled { get; set; }
 
-		internal CarbonEventHandlerStatus HandledStatus {
-			get {
-				return Handled ? CarbonEventHandlerStatus.Handled : CarbonEventHandlerStatus.NotHandled;
-			}
-		}
+		internal CarbonEventHandlerStatus HandledStatus => Handled ? CarbonEventHandlerStatus.Handled : CarbonEventHandlerStatus.NotHandled;
 	}
 
 	public class ApplicationQuitEventArgs : ApplicationEventArgs

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -497,23 +497,17 @@ namespace Pinta.MacInterop
 			this.attributes = CarbonHICommandAttributes.FromMenu;
 		}
 
-		public readonly CarbonHICommandAttributes Attributes { get { return attributes; } }
-		public readonly uint CommandID { get { return commandID; } }
-		public readonly IntPtr ControlRef { get { return controlRef; } }
-		public readonly IntPtr WindowRef { get { return windowRef; } }
-		public readonly HIMenuItem MenuItem { get { return menuItem; } }
+		public readonly CarbonHICommandAttributes Attributes => attributes;
+		public readonly uint CommandID => commandID;
+		public readonly IntPtr ControlRef => controlRef;
+		public readonly IntPtr WindowRef => windowRef;
+		public readonly HIMenuItem MenuItem => menuItem;
 
-		public readonly bool IsFromMenu {
-			get { return attributes == CarbonHICommandAttributes.FromMenu; }
-		}
+		public readonly bool IsFromMenu => attributes == CarbonHICommandAttributes.FromMenu;
 
-		public readonly bool IsFromControl {
-			get { return attributes == CarbonHICommandAttributes.FromControl; }
-		}
+		public readonly bool IsFromControl => attributes == CarbonHICommandAttributes.FromControl;
 
-		public readonly bool IsFromWindow {
-			get { return attributes == CarbonHICommandAttributes.FromWindow; }
-		}
+		public readonly bool IsFromWindow => attributes == CarbonHICommandAttributes.FromWindow;
 	}
 
 	[StructLayout (LayoutKind.Sequential, Pack = 2)]
@@ -528,8 +522,8 @@ namespace Pinta.MacInterop
 			this.menuRef = menuRef;
 		}
 
-		public readonly IntPtr MenuRef { get { return menuRef; } }
-		public readonly ushort Index { get { return index; } }
+		public readonly IntPtr MenuRef => menuRef;
+		public readonly ushort Index => index;
 	}
 
 	//*NOT* flags
@@ -544,9 +538,7 @@ namespace Pinta.MacInterop
 	{
 		readonly int value;
 
-		public readonly int Value {
-			get { return value; }
-		}
+		public readonly int Value => value;
 
 		public OSType (int value)
 		{

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -164,8 +164,8 @@ namespace Mono.Options
 
 		#region ICollection
 		void ICollection.CopyTo (Array array, int index) { (values as ICollection).CopyTo (array, index); }
-		bool ICollection.IsSynchronized { get { return (values as ICollection).IsSynchronized; } }
-		object ICollection.SyncRoot { get { return (values as ICollection).SyncRoot; } }
+		bool ICollection.IsSynchronized => (values as ICollection).IsSynchronized;
+		object ICollection.SyncRoot => (values as ICollection).SyncRoot;
 		#endregion
 
 		#region ICollection<T>
@@ -174,8 +174,8 @@ namespace Mono.Options
 		public bool Contains (string item) { return values.Contains (item); }
 		public void CopyTo (string[] array, int arrayIndex) { values.CopyTo (array, arrayIndex); }
 		public bool Remove (string item) { return values.Remove (item); }
-		public int Count { get { return values.Count; } }
-		public bool IsReadOnly { get { return false; } }
+		public int Count => values.Count;
+		public bool IsReadOnly => false;
 		#endregion
 
 		#region IEnumerable
@@ -193,7 +193,7 @@ namespace Mono.Options
 		void IList.Insert (int index, object value) { (values as IList).Insert (index, value); }
 		void IList.Remove (object value) { (values as IList).Remove (value); }
 		void IList.RemoveAt (int index) { (values as IList).RemoveAt (index); }
-		bool IList.IsFixedSize { get { return false; } }
+		bool IList.IsFixedSize => false;
 		object IList.this[int index] { get { return this[index]; } set { (values as IList)[index] = value; } }
 		#endregion
 
@@ -271,13 +271,9 @@ namespace Mono.Options
 			set { index = value; }
 		}
 
-		public OptionSet OptionSet {
-			get { return set; }
-		}
+		public OptionSet OptionSet => set;
 
-		public OptionValueCollection OptionValues {
-			get { return c; }
-		}
+		public OptionValueCollection OptionValues => c;
 	}
 
 	public enum OptionValueType
@@ -330,10 +326,10 @@ namespace Mono.Options
 						nameof (prototype));
 		}
 
-		public string Prototype { get { return prototype; } }
-		public string Description { get { return description; } }
-		public OptionValueType OptionValueType { get { return type; } }
-		public int MaxValueCount { get { return count; } }
+		public string Prototype => prototype;
+		public string Description => description;
+		public OptionValueType OptionValueType => type;
+		public int MaxValueCount => count;
 
 		public string[] GetNames ()
 		{
@@ -369,8 +365,8 @@ namespace Mono.Options
 			return t;
 		}
 
-		internal string[] Names { get { return names; } }
-		internal string[] ValueSeparators { get { return separators; } }
+		internal string[] Names => names;
+		internal string[] ValueSeparators => separators;
 
 		static readonly char[] NameTerminator = new char[] { '=', ':' };
 
@@ -490,9 +486,7 @@ namespace Mono.Options
 			this.option = info.GetString ("OptionName");
 		}
 
-		public string OptionName {
-			get { return this.option; }
-		}
+		public string OptionName => this.option;
 
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
@@ -517,9 +511,7 @@ namespace Mono.Options
 
 		readonly Converter<string, string> localizer;
 
-		public Converter<string, string> MessageLocalizer {
-			get { return localizer; }
-		}
+		public Converter<string, string> MessageLocalizer => localizer;
 
 		protected override string GetKeyForItem (Option item)
 		{


### PR DESCRIPTION
Done automatically by IDE + a later search/replace to fix any potential issues with line endings.

Only these two projects in this pull request, though, reviewing all occurrences in the solution could be too daunting to review.

I think this only covers the properties that have _only_ a getter.