### PR TITLE
Modernized getter syntax in `Pinta.Effects`

### DIFF
--- a/Pinta.Effects/Adjustments/AutoLevelEffect.cs
+++ b/Pinta.Effects/Adjustments/AutoLevelEffect.cs
@@ -16,17 +16,11 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOps.Level? op;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsAutoLevel; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsAutoLevel;
 
-		public override string Name {
-			get { return Translations.GetString ("Auto Level"); }
-		}
+		public override string Name => Translations.GetString ("Auto Level");
 
-		public override string AdjustmentMenuKey {
-			get { return "L"; }
-		}
+		public override string AdjustmentMenuKey => "L";
 
 		public override void Render (ImageSurface src, ImageSurface dest, RectangleI[] rois)
 		{

--- a/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
+++ b/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
@@ -16,17 +16,11 @@ namespace Pinta.Effects
 	{
 		readonly UnaryPixelOp op = new UnaryPixelOps.Desaturate ();
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsBlackAndWhite; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsBlackAndWhite;
 
-		public override string Name {
-			get { return Translations.GetString ("Black and White"); }
-		}
+		public override string Name => Translations.GetString ("Black and White");
 
-		public override string AdjustmentMenuKey {
-			get { return "G"; }
-		}
+		public override string AdjustmentMenuKey => "G";
 
 		public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
 		{

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -20,23 +20,15 @@ namespace Pinta.Effects
 		private byte[]? rgb_table;
 		private bool table_calculated;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsBrightnessContrast; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsBrightnessContrast;
 
-		public override string Name {
-			get { return Translations.GetString ("Brightness / Contrast"); }
-		}
+		public override string Name => Translations.GetString ("Brightness / Contrast");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "B"; }
-		}
+		public override string AdjustmentMenuKey => "B";
 
-		public BrightnessContrastData Data { get { return (BrightnessContrastData) EffectData!; } } // NRT - Set in constructor
+		public BrightnessContrastData Data => (BrightnessContrastData) EffectData!;  // NRT - Set in constructor
 
 		public BrightnessContrastEffect ()
 		{
@@ -168,9 +160,7 @@ namespace Pinta.Effects
 			}
 
 			[Skip]
-			public override bool IsDefault {
-				get { return Brightness == 0 && Contrast == 0; }
-			}
+			public override bool IsDefault => Brightness == 0 && Contrast == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -18,23 +18,15 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOp? op = null;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsCurves; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsCurves;
 
-		public override string Name {
-			get { return Translations.GetString ("Curves"); }
-		}
+		public override string Name => Translations.GetString ("Curves");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "M"; }
-		}
+		public override string AdjustmentMenuKey => "M";
 
-		public CurvesData Data { get { return (CurvesData) EffectData!; } } // NRT - Set in constructor
+		public CurvesData Data => (CurvesData) EffectData!;  // NRT - Set in constructor
 
 		public CurvesEffect ()
 		{

--- a/Pinta.Effects/Adjustments/HueSaturationEffect.cs
+++ b/Pinta.Effects/Adjustments/HueSaturationEffect.cs
@@ -17,21 +17,13 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOp? op;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsHueSaturation; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsHueSaturation;
 
-		public override string Name {
-			get { return Translations.GetString ("Hue / Saturation"); }
-		}
+		public override string Name => Translations.GetString ("Hue / Saturation");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "U"; }
-		}
+		public override string AdjustmentMenuKey => "U";
 
 		public HueSaturationEffect ()
 		{
@@ -59,7 +51,7 @@ namespace Pinta.Effects
 			op.Apply (dest, src, rois);
 		}
 
-		private HueSaturationData Data { get { return (HueSaturationData) EffectData!; } } // NRT - Set in constructor
+		private HueSaturationData Data => (HueSaturationData) EffectData!;  // NRT - Set in constructor
 
 		private class HueSaturationData : EffectData
 		{
@@ -73,9 +65,7 @@ namespace Pinta.Effects
 			public int Lightness = 0;
 
 			[Skip]
-			public override bool IsDefault {
-				get { return Hue == 0 && Saturation == 100 && Lightness == 0; }
-			}
+			public override bool IsDefault => Hue == 0 && Saturation == 100 && Lightness == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Adjustments/InvertColorsEffect.cs
+++ b/Pinta.Effects/Adjustments/InvertColorsEffect.cs
@@ -16,17 +16,11 @@ namespace Pinta.Effects
 	{
 		readonly UnaryPixelOp op = new UnaryPixelOps.Invert ();
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsInvertColors; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsInvertColors;
 
-		public override string Name {
-			get { return Translations.GetString ("Invert Colors"); }
-		}
+		public override string Name => Translations.GetString ("Invert Colors");
 
-		public override string AdjustmentMenuKey {
-			get { return "I"; }
-		}
+		public override string AdjustmentMenuKey => "I";
 
 		public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
 		{

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -14,27 +14,17 @@ namespace Pinta.Effects
 {
 	public class LevelsEffect : BaseEffect
 	{
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsLevels; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsLevels;
 
-		public override string Name {
-			get { return Translations.GetString ("Levels"); }
-		}
+		public override string Name => Translations.GetString ("Levels");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "L"; }
-		}
+		public override string AdjustmentMenuKey => "L";
 
-		public override string AdjustmentMenuKeyModifiers {
-			get { return "<Primary>"; }
-		}
+		public override string AdjustmentMenuKeyModifiers => "<Primary>";
 
-		public LevelsData Data { get { return (LevelsData) EffectData!; } } // NRT - Set in constructor
+		public LevelsData Data => (LevelsData) EffectData!;  // NRT - Set in constructor
 
 		public LevelsEffect ()
 		{

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -16,23 +16,15 @@ namespace Pinta.Effects
 	{
 		UnaryPixelOps.PosterizePixel? op = null;
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsPosterize; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsPosterize;
 
-		public override string Name {
-			get { return Translations.GetString ("Posterize"); }
-		}
+		public override string Name => Translations.GetString ("Posterize");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string AdjustmentMenuKey {
-			get { return "P"; }
-		}
+		public override string AdjustmentMenuKey => "P";
 
-		public PosterizeData Data { get { return (PosterizeData) EffectData!; } } // NRT - Set in constructor
+		public PosterizeData Data => (PosterizeData) EffectData!;  // NRT - Set in constructor
 
 		public PosterizeEffect ()
 		{

--- a/Pinta.Effects/Adjustments/SepiaEffect.cs
+++ b/Pinta.Effects/Adjustments/SepiaEffect.cs
@@ -17,17 +17,11 @@ namespace Pinta.Effects
 		readonly UnaryPixelOp desat = new UnaryPixelOps.Desaturate ();
 		readonly UnaryPixelOp level = new UnaryPixelOps.Desaturate ();
 
-		public override string Icon {
-			get { return Pinta.Resources.Icons.AdjustmentsSepia; }
-		}
+		public override string Icon => Pinta.Resources.Icons.AdjustmentsSepia;
 
-		public override string Name {
-			get { return Translations.GetString ("Sepia"); }
-		}
+		public override string Name => Translations.GetString ("Sepia");
 
-		public override string AdjustmentMenuKey {
-			get { return "E"; }
-		}
+		public override string AdjustmentMenuKey => "E";
 
 		public SepiaEffect ()
 		{

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -78,13 +78,9 @@ namespace Pinta.Effects
 			}
 		}
 
-		public ColorTransferMode Mode {
-			get {
-				return (combo_map.Active == 0) ?
+		public ColorTransferMode Mode => (combo_map.Active == 0) ?
 						ColorTransferMode.Rgb :
 						ColorTransferMode.Luminosity;
-			}
-		}
 
 		public CurvesData EffectData { get; }
 

--- a/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
@@ -39,17 +39,11 @@ namespace Pinta.Effects
 		private HScaleSpinButtonWidget blue_spinbox;
 		private CheckButton link_button;
 
-		public int Red {
-			get { return red_spinbox.ValueAsInt; }
-		}
+		public int Red => red_spinbox.ValueAsInt;
 
-		public int Green {
-			get { return green_spinbox.ValueAsInt; }
-		}
+		public int Green => green_spinbox.ValueAsInt;
 
-		public int Blue {
-			get { return blue_spinbox.ValueAsInt; }
-		}
+		public int Blue => blue_spinbox.ValueAsInt;
 
 		public PosterizeData? EffectData { get; set; }
 

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -23,19 +23,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsNoiseAddNoise;
 
-		public override string Name {
-			get { return Translations.GetString ("Add Noise"); }
-		}
+		public override string Name => Translations.GetString ("Add Noise");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Noise"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Noise");
 
-		public NoiseData Data { get { return (NoiseData) EffectData!; } } // NRT - Set in constructor
+		public NoiseData Data => (NoiseData) EffectData!;  // NRT - Set in constructor
 
 		static AddNoiseEffect ()
 		{

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortBulge;
 
-		public override string Name {
-			get { return Translations.GetString ("Bulge"); }
-		}
+		public override string Name => Translations.GetString ("Bulge");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public BulgeData Data {
-			get { return (BulgeData) EffectData!; } // NRT - Set in constructor
-		}
+		public BulgeData Data => (BulgeData) EffectData!;
 
 		public BulgeEffect ()
 		{
@@ -99,9 +91,7 @@ namespace Pinta.Effects
 			public Core.PointD Offset = new (0.0, 0.0);
 
 			[Skip]
-			public override bool IsDefault {
-				get { return Amount == 0; }
-			}
+			public override bool IsDefault => Amount == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -23,19 +23,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderClouds;
 
-		public override string Name {
-			get { return Translations.GetString ("Clouds"); }
-		}
+		public override string Name => Translations.GetString ("Clouds");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Render"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Render");
 
-		public CloudsData Data { get { return (CloudsData) EffectData!; } } // NRT - Set in constructor
+		public CloudsData Data => (CloudsData) EffectData!;  // NRT - Set in constructor
 
 		public CloudsEffect ()
 		{
@@ -192,7 +186,7 @@ namespace Pinta.Effects
 		public class CloudsData : EffectData
 		{
 			[Skip]
-			public override bool IsDefault { get { return Power == 0; } }
+			public override bool IsDefault => Power == 0;
 
 			[Caption ("Scale"), MinimumValue (2), MaximumValue (1000)]
 			public int Scale = 250;

--- a/Pinta.Effects/Effects/EdgeDetectEffect.cs
+++ b/Pinta.Effects/Effects/EdgeDetectEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeEdgeDetect;
 
-		public override string Name {
-			get { return Translations.GetString ("Edge Detect"); }
-		}
+		public override string Name => Translations.GetString ("Edge Detect");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
-		public EdgeDetectData Data { get { return (EdgeDetectData) EffectData!; } } // NRT - Set in constructor
+		public EdgeDetectData Data => (EdgeDetectData) EffectData!;  // NRT - Set in constructor
 
 		public EdgeDetectEffect ()
 		{

--- a/Pinta.Effects/Effects/EmbossEffect.cs
+++ b/Pinta.Effects/Effects/EmbossEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeEmboss;
 
-		public override string Name {
-			get { return Translations.GetString ("Emboss"); }
-		}
+		public override string Name => Translations.GetString ("Emboss");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
-		public EmbossData Data {
-			get { return (EmbossData) EffectData!; } // NRT - Set in constructor
-		}
+		public EmbossData Data => (EmbossData) EffectData!;
 
 		public EmbossEffect ()
 		{

--- a/Pinta.Effects/Effects/FragmentEffect.cs
+++ b/Pinta.Effects/Effects/FragmentEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursFragment;
 
-		public override string Name {
-			get { return Translations.GetString ("Fragment"); }
-		}
+		public override string Name => Translations.GetString ("Fragment");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public FragmentData Data { get { return (FragmentData) EffectData!; } } // NRT - Set in constructor
+		public FragmentData Data => (FragmentData) EffectData!;  // NRT - Set in constructor
 
 		public FragmentEffect ()
 		{

--- a/Pinta.Effects/Effects/FrostedGlassEffect.cs
+++ b/Pinta.Effects/Effects/FrostedGlassEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortFrostedGlass;
 
-		public override string Name {
-			get { return Translations.GetString ("Frosted Glass"); }
-		}
+		public override string Name => Translations.GetString ("Frosted Glass");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public FrostedGlassData Data {
-			get { return (FrostedGlassData) EffectData!; } // NRT - Set in constructor
-		}
+		public FrostedGlassData Data => (FrostedGlassData) EffectData!;
 
 		private readonly Random random = new ();
 

--- a/Pinta.Effects/Effects/GaussianBlurEffect.cs
+++ b/Pinta.Effects/Effects/GaussianBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursGaussianBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Gaussian Blur"); }
-		}
+		public override string Name => Translations.GetString ("Gaussian Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public GaussianBlurData Data { get { return (GaussianBlurData) EffectData!; } } // NRT - Set in constructor
+		public GaussianBlurData Data => (GaussianBlurData) EffectData!;  // NRT - Set in constructor
 
 		public GaussianBlurEffect ()
 		{
@@ -242,7 +236,7 @@ namespace Pinta.Effects
 			public int Radius = 2;
 
 			[Skip]
-			public override bool IsDefault { get { return Radius == 0; } }
+			public override bool IsDefault => Radius == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/GlowEffect.cs
+++ b/Pinta.Effects/Effects/GlowEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoGlow;
 
-		public override string Name {
-			get { return Translations.GetString ("Glow"); }
-		}
+		public override string Name => Translations.GetString ("Glow");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public GlowData Data { get { return (GlowData) EffectData!; } } // NRT - Set in constructor
+		public GlowData Data => (GlowData) EffectData!;  // NRT - Set in constructor
 
 		public GlowEffect ()
 		{

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -25,19 +25,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsArtisticInkSketch;
 
-		public override string Name {
-			get { return Translations.GetString ("Ink Sketch"); }
-		}
+		public override string Name => Translations.GetString ("Ink Sketch");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Artistic"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Artistic");
 
-		public InkSketchData Data { get { return (InkSketchData) EffectData!; } } // NRT - Set in constructor
+		public InkSketchData Data => (InkSketchData) EffectData!;  // NRT - Set in constructor
 
 		public InkSketchEffect ()
 		{

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderJuliaFractal;
 
-		public override string Name {
-			get { return Translations.GetString ("Julia Fractal"); }
-		}
+		public override string Name => Translations.GetString ("Julia Fractal");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Render"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Render");
 
-		public JuliaFractalData Data { get { return (JuliaFractalData) EffectData!; } } // NRT - Set in constructor
+		public JuliaFractalData Data => (JuliaFractalData) EffectData!;  // NRT - Set in constructor
 
 		public JuliaFractalEffect ()
 		{

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsRenderMandelbrotFractal;
 
-		public override string Name {
-			get { return Translations.GetString ("Mandelbrot Fractal"); }
-		}
+		public override string Name => Translations.GetString ("Mandelbrot Fractal");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Render"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Render");
 
-		public MandelbrotFractalData Data { get { return (MandelbrotFractalData) EffectData!; } } // NRT - Set in constructor
+		public MandelbrotFractalData Data => (MandelbrotFractalData) EffectData!;  // NRT - Set in constructor
 
 		public MandelbrotFractalEffect ()
 		{

--- a/Pinta.Effects/Effects/MedianEffect.cs
+++ b/Pinta.Effects/Effects/MedianEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsNoiseMedian;
 
-		public override string Name {
-			get { return Translations.GetString ("Median"); }
-		}
+		public override string Name => Translations.GetString ("Median");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Noise"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Noise");
 
-		public MedianData Data { get { return (MedianData) EffectData!; } } // NRT - Set in constructor
+		public MedianData Data => (MedianData) EffectData!;  // NRT - Set in constructor
 
 		public MedianEffect ()
 		{
@@ -71,7 +65,7 @@ namespace Pinta.Effects
 			public int Percentile = 50;
 
 			[Skip]
-			public override bool IsDefault { get { return Radius == 0; } }
+			public override bool IsDefault => Radius == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/MotionBlurEffect.cs
+++ b/Pinta.Effects/Effects/MotionBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursMotionBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Motion Blur"); }
-		}
+		public override string Name => Translations.GetString ("Motion Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public MotionBlurData Data { get { return (MotionBlurData) EffectData!; } } // NRT - Set in constructor
+		public MotionBlurData Data => (MotionBlurData) EffectData!;  // NRT - Set in constructor
 
 		public MotionBlurEffect ()
 		{
@@ -103,7 +97,7 @@ namespace Pinta.Effects
 		public class MotionBlurData : EffectData
 		{
 			[Skip]
-			public override bool IsDefault { get { return Distance == 0; } }
+			public override bool IsDefault => Distance == 0;
 
 			[Caption ("Angle")]
 			public double Angle = 25;

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsArtisticOilPainting;
 
-		public override string Name {
-			get { return Translations.GetString ("Oil Painting"); }
-		}
+		public override string Name => Translations.GetString ("Oil Painting");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Artistic"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Artistic");
 
-		public OilPaintingData Data { get { return (OilPaintingData) EffectData!; } } // NRT - Set in constructor
+		public OilPaintingData Data => (OilPaintingData) EffectData!;  // NRT - Set in constructor
 
 		public OilPaintingEffect ()
 		{

--- a/Pinta.Effects/Effects/OutlineEffect.cs
+++ b/Pinta.Effects/Effects/OutlineEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeOutline;
 
-		public override string Name {
-			get { return Translations.GetString ("Outline"); }
-		}
+		public override string Name => Translations.GetString ("Outline");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
-		public OutlineData Data { get { return (OutlineData) EffectData!; } } // NRT - Set in constructor
+		public OutlineData Data => (OutlineData) EffectData!;  // NRT - Set in constructor
 
 		public OutlineEffect ()
 		{
@@ -143,7 +137,7 @@ namespace Pinta.Effects
 			public int Intensity = 50;
 
 			[Skip]
-			public override bool IsDefault { get { return Thickness == 0; } }
+			public override bool IsDefault => Thickness == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/PencilSketchEffect.cs
+++ b/Pinta.Effects/Effects/PencilSketchEffect.cs
@@ -23,19 +23,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsArtisticPencilSketch;
 
-		public override string Name {
-			get { return Translations.GetString ("Pencil Sketch"); }
-		}
+		public override string Name => Translations.GetString ("Pencil Sketch");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Artistic"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Artistic");
 
-		public PencilSketchData Data { get { return (PencilSketchData) EffectData!; } } // NRT - Set in constructor
+		public PencilSketchData Data => (PencilSketchData) EffectData!;  // NRT - Set in constructor
 
 		public PencilSketchEffect ()
 		{

--- a/Pinta.Effects/Effects/PixelateEffect.cs
+++ b/Pinta.Effects/Effects/PixelateEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortPixelate;
 
-		public override string Name {
-			get { return Translations.GetString ("Pixelate"); }
-		}
+		public override string Name => Translations.GetString ("Pixelate");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public PixelateData Data {
-			get { return (PixelateData) EffectData!; } // NRT - Set in constructor
-		}
+		public PixelateData Data => (PixelateData) EffectData!;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
 		public PixelateEffect ()
 		{

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -16,21 +16,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortPolarInversion;
 
-		public override string Name {
-			get { return Translations.GetString ("Polar Inversion"); }
-		}
+		public override string Name => Translations.GetString ("Polar Inversion");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public new PolarInversionData Data {
-			get { return (PolarInversionData) EffectData!; } // NRT - Set in constructor
-		}
+		public new PolarInversionData Data => (PolarInversionData) EffectData!;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
 		public PolarInversionEffect ()
 		{

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursRadialBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Radial Blur"); }
-		}
+		public override string Name => Translations.GetString ("Radial Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public RadialBlurData Data { get { return (RadialBlurData) EffectData!; } } // NRT - Set in constructor
+		public RadialBlurData Data => (RadialBlurData) EffectData!;  // NRT - Set in constructor
 
 		public RadialBlurEffect ()
 		{
@@ -164,7 +158,7 @@ namespace Pinta.Effects
 			public int Quality = 2;
 
 			[Skip]
-			public override bool IsDefault { get { return Angle == 0; } }
+			public override bool IsDefault => Angle == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
+++ b/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
@@ -19,19 +19,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoRedEyeRemove;
 
-		public override string Name {
-			get { return Translations.GetString ("Red Eye Removal"); }
-		}
+		public override string Name => Translations.GetString ("Red Eye Removal");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public RedEyeRemoveData Data { get { return (RedEyeRemoveData) EffectData!; } } // NRT - Set in constructor
+		public RedEyeRemoveData Data => (RedEyeRemoveData) EffectData!;  // NRT - Set in constructor
 
 		public RedEyeRemoveEffect ()
 		{

--- a/Pinta.Effects/Effects/ReduceNoiseEffect.cs
+++ b/Pinta.Effects/Effects/ReduceNoiseEffect.cs
@@ -21,19 +21,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsNoiseReduceNoise;
 
-		public override string Name {
-			get { return Translations.GetString ("Reduce Noise"); }
-		}
+		public override string Name => Translations.GetString ("Reduce Noise");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Noise"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Noise");
 
-		public ReduceNoiseData Data { get { return (ReduceNoiseData) EffectData!; } } // NRT - Set in constructor
+		public ReduceNoiseData Data => (ReduceNoiseData) EffectData!;  // NRT - Set in constructor
 
 		public ReduceNoiseEffect ()
 		{

--- a/Pinta.Effects/Effects/ReliefEffect.cs
+++ b/Pinta.Effects/Effects/ReliefEffect.cs
@@ -20,17 +20,11 @@ namespace Pinta.Effects
 			EffectData = new ReliefData ();
 		}
 
-		public ReliefData Data {
-			get { return (ReliefData) EffectData!; } // NRT - Set in constructor
-		}
+		public ReliefData Data => (ReliefData) EffectData!;
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Stylize"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
 		public override void LaunchConfiguration ()
 		{
@@ -39,9 +33,7 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsStylizeRelief;
 
-		public override string Name {
-			get { return Translations.GetString ("Relief"); }
-		}
+		public override string Name => Translations.GetString ("Relief");
 
 		#region Algorithm Code Ported From PDN
 		public override void Render (Cairo.ImageSurface src, Cairo.ImageSurface dst, Core.RectangleI[] rois)

--- a/Pinta.Effects/Effects/SharpenEffect.cs
+++ b/Pinta.Effects/Effects/SharpenEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoSharpen;
 
-		public override string Name {
-			get { return Translations.GetString ("Sharpen"); }
-		}
+		public override string Name => Translations.GetString ("Sharpen");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public SharpenData Data { get { return (SharpenData) EffectData!; } } // NRT - Set in constructor
+		public SharpenData Data => (SharpenData) EffectData!;  // NRT - Set in constructor
 
 		public SharpenEffect ()
 		{

--- a/Pinta.Effects/Effects/SoftenPortraitEffect.cs
+++ b/Pinta.Effects/Effects/SoftenPortraitEffect.cs
@@ -49,19 +49,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsPhotoSoftenPortrait;
 
-		public override string Name {
-			get { return Translations.GetString ("Soften Portrait"); }
-		}
+		public override string Name => Translations.GetString ("Soften Portrait");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Photo"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Photo");
 
-		public SoftenPortraitData Data { get { return (SoftenPortraitData) EffectData!; } } // NRT - Set in constructor
+		public SoftenPortraitData Data => (SoftenPortraitData) EffectData!;  // NRT - Set in constructor
 
 		public SoftenPortraitEffect ()
 		{

--- a/Pinta.Effects/Effects/TileEffect.cs
+++ b/Pinta.Effects/Effects/TileEffect.cs
@@ -18,21 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortTile;
 
-		public override string Name {
-			get { return Translations.GetString ("Tile Reflection"); }
-		}
+		public override string Name => Translations.GetString ("Tile Reflection");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public TileData Data {
-			get { return (TileData) EffectData!; } // NRT - Set in constructor
-		}
+		public TileData Data => (TileData) EffectData!;
 
 		public TileEffect ()
 		{

--- a/Pinta.Effects/Effects/TwistEffect.cs
+++ b/Pinta.Effects/Effects/TwistEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsDistortTwist;
 
-		public override string Name {
-			get { return Translations.GetString ("Twist"); }
-		}
+		public override string Name => Translations.GetString ("Twist");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Distort"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Distort");
 
-		public TwistData Data { get { return (TwistData) EffectData!; } } // NRT - Set in constructor
+		public TwistData Data => (TwistData) EffectData!;  // NRT - Set in constructor
 
 		public TwistEffect ()
 		{

--- a/Pinta.Effects/Effects/UnfocusEffect.cs
+++ b/Pinta.Effects/Effects/UnfocusEffect.cs
@@ -20,19 +20,13 @@ namespace Pinta.Effects
 
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursUnfocus;
 
-		public override string Name {
-			get { return Translations.GetString ("Unfocus"); }
-		}
+		public override string Name => Translations.GetString ("Unfocus");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public UnfocusData Data { get { return (UnfocusData) EffectData!; } } // NRT - Set in constructor
+		public UnfocusData Data => (UnfocusData) EffectData!;  // NRT - Set in constructor
 
 		public UnfocusEffect ()
 		{
@@ -96,7 +90,7 @@ namespace Pinta.Effects
 			public int Radius = 4;
 
 			[Skip]
-			public override bool IsDefault { get { return Radius == 0; } }
+			public override bool IsDefault => Radius == 0;
 		}
 	}
 }

--- a/Pinta.Effects/Effects/WarpEffect.cs
+++ b/Pinta.Effects/Effects/WarpEffect.cs
@@ -35,9 +35,7 @@ namespace Pinta.Effects
 	public abstract class WarpEffect : BaseEffect
 	{
 
-		public WarpData Data {
-			get { return (WarpData) EffectData!; } // NRT - Set in constructor
-		}
+		public WarpData Data => (WarpData) EffectData!;
 
 		public WarpEffect ()
 		{
@@ -52,8 +50,8 @@ namespace Pinta.Effects
 		private double default_radius = 0;
 		private double default_radius_2 = 0;
 
-		protected double DefaultRadius { get { return this.default_radius; } }
-		protected double DefaultRadius2 { get { return this.default_radius_2; } }
+		protected double DefaultRadius => this.default_radius;
+		protected double DefaultRadius2 => this.default_radius_2;
 
 		#region Algorithm Code Ported From PDN
 		public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -18,19 +18,13 @@ namespace Pinta.Effects
 	{
 		public override string Icon => Pinta.Resources.Icons.EffectsBlursZoomBlur;
 
-		public override string Name {
-			get { return Translations.GetString ("Zoom Blur"); }
-		}
+		public override string Name => Translations.GetString ("Zoom Blur");
 
-		public override bool IsConfigurable {
-			get { return true; }
-		}
+		public override bool IsConfigurable => true;
 
-		public override string EffectMenuCategory {
-			get { return Translations.GetString ("Blurs"); }
-		}
+		public override string EffectMenuCategory => Translations.GetString ("Blurs");
 
-		public ZoomBlurData Data { get { return (ZoomBlurData) EffectData!; } } // NRT - Set in constructor
+		public ZoomBlurData Data => (ZoomBlurData) EffectData!;  // NRT - Set in constructor
 
 		public ZoomBlurEffect ()
 		{
@@ -132,7 +126,7 @@ namespace Pinta.Effects
 			public Core.PointI Offset = new (0, 0);
 
 			[Skip]
-			public override bool IsDefault { get { return Amount == 0; } }
+			public override bool IsDefault => Amount == 0;
 		}
 	}
 }


### PR DESCRIPTION
Done automatically by IDE + a subsequent search/replace to fix any potential issues with line endings.

Only this project in this pull request, though, as reviewing all occurrences in the solution could be too daunting.

I think this only covers the properties that have _only_ a getter.