### PR TITLE
`Scanline`'s constructor rejects negative `length`

### DIFF
--- a/Pinta.Core/Effects/Scanline.cs
+++ b/Pinta.Core/Effects/Scanline.cs
@@ -5,6 +5,8 @@
 // See license-pdn.txt for full licensing and attribution details.             //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
+
 namespace Pinta.Core
 {
 	public struct Scanline
@@ -53,6 +55,9 @@ namespace Pinta.Core
 
 		public Scanline (int x, int y, int length)
 		{
+			if (length < 0)
+				throw new ArgumentOutOfRangeException (nameof (length));
+
 			this.x = x;
 			this.y = y;
 			this.length = length;

--- a/tests/Pinta.Core.Tests/ScanlineTest.cs
+++ b/tests/Pinta.Core.Tests/ScanlineTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -8,6 +9,12 @@ internal sealed class ScanlineTest
 {
 	// Perhaps most (all?) of these tests can be removed if Scanline is
 	// made into a record struct (a feature offered by C#10+)
+
+	[TestCaseSource (nameof (invalid_constructor_argument_combinations))]
+	public void Constructor_RejectsInvalidArguments (int x, int y, int length)
+	{
+		Assert.Throws<ArgumentOutOfRangeException> (() => _ = new Scanline (x, y, length));
+	}
 
 	[TestCaseSource (nameof (sample_initializations))]
 	public void MembersInitializingCorrectly (int x, int y, int length)
@@ -101,6 +108,10 @@ internal sealed class ScanlineTest
 		new (new Scanline(1, 1, 1), null),
 		new (new Scanline(1, 1, 1), new [] { 1, 1, 1 }),
 		new (new Scanline(1, 1, 1), 111),
+	};
+
+	static readonly IReadOnlyList<TestCaseData> invalid_constructor_argument_combinations = new TestCaseData[] {
+		new (0, 0, -1),
 	};
 
 	static readonly IReadOnlyList<TestCaseData> sample_initializations = new TestCaseData[] {


### PR DESCRIPTION
I'm not quite sure if it should reject negative coordinates, too. I need time to study the code.

However, it can't be too bad to leave out that check for now. One check is better than no checks