### PR TITLE
Return type of `DocumentLayers.GetLayersToPaint` is now `IEnumerable<Layer>` (instead of `List<Layer>`)

### DIFF
--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -6,7 +6,7 @@ using Cairo;
 
 namespace Pinta.Core
 {
-	public class DocumentLayers
+	public sealed class DocumentLayers
 	{
 		private readonly Document document;
 		private readonly List<UserLayer> user_layers = new ();

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -291,21 +291,21 @@ namespace Pinta.Core
 		{
 			foreach (var layer in user_layers) {
 				if (!layer.Hidden)
-					yield return (layer);
+					yield return layer;
 
 				if (layer == CurrentUserLayer) {
 					if (includeToolLayer && tool_layer is not null && !ToolLayer.Hidden)
-						yield return (ToolLayer);
+						yield return ToolLayer;
 
 					if (ShowSelectionLayer && (!SelectionLayer.Hidden))
-						yield return (SelectionLayer);
+						yield return SelectionLayer;
 				}
 
 				if (!layer.Hidden) {
 					foreach (var rel in layer.ReEditableLayers) {
 						//Make sure that each UserLayer's ReEditableLayer is in use before adding it to the List of Layers to Paint.
 						if (rel.IsLayerSetup)
-							yield return (rel.Layer);
+							yield return rel.Layer;
 					}
 				}
 			}

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -287,32 +287,28 @@ namespace Pinta.Core
 		/// Returns all layers that are visible and need to be painted, optionally
 		/// including tool and selection layers.
 		/// </summary>
-		public List<Layer> GetLayersToPaint (bool includeToolLayer = true)
+		public IEnumerable<Layer> GetLayersToPaint (bool includeToolLayer = true)
 		{
-			var paint_layers = new List<Layer> ();
-
 			foreach (var layer in user_layers) {
 				if (!layer.Hidden)
-					paint_layers.Add (layer);
+					yield return (layer);
 
 				if (layer == CurrentUserLayer) {
 					if (includeToolLayer && tool_layer is not null && !ToolLayer.Hidden)
-						paint_layers.Add (ToolLayer);
+						yield return (ToolLayer);
 
 					if (ShowSelectionLayer && (!SelectionLayer.Hidden))
-						paint_layers.Add (SelectionLayer);
+						yield return (SelectionLayer);
 				}
 
 				if (!layer.Hidden) {
 					foreach (var rel in layer.ReEditableLayers) {
 						//Make sure that each UserLayer's ReEditableLayer is in use before adding it to the List of Layers to Paint.
 						if (rel.IsLayerSetup)
-							paint_layers.Add (rel.Layer);
+							yield return (rel.Layer);
 					}
 				}
 			}
-
-			return paint_layers;
 		}
 
 		/// <summary>

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -188,7 +188,7 @@ namespace Pinta.Gui.Widgets
 			g.Translate (x, y);
 
 			// Render all the layers to a surface
-			var layers = document.Layers.GetLayersToPaint ();
+			var layers = document.Layers.GetLayersToPaint ().ToList ();
 
 			if (layers.Count == 0)
 				canvas.Clear ();


### PR DESCRIPTION
Thanks to `yield return`.

The method is essentially a query, so it can be made lazy, (except when we need it to be eager as in the case of `PintaCanvas.Draw`, where a call to `.ToList()` was added.