### PR TITLE
Modernized getter syntax in `Pinta.Docking` and `Pinta.Tools`

### DIFF
--- a/Pinta.Docking/DockNotebook.cs
+++ b/Pinta.Docking/DockNotebook.cs
@@ -107,7 +107,7 @@ namespace Pinta.Docking
 		/// <summary>
 		/// The items currently in the notebook.
 		/// </summary>
-		public IEnumerable<IDockNotebookItem> Items { get { return items; } }
+		public IEnumerable<IDockNotebookItem> Items => items;
 
 		/// <summary>
 		/// Whether to show the tab bar.

--- a/Pinta.Tools/Brushes/CircleBrush.cs
+++ b/Pinta.Tools/Brushes/CircleBrush.cs
@@ -33,13 +33,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class CircleBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Circles"); }
-		}
+		public override string Name => Translations.GetString ("Circles");
 
-		public override double StrokeAlphaMultiplier {
-			get { return 0.05; }
-		}
+		public override double StrokeAlphaMultiplier => 0.05;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/GridBrush.cs
+++ b/Pinta.Tools/Brushes/GridBrush.cs
@@ -33,13 +33,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class GridBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Grid"); }
-		}
+		public override string Name => Translations.GetString ("Grid");
 
-		public override double StrokeAlphaMultiplier {
-			get { return 0.05; }
-		}
+		public override double StrokeAlphaMultiplier => 0.05;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -32,13 +32,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class PlainBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Normal"); }
-		}
+		public override string Name => Translations.GetString ("Normal");
 
-		public override int Priority {
-			get { return -100; }
-		}
+		public override int Priority => -100;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/SplatterBrush.cs
+++ b/Pinta.Tools/Brushes/SplatterBrush.cs
@@ -33,13 +33,9 @@ namespace Pinta.Tools.Brushes
 {
 	public class SplatterBrush : BasePaintBrush
 	{
-		public override string Name {
-			get { return Translations.GetString ("Splatter"); }
-		}
+		public override string Name => Translations.GetString ("Splatter");
 
-		public override double StrokeAlphaMultiplier {
-			get { return 0.5; }
-		}
+		public override double StrokeAlphaMultiplier => 0.5;
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -35,9 +35,7 @@ namespace Pinta.Tools.Brushes
 	{
 		private static readonly double theta = Math.PI / 2;
 
-		public override string Name {
-			get { return Translations.GetString ("Squares"); }
-		}
+		public override string Name => Translations.GetString ("Squares");
 
 		protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
 							      int x, int y, int lastX, int lastY)

--- a/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
@@ -35,7 +35,7 @@ namespace Pinta.Tools
 {
 	public class EllipseEditEngine : BaseEditEngine
 	{
-		protected override string ShapeName { get { return Translations.GetString ("Ellipse"); } }
+		protected override string ShapeName => Translations.GetString ("Ellipse");
 
 		public EllipseEditEngine (ShapeTool owner)
 		    : base (owner)

--- a/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
@@ -35,11 +35,7 @@ namespace Pinta.Tools
 {
 	public class LineCurveEditEngine : ArrowedEditEngine
 	{
-		protected override string ShapeName {
-			get {
-				return Translations.GetString ("Open Curve Shape");
-			}
-		}
+		protected override string ShapeName => Translations.GetString ("Open Curve Shape");
 
 		public LineCurveEditEngine (ShapeTool passedOwner) : base (passedOwner)
 		{

--- a/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
@@ -35,11 +35,7 @@ namespace Pinta.Tools
 {
 	public class RectangleEditEngine : BaseEditEngine
 	{
-		protected override string ShapeName {
-			get {
-				return Translations.GetString ("Closed Curve Shape");
-			}
-		}
+		protected override string ShapeName => Translations.GetString ("Closed Curve Shape");
 
 		public RectangleEditEngine (ShapeTool passedOwner) : base (passedOwner)
 		{

--- a/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
@@ -35,11 +35,7 @@ namespace Pinta.Tools
 {
 	public class RoundedLineEditEngine : BaseEditEngine
 	{
-		protected override string ShapeName {
-			get {
-				return Translations.GetString ("Rounded Line Shape");
-			}
-		}
+		protected override string ShapeName => Translations.GetString ("Rounded Line Shape");
 
 		public const double DefaultRadius = 20d;
 

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -45,7 +45,7 @@ namespace Pinta.Tools
 		// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
 		public override string StatusBarText => Translations.GetString ("{0} + left click to set origin, left click to paint.", GtkExtensions.CtrlLabel ());
 		public override bool CursorChangesOnZoom => true;
-		public override Key ShortcutKey { get { return Key.L; } }
+		public override Key ShortcutKey => Key.L;
 		public override int Priority => 47;
 		protected override bool ShowAntialiasingButton => true;
 

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -50,8 +50,8 @@ namespace Pinta.Tools
 		private int? active_handle;
 		private string? active_cursor_name;
 
-		public override Gdk.Key ShortcutKey { get { return Gdk.Key.S; } }
-		protected override bool ShowAntialiasingButton { get { return false; } }
+		public override Gdk.Key ShortcutKey => Gdk.Key.S;
+		protected override bool ShowAntialiasingButton => false;
 		public override IEnumerable<MoveHandle> Handles => handles;
 
 		public SelectTool (IServiceManager services) : base (services)

--- a/Pinta.Tools/Tools/ShapeTool.cs
+++ b/Pinta.Tools/Tools/ShapeTool.cs
@@ -43,10 +43,9 @@ namespace Pinta.Tools
 		public virtual BaseEditEngine.ShapeTypes ShapeType => BaseEditEngine.ShapeTypes.ClosedLineCurveSeries;
 		public override bool IsEditableShapeTool => true;
 
-		public override string StatusBarText {
-			get {
+		public override string StatusBarText =>
 				// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
-				return Translations.GetString ("Left click to draw a shape with the primary color." +
+				Translations.GetString ("Left click to draw a shape with the primary color." +
 				    "\nLeft click on a shape to add a control point." +
 				    "\nLeft click on a control point and drag to move it." +
 				    "\nRight click on a control point and drag to change its tension." +
@@ -58,8 +57,6 @@ namespace Pinta.Tools
 				    "\nHold {0} while pressing Space to create the control point at the exact same position." +
 				    "\nHold {0} while left clicking on a control point to create a new shape at the exact same position." +
 				    "\nPress Enter to finalize the shape.", GtkExtensions.CtrlLabel ());
-			}
-		}
 
 		protected abstract BaseEditEngine CreateEditEngine ();
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -81,15 +81,13 @@ namespace Pinta.Tools
 		//Whether or not the previous TextTool mouse cursor shown was the normal one.
 		private bool previous_mouse_cursor_normal = true;
 
-		public override string Name { get { return Translations.GetString ("Text"); } }
-		private string FinalizeName { get { return Translations.GetString ("Text - Finalize"); } }
-		public override string Icon { get { return Pinta.Resources.Icons.ToolText; } }
-		public override Gdk.Key ShortcutKey { get { return Gdk.Key.T; } }
-		public override int Priority { get { return 35; } }
+		public override string Name => Translations.GetString ("Text");
+		private string FinalizeName => Translations.GetString ("Text - Finalize");
+		public override string Icon => Pinta.Resources.Icons.ToolText;
+		public override Gdk.Key ShortcutKey => Gdk.Key.T;
+		public override int Priority => 35;
 
-		public override string StatusBarText {
-			get { return Translations.GetString ("Left click to place cursor, then type desired text. Text color is primary color."); }
-		}
+		public override string StatusBarText => Translations.GetString ("Left click to place cursor, then type desired text. Text color is primary color.");
 
 		public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Text.png"), 16, 16, null);
 		public Gdk.Cursor InvalidEditCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon (Pinta.Resources.Icons.EditSelectionErase), 0, 0, null);
@@ -407,9 +405,9 @@ namespace Pinta.Tools
 
 		private int OutlineWidth => outline_width.GetValueAsInt ();
 
-		protected bool StrokeText { get { return (fill_button.SelectedItem.GetTagOrDefault (0) >= 1 && fill_button.SelectedItem.GetTagOrDefault (0) != 3); } }
-		protected bool FillText { get { return fill_button.SelectedItem.GetTagOrDefault (0) <= 1 || fill_button.SelectedItem.GetTagOrDefault (0) == 3; } }
-		protected bool BackgroundFill { get { return fill_button.SelectedItem.GetTagOrDefault (0) == 3; } }
+		protected bool StrokeText => (fill_button.SelectedItem.GetTagOrDefault (0) >= 1 && fill_button.SelectedItem.GetTagOrDefault (0) != 3);
+		protected bool FillText => fill_button.SelectedItem.GetTagOrDefault (0) <= 1 || fill_button.SelectedItem.GetTagOrDefault (0) == 3;
+		protected bool BackgroundFill => fill_button.SelectedItem.GetTagOrDefault (0) == 3;
 		#endregion
 
 		#region Activation/Deactivation


### PR DESCRIPTION
Done automatically by IDE + a subsequent search/replace to fix any potential issues with line endings.

Only these two projects in this pull request, though, as reviewing all occurrences in the solution at once could be too daunting.

I think this only covers the properties that have _only_ a getter.