### PR TITLE
File-scoped namespaces for code files in `Pinta.Resources`

### DIFF
--- a/Pinta.Resources/Icons.cs
+++ b/Pinta.Resources/Icons.cs
@@ -24,238 +24,237 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-namespace Pinta.Resources
+namespace Pinta.Resources;
+
+public static class StandardIcons
 {
-	public static class StandardIcons
-	{
-		public const string ApplicationExit = "application-exit-symbolic";
+	public const string ApplicationExit = "application-exit-symbolic";
 
-		public const string DialogError = "dialog-error-symbolic";
+	public const string DialogError = "dialog-error-symbolic";
 
-		public const string DocumentNew = "document-new-symbolic";
-		public const string DocumentOpen = "document-open-symbolic";
-		public const string DocumentPrint = "document-print-symbolic";
-		public const string DocumentRevert = "document-revert-symbolic";
-		public const string DocumentSave = "document-save-symbolic";
-		public const string DocumentSaveAs = "document-save-as-symbolic";
+	public const string DocumentNew = "document-new-symbolic";
+	public const string DocumentOpen = "document-open-symbolic";
+	public const string DocumentPrint = "document-print-symbolic";
+	public const string DocumentRevert = "document-revert-symbolic";
+	public const string DocumentSave = "document-save-symbolic";
+	public const string DocumentSaveAs = "document-save-as-symbolic";
 
-		public const string FormatJustifyLeft = "format-justify-left-symbolic";
-		public const string FormatJustifyCenter = "format-justify-center-symbolic";
-		public const string FormatJustifyRight = "format-justify-right-symbolic";
-		public const string FormatTextBold = "format-text-bold-symbolic";
-		public const string FormatTextItalic = "format-text-italic-symbolic";
-		public const string FormatTextUnderline = "format-text-underline-symbolic";
+	public const string FormatJustifyLeft = "format-justify-left-symbolic";
+	public const string FormatJustifyCenter = "format-justify-center-symbolic";
+	public const string FormatJustifyRight = "format-justify-right-symbolic";
+	public const string FormatTextBold = "format-text-bold-symbolic";
+	public const string FormatTextItalic = "format-text-italic-symbolic";
+	public const string FormatTextUnderline = "format-text-underline-symbolic";
 
-		public const string EditCopy = "edit-copy-symbolic";
-		public const string EditCut = "edit-cut-symbolic";
-		public const string EditPaste = "edit-paste-symbolic";
-		public const string EditRedo = "edit-redo-symbolic";
-		public const string EditSelectAll = "edit-select-all-symbolic";
-		public const string EditUndo = "edit-undo-symbolic";
+	public const string EditCopy = "edit-copy-symbolic";
+	public const string EditCut = "edit-cut-symbolic";
+	public const string EditPaste = "edit-paste-symbolic";
+	public const string EditRedo = "edit-redo-symbolic";
+	public const string EditSelectAll = "edit-select-all-symbolic";
+	public const string EditUndo = "edit-undo-symbolic";
 
-		public const string GoPrevious = "go-previous-symbolic";
+	public const string GoPrevious = "go-previous-symbolic";
 
-		public const string HelpAbout = "help-about-symbolic";
-		public const string HelpBrowser = "help-browser-symbolic";
+	public const string HelpAbout = "help-about-symbolic";
+	public const string HelpBrowser = "help-browser-symbolic";
 
-		public const string ImageMissing = "image-missing-symbolic";
+	public const string ImageMissing = "image-missing-symbolic";
 
-		public const string OpenMenu = "open-menu-symbolic";
+	public const string OpenMenu = "open-menu-symbolic";
 
-		public const string ApplicationAddon = "application-x-addon-symbolic";
-		public const string SystemSearch = "system-search-symbolic";
-		public const string SystemSoftwareInstall = "system-software-install-symbolic";
-		public const string SoftwareUpdateAvailable = "software-update-available-symbolic";
+	public const string ApplicationAddon = "application-x-addon-symbolic";
+	public const string SystemSearch = "system-search-symbolic";
+	public const string SystemSoftwareInstall = "system-software-install-symbolic";
+	public const string SoftwareUpdateAvailable = "software-update-available-symbolic";
 
-		public const string ValueDecrease = "value-decrease-symbolic";
-		public const string ValueIncrease = "value-increase-symbolic";
-		public const string ViewFullscreen = "view-fullscreen-symbolic";
-		public const string ViewRefresh = "view-refresh-symbolic";
+	public const string ValueDecrease = "value-decrease-symbolic";
+	public const string ValueIncrease = "value-increase-symbolic";
+	public const string ViewFullscreen = "view-fullscreen-symbolic";
+	public const string ViewRefresh = "view-refresh-symbolic";
 
-		public const string WindowClose = "window-close-symbolic";
-		public const string WindowMaximize = "window-maximize-symbolic";
-		public const string WindowMinimize = "window-minimize-symbolic";
+	public const string WindowClose = "window-close-symbolic";
+	public const string WindowMaximize = "window-maximize-symbolic";
+	public const string WindowMinimize = "window-minimize-symbolic";
 
-		public const string ZoomFitBest = "zoom-fit-best-symbolic";
-		public const string ZoomIn = "zoom-in-symbolic";
-		public const string ZoomOut = "zoom-out-symbolic";
-		public const string ZoomOriginal = "zoom-original-symbolic";
-	}
+	public const string ZoomFitBest = "zoom-fit-best-symbolic";
+	public const string ZoomIn = "zoom-in-symbolic";
+	public const string ZoomOut = "zoom-out-symbolic";
+	public const string ZoomOriginal = "zoom-original-symbolic";
+}
 
-	public static class Icons
-	{
-		public const string AboutPinta = "about-pinta";
+public static class Icons
+{
+	public const string AboutPinta = "about-pinta";
 
-		public const string AddinsManage = "addins-manage";
+	public const string AddinsManage = "addins-manage";
 
-		public const string AdjustmentsAutoLevel = "adjustments-autolevel";
-		public const string AdjustmentsBlackAndWhite = "adjustments-blackandwhite";
-		public const string AdjustmentsBrightnessContrast = "adjustments-brightnesscontrast";
-		public const string AdjustmentsCurves = "adjustments-curves";
-		public const string AdjustmentsHueSaturation = "adjustments-huesaturation";
-		public const string AdjustmentsInvertColors = "adjustments-invertcolors";
-		public const string AdjustmentsLevels = "adjustments-levels";
-		public const string AdjustmentsPosterize = "adjustments-posterize";
-		public const string AdjustmentsSepia = "adjustments-sepia";
+	public const string AdjustmentsAutoLevel = "adjustments-autolevel";
+	public const string AdjustmentsBlackAndWhite = "adjustments-blackandwhite";
+	public const string AdjustmentsBrightnessContrast = "adjustments-brightnesscontrast";
+	public const string AdjustmentsCurves = "adjustments-curves";
+	public const string AdjustmentsHueSaturation = "adjustments-huesaturation";
+	public const string AdjustmentsInvertColors = "adjustments-invertcolors";
+	public const string AdjustmentsLevels = "adjustments-levels";
+	public const string AdjustmentsPosterize = "adjustments-posterize";
+	public const string AdjustmentsSepia = "adjustments-sepia";
 
-		public const string AntiAliasingEnabled = "tool-antialiasing-enabled-symbolic";
-		public const string AntiAliasingDisabled = "tool-antialiasing-disabled-symbolic";
+	public const string AntiAliasingEnabled = "tool-antialiasing-enabled-symbolic";
+	public const string AntiAliasingDisabled = "tool-antialiasing-disabled-symbolic";
 
-		public const string BlendingNormal = "tool-blending-normal-symbolic";
-		public const string BlendingOverwrite = "tool-blending-overwrite-symbolic";
+	public const string BlendingNormal = "tool-blending-normal-symbolic";
+	public const string BlendingOverwrite = "tool-blending-overwrite-symbolic";
 
-		public const string ColorModeColor = "tool-gradient-colormode-color-symbolic";
-		public const string ColorModeTransparency = "tool-gradient-colormode-transparency-symbolic";
+	public const string ColorModeColor = "tool-gradient-colormode-color-symbolic";
+	public const string ColorModeTransparency = "tool-gradient-colormode-transparency-symbolic";
 
-		public const string CursorPosition = "ui-cursor-location-symbolic";
+	public const string CursorPosition = "ui-cursor-location-symbolic";
 
-		public const string EditSelectionErase = "edit-selection-erase";
-		public const string EditSelectionFill = "edit-selection-fill";
-		public const string EditSelectionInvert = "edit-selection-invert";
-		public const string EditSelectionNone = "ui-deselect-symbolic";
+	public const string EditSelectionErase = "edit-selection-erase";
+	public const string EditSelectionFill = "edit-selection-fill";
+	public const string EditSelectionInvert = "edit-selection-invert";
+	public const string EditSelectionNone = "ui-deselect-symbolic";
 
-		public const string EffectsArtisticInkSketch = "effects-artistic-inksketch";
-		public const string EffectsArtisticOilPainting = "effects-artistic-oilpainting";
-		public const string EffectsArtisticPencilSketch = "effects-artistic-pencilsketch";
-		public const string EffectsBlursFragment = "effects-blurs-fragment";
-		public const string EffectsBlursGaussianBlur = "effects-blurs-gaussianblur";
-		public const string EffectsBlursMotionBlur = "effects-blurs-motionblur";
-		public const string EffectsBlursRadialBlur = "effects-blurs-radialblur";
-		public const string EffectsBlursUnfocus = "effects-blurs-unfocus";
-		public const string EffectsBlursZoomBlur = "effects-blurs-zoomblur";
-		public const string EffectsDefault = "effects-default";
-		public const string EffectsDistortBulge = "effects-distort-bulge";
-		public const string EffectsDistortFrostedGlass = "effects-distort-frostedglass";
-		public const string EffectsDistortPixelate = "effects-distort-pixelate";
-		public const string EffectsDistortPolarInversion = "effects-distort-polarinversion";
-		public const string EffectsDistortTile = "effects-distort-tile";
-		public const string EffectsDistortTwist = "effects-distort-twist";
-		public const string EffectsNoiseAddNoise = "effects-noise-addnoise";
-		public const string EffectsNoiseMedian = "effects-noise-median";
-		public const string EffectsNoiseReduceNoise = "effects-noise-reducenoise";
-		public const string EffectsPhotoGlow = "effects-photo-glow";
-		public const string EffectsPhotoRedEyeRemove = "effects-photo-redeyeremove";
-		public const string EffectsPhotoSharpen = "effects-photo-sharpen";
-		public const string EffectsPhotoSoftenPortrait = "effects-photo-softenportrait";
-		public const string EffectsRenderClouds = "effects-render-clouds";
-		public const string EffectsRenderJuliaFractal = "effects-render-juliafractal";
-		public const string EffectsRenderMandelbrotFractal = "effects-render-mandelbrotfractal";
-		public const string EffectsStylizeEdgeDetect = "effects-stylize-edgedetect";
-		public const string EffectsStylizeEmboss = "effects-stylize-emboss";
-		public const string EffectsStylizeOutline = "effects-stylize-outline";
-		public const string EffectsStylizeRelief = "effects-stylize-relief";
+	public const string EffectsArtisticInkSketch = "effects-artistic-inksketch";
+	public const string EffectsArtisticOilPainting = "effects-artistic-oilpainting";
+	public const string EffectsArtisticPencilSketch = "effects-artistic-pencilsketch";
+	public const string EffectsBlursFragment = "effects-blurs-fragment";
+	public const string EffectsBlursGaussianBlur = "effects-blurs-gaussianblur";
+	public const string EffectsBlursMotionBlur = "effects-blurs-motionblur";
+	public const string EffectsBlursRadialBlur = "effects-blurs-radialblur";
+	public const string EffectsBlursUnfocus = "effects-blurs-unfocus";
+	public const string EffectsBlursZoomBlur = "effects-blurs-zoomblur";
+	public const string EffectsDefault = "effects-default";
+	public const string EffectsDistortBulge = "effects-distort-bulge";
+	public const string EffectsDistortFrostedGlass = "effects-distort-frostedglass";
+	public const string EffectsDistortPixelate = "effects-distort-pixelate";
+	public const string EffectsDistortPolarInversion = "effects-distort-polarinversion";
+	public const string EffectsDistortTile = "effects-distort-tile";
+	public const string EffectsDistortTwist = "effects-distort-twist";
+	public const string EffectsNoiseAddNoise = "effects-noise-addnoise";
+	public const string EffectsNoiseMedian = "effects-noise-median";
+	public const string EffectsNoiseReduceNoise = "effects-noise-reducenoise";
+	public const string EffectsPhotoGlow = "effects-photo-glow";
+	public const string EffectsPhotoRedEyeRemove = "effects-photo-redeyeremove";
+	public const string EffectsPhotoSharpen = "effects-photo-sharpen";
+	public const string EffectsPhotoSoftenPortrait = "effects-photo-softenportrait";
+	public const string EffectsRenderClouds = "effects-render-clouds";
+	public const string EffectsRenderJuliaFractal = "effects-render-juliafractal";
+	public const string EffectsRenderMandelbrotFractal = "effects-render-mandelbrotfractal";
+	public const string EffectsStylizeEdgeDetect = "effects-stylize-edgedetect";
+	public const string EffectsStylizeEmboss = "effects-stylize-emboss";
+	public const string EffectsStylizeOutline = "effects-stylize-outline";
+	public const string EffectsStylizeRelief = "effects-stylize-relief";
 
-		public const string GradientConical = "tool-gradient-conical-symbolic";
-		public const string GradientDiamond = "tool-gradient-diamond-symbolic";
-		public const string GradientLinear = "tool-gradient-linear-symbolic";
-		public const string GradientLinearReflected = "tool-gradient-linear-reflected-symbolic";
-		public const string GradientRadial = "tool-gradient-radial-symbolic";
+	public const string GradientConical = "tool-gradient-conical-symbolic";
+	public const string GradientDiamond = "tool-gradient-diamond-symbolic";
+	public const string GradientLinear = "tool-gradient-linear-symbolic";
+	public const string GradientLinearReflected = "tool-gradient-linear-reflected-symbolic";
+	public const string GradientRadial = "tool-gradient-radial-symbolic";
 
-		public const string FillStyleBackground = "tool-fillstyle-background-symbolic";
-		public const string FillStyleFill = "tool-fillstyle-fill-symbolic";
-		public const string FillStyleOutline = "tool-fillstyle-outline-symbolic";
-		public const string FillStyleOutlineFill = "tool-fillstyle-outlinefill-symbolic";
+	public const string FillStyleBackground = "tool-fillstyle-background-symbolic";
+	public const string FillStyleFill = "tool-fillstyle-fill-symbolic";
+	public const string FillStyleOutline = "tool-fillstyle-outline-symbolic";
+	public const string FillStyleOutlineFill = "tool-fillstyle-outlinefill-symbolic";
 
-		public const string HelpBug = "help-bug";
-		public const string HelpTranslate = "help-translate";
-		public const string HelpWebsite = "help-website-symbolic";
+	public const string HelpBug = "help-bug";
+	public const string HelpTranslate = "help-translate";
+	public const string HelpWebsite = "help-website-symbolic";
 
-		public const string HistoryList = "ui-historylist-symbolic";
+	public const string HistoryList = "ui-historylist-symbolic";
 
-		public const string ImageCrop = "ui-crop-to-selection-symbolic";
-		public const string ImageResize = "image-resize";
-		public const string ImageResizeCanvas = "image-resize-canvas";
-		public const string ImageFlipHorizontal = "image-flip-horizontal-symbolic";
-		public const string ImageFlipVertical = "image-flip-vertical-symbolic";
-		public const string ImageRotate90CW = "image-rotate-90cw-symbolic";
-		public const string ImageRotate90CCW = "image-rotate-90ccw-symbolic";
-		public const string ImageRotate180 = "image-rotate-180-symbolic";
-		public const string ImageFlatten = "image-flatten";
-		public const string OrientationPortrait = "image-orientation-portrait-symbolic";
-		public const string OrientationLandscape = "image-orientation-landscape-symbolic";
+	public const string ImageCrop = "ui-crop-to-selection-symbolic";
+	public const string ImageResize = "image-resize";
+	public const string ImageResizeCanvas = "image-resize-canvas";
+	public const string ImageFlipHorizontal = "image-flip-horizontal-symbolic";
+	public const string ImageFlipVertical = "image-flip-vertical-symbolic";
+	public const string ImageRotate90CW = "image-rotate-90cw-symbolic";
+	public const string ImageRotate90CCW = "image-rotate-90ccw-symbolic";
+	public const string ImageRotate180 = "image-rotate-180-symbolic";
+	public const string ImageFlatten = "image-flatten";
+	public const string OrientationPortrait = "image-orientation-portrait-symbolic";
+	public const string OrientationLandscape = "image-orientation-landscape-symbolic";
 
-		public const string LayerDelete = "layers-remove-layer-symbolic";
-		public const string LayerDuplicate = "layers-duplicate-layer-symbolic";
-		public const string LayerFlipHorizontal = ImageFlipHorizontal;
-		public const string LayerFlipVertical = ImageFlipVertical;
-		public const string LayerImport = "layer-import";
-		public const string LayerMergeDown = "layers-merge-down-symbolic";
-		public const string LayerMoveDown = "layers-move-layer-down-symbolic";
-		public const string LayerMoveUp = "layers-move-layer-up-symbolic";
-		public const string LayerNew = "layers-add-layer-symbolic";
-		public const string LayerProperties = "document-properties-symbolic";
-		public const string LayerRotateZoom = "layers-rotate-zoom-symbolic";
+	public const string LayerDelete = "layers-remove-layer-symbolic";
+	public const string LayerDuplicate = "layers-duplicate-layer-symbolic";
+	public const string LayerFlipHorizontal = ImageFlipHorizontal;
+	public const string LayerFlipVertical = ImageFlipVertical;
+	public const string LayerImport = "layer-import";
+	public const string LayerMergeDown = "layers-merge-down-symbolic";
+	public const string LayerMoveDown = "layers-move-layer-down-symbolic";
+	public const string LayerMoveUp = "layers-move-layer-up-symbolic";
+	public const string LayerNew = "layers-add-layer-symbolic";
+	public const string LayerProperties = "document-properties-symbolic";
+	public const string LayerRotateZoom = "layers-rotate-zoom-symbolic";
 
-		public const string Pinta = "pinta";
+	public const string Pinta = "pinta";
 
-		public const string ResizeCanvasBase = "image-resize-canvas-base-symbolic";
-		public const string ResizeCanvasDown = "image-resize-canvas-down-symbolic";
-		public const string ResizeCanvasLeft = "image-resize-canvas-left-symbolic";
-		public const string ResizeCanvasNE = "image-resize-canvas-ne-symbolic";
-		public const string ResizeCanvasNW = "image-resize-canvas-nw-symbolic";
-		public const string ResizeCanvasRight = "image-resize-canvas-right-symbolic";
-		public const string ResizeCanvasSE = "image-resize-canvas-se-symbolic";
-		public const string ResizeCanvasSW = "image-resize-canvas-sw-symbolic";
-		public const string ResizeCanvasUp = "image-resize-canvas-up-symbolic";
+	public const string ResizeCanvasBase = "image-resize-canvas-base-symbolic";
+	public const string ResizeCanvasDown = "image-resize-canvas-down-symbolic";
+	public const string ResizeCanvasLeft = "image-resize-canvas-left-symbolic";
+	public const string ResizeCanvasNE = "image-resize-canvas-ne-symbolic";
+	public const string ResizeCanvasNW = "image-resize-canvas-nw-symbolic";
+	public const string ResizeCanvasRight = "image-resize-canvas-right-symbolic";
+	public const string ResizeCanvasSE = "image-resize-canvas-se-symbolic";
+	public const string ResizeCanvasSW = "image-resize-canvas-sw-symbolic";
+	public const string ResizeCanvasUp = "image-resize-canvas-up-symbolic";
 
-		public const string Sampling1 = "tool-colorpicker-sampling-1x1-symbolic";
-		public const string Sampling3 = "tool-colorpicker-sampling-3x3-symbolic";
-		public const string Sampling5 = "tool-colorpicker-sampling-5x5-symbolic";
-		public const string Sampling7 = "tool-colorpicker-sampling-7x7-symbolic";
-		public const string Sampling9 = "tool-colorpicker-sampling-9x9-symbolic";
+	public const string Sampling1 = "tool-colorpicker-sampling-1x1-symbolic";
+	public const string Sampling3 = "tool-colorpicker-sampling-3x3-symbolic";
+	public const string Sampling5 = "tool-colorpicker-sampling-5x5-symbolic";
+	public const string Sampling7 = "tool-colorpicker-sampling-7x7-symbolic";
+	public const string Sampling9 = "tool-colorpicker-sampling-9x9-symbolic";
 
-		public const string ToolCloneStamp = "tool-clonestamp-symbolic";
-		public const string ToolColorPicker = "tool-colorpicker-symbolic";
-		public const string ToolColorPickerPreviousTool = "go-previous-symbolic";
-		public const string ToolEllipse = "tool-ellipse-symbolic";
-		public const string ToolEraser = "tool-eraser-symbolic";
-		public const string ToolFreeformShape = "tool-freeformshape-symbolic";
-		public const string ToolGradient = "tool-gradient-symbolic";
-		public const string ToolLine = "tool-line-symbolic";
-		public const string ToolMove = "tool-move-symbolic";
-		public const string ToolMoveCursor = "tool-move-cursor-symbolic";
-		public const string ToolMoveSelection = "tool-move-selection-symbolic";
-		public const string ToolPaintBrush = "tool-paintbrush-symbolic";
-		public const string ToolPaintBucket = "tool-paintbucket-symbolic";
-		public const string ToolPan = "tool-pan-symbolic";
-		public const string ToolPencil = "tool-pencil-symbolic";
-		public const string ToolRecolor = "tool-recolor-symbolic";
-		public const string ToolRectangle = "tool-rectangle-symbolic";
-		public const string ToolRectangleRounded = "tool-rectangle-rounded-symbolic";
-		public const string ToolSelectEllipse = "tool-select-ellipse-symbolic";
-		public const string ToolSelectLasso = "tool-select-lasso-symbolic";
-		public const string ToolSelectMagicWand = "tool-select-magicwand-symbolic";
-		public const string ToolSelectRectangle = "tool-select-rectangle-symbolic";
-		public const string ToolText = "tool-text-symbolic";
-		public const string ToolZoom = "tool-zoom-symbolic";
+	public const string ToolCloneStamp = "tool-clonestamp-symbolic";
+	public const string ToolColorPicker = "tool-colorpicker-symbolic";
+	public const string ToolColorPickerPreviousTool = "go-previous-symbolic";
+	public const string ToolEllipse = "tool-ellipse-symbolic";
+	public const string ToolEraser = "tool-eraser-symbolic";
+	public const string ToolFreeformShape = "tool-freeformshape-symbolic";
+	public const string ToolGradient = "tool-gradient-symbolic";
+	public const string ToolLine = "tool-line-symbolic";
+	public const string ToolMove = "tool-move-symbolic";
+	public const string ToolMoveCursor = "tool-move-cursor-symbolic";
+	public const string ToolMoveSelection = "tool-move-selection-symbolic";
+	public const string ToolPaintBrush = "tool-paintbrush-symbolic";
+	public const string ToolPaintBucket = "tool-paintbucket-symbolic";
+	public const string ToolPan = "tool-pan-symbolic";
+	public const string ToolPencil = "tool-pencil-symbolic";
+	public const string ToolRecolor = "tool-recolor-symbolic";
+	public const string ToolRectangle = "tool-rectangle-symbolic";
+	public const string ToolRectangleRounded = "tool-rectangle-rounded-symbolic";
+	public const string ToolSelectEllipse = "tool-select-ellipse-symbolic";
+	public const string ToolSelectLasso = "tool-select-lasso-symbolic";
+	public const string ToolSelectMagicWand = "tool-select-magicwand-symbolic";
+	public const string ToolSelectRectangle = "tool-select-rectangle-symbolic";
+	public const string ToolText = "tool-text-symbolic";
+	public const string ToolZoom = "tool-zoom-symbolic";
 
-		public const string ViewGrid = "view-grid";
-		public const string ViewRulers = "view-rulers";
-		public const string ViewZoom100 = "view-zoom-100";
-		public const string ViewZoomSelection = "view-zoom-selection";
-		public const string ViewZoomWindow = "view-zoom-window";
-	}
+	public const string ViewGrid = "view-grid";
+	public const string ViewRulers = "view-rulers";
+	public const string ViewZoom100 = "view-zoom-100";
+	public const string ViewZoomSelection = "view-zoom-selection";
+	public const string ViewZoomWindow = "view-zoom-window";
+}
 
-	/// <summary>
-	/// Standard CSS cursor names (see Gdk.Cursor.new_from_name docs for a complete list).
-	/// </summary>
-	public static class StandardCursors
-	{
-		public const string Default = "default";
-		public const string Grab = "grab";
-		public const string Grabbing = "grabbing";
-		public const string Progress = "progress";
+/// <summary>
+/// Standard CSS cursor names (see Gdk.Cursor.new_from_name docs for a complete list).
+/// </summary>
+public static class StandardCursors
+{
+	public const string Default = "default";
+	public const string Grab = "grab";
+	public const string Grabbing = "grabbing";
+	public const string Progress = "progress";
 
-		public const string ResizeN = "n-resize";
-		public const string ResizeE = "e-resize";
-		public const string ResizeS = "s-resize";
-		public const string ResizeW = "w-resize";
-		public const string ResizeNE = "ne-resize";
-		public const string ResizeNW = "nw-resize";
-		public const string ResizeSE = "se-resize";
-		public const string ResizeSW = "sw-resize";
+	public const string ResizeN = "n-resize";
+	public const string ResizeE = "e-resize";
+	public const string ResizeS = "s-resize";
+	public const string ResizeW = "w-resize";
+	public const string ResizeNE = "ne-resize";
+	public const string ResizeNW = "nw-resize";
+	public const string ResizeSE = "se-resize";
+	public const string ResizeSW = "sw-resize";
 
-		public const string ZoomIn = "zoom-in";
-		public const string ZoomOut = "zoom-out";
-	}
+	public const string ZoomIn = "zoom-in";
+	public const string ZoomOut = "zoom-out";
 }

--- a/Pinta.Resources/ResourceManager.cs
+++ b/Pinta.Resources/ResourceManager.cs
@@ -32,125 +32,124 @@ using System.Runtime.CompilerServices;
 using Gdk;
 using Gtk;
 
-namespace Pinta.Resources
+namespace Pinta.Resources;
+
+public static class ResourceLoader
 {
-	public static class ResourceLoader
+	[MethodImpl (MethodImplOptions.NoInlining)]
+	public static Texture GetIcon (string name, int size)
 	{
-		[MethodImpl (MethodImplOptions.NoInlining)]
-		public static Texture GetIcon (string name, int size)
-		{
-			// First see if it's a built-in gtk icon, like gtk-new.
-			if (TryGetIconFromTheme (name, size, out var theme_result))
-				return theme_result;
+		// First see if it's a built-in gtk icon, like gtk-new.
+		if (TryGetIconFromTheme (name, size, out var theme_result))
+			return theme_result;
 
-			// Otherwise, get it from our embedded resources.
-			if (TryGetIconFromResources (name, out var resource_result))
-				return resource_result;
+		// Otherwise, get it from our embedded resources.
+		if (TryGetIconFromResources (name, out var resource_result))
+			return resource_result;
 
-			// We can't find this image, but we are going to return *some* image rather than null to prevent crashes
-			// Try to return GTK's default "missing image" image
-			if (name != StandardIcons.ImageMissing)
-				return GetIcon (StandardIcons.ImageMissing, size);
+		// We can't find this image, but we are going to return *some* image rather than null to prevent crashes
+		// Try to return GTK's default "missing image" image
+		if (name != StandardIcons.ImageMissing)
+			return GetIcon (StandardIcons.ImageMissing, size);
 
-			// If even the "missing image" is missing, make one on the fly
-			return CreateMissingImage (size);
-		}
+		// If even the "missing image" is missing, make one on the fly
+		return CreateMissingImage (size);
+	}
 
-		private static bool TryGetIconFromTheme (string name, int size, [NotNullWhen (true)] out Gdk.Texture? image)
-		{
-			image = null;
+	private static bool TryGetIconFromTheme (string name, int size, [NotNullWhen (true)] out Gdk.Texture? image)
+	{
+		image = null;
 
-			try {
-				// This will also load any icons added by Gtk.IconFactory.AddDefault() .
-				var icon_theme = Gtk.IconTheme.GetForDisplay (Gdk.Display.GetDefault ()!);
-				var icon_paintable = icon_theme.LookupIcon (name, Array.Empty<string> (), size, 1, TextDirection.None, Gtk.IconLookupFlags.Preload);
-				if (icon_paintable == null || (name != StandardIcons.ImageMissing && icon_paintable.IconName!.StartsWith ("image-missing")))
-					return false;
+		try {
+			// This will also load any icons added by Gtk.IconFactory.AddDefault() .
+			var icon_theme = Gtk.IconTheme.GetForDisplay (Gdk.Display.GetDefault ()!);
+			var icon_paintable = icon_theme.LookupIcon (name, Array.Empty<string> (), size, 1, TextDirection.None, Gtk.IconLookupFlags.Preload);
+			if (icon_paintable == null || (name != StandardIcons.ImageMissing && icon_paintable.IconName!.StartsWith ("image-missing")))
+				return false;
 
-				var snapshot = Gtk.Snapshot.New ();
-				icon_paintable.Snapshot (snapshot, size, size);
+			var snapshot = Gtk.Snapshot.New ();
+			icon_paintable.Snapshot (snapshot, size, size);
 
-				var node = snapshot.ToNode ();
-				if (node != null && node.GetNodeType () == Gsk.RenderNodeType.ColorMatrixNode) {
-					node = new Gsk.RenderNode (Gsk.Internal.ColorMatrixNode.GetChild (node.Handle));
-				}
-
-				if (node == null || node.GetNodeType () != Gsk.RenderNodeType.TextureNode)
-					return false;
-
-				// TODO-GTK4 (bindings, unsubmitted) - the node should be a Gsk.TextureNode instance.
-				image = GObject.Internal.ObjectWrapper.WrapHandle<Gdk.Texture> (Gsk.Internal.TextureNode.GetTexture (node.Handle), false);
-			} catch (Exception ex) {
-				Console.Error.WriteLine (ex.Message);
+			var node = snapshot.ToNode ();
+			if (node != null && node.GetNodeType () == Gsk.RenderNodeType.ColorMatrixNode) {
+				node = new Gsk.RenderNode (Gsk.Internal.ColorMatrixNode.GetChild (node.Handle));
 			}
 
-			return image != null;
+			if (node == null || node.GetNodeType () != Gsk.RenderNodeType.TextureNode)
+				return false;
+
+			// TODO-GTK4 (bindings, unsubmitted) - the node should be a Gsk.TextureNode instance.
+			image = GObject.Internal.ObjectWrapper.WrapHandle<Gdk.Texture> (Gsk.Internal.TextureNode.GetTexture (node.Handle), false);
+		} catch (Exception ex) {
+			Console.Error.WriteLine (ex.Message);
 		}
 
-		private static bool TryGetIconFromResources (string name, [NotNullWhen (true)] out Texture? image)
-		{
-			// Check 'Pinta.Resources' for our image
-			if (TryGetIconFromAssembly (Assembly.GetExecutingAssembly (), name, out image))
+		return image != null;
+	}
+
+	private static bool TryGetIconFromResources (string name, [NotNullWhen (true)] out Texture? image)
+	{
+		// Check 'Pinta.Resources' for our image
+		if (TryGetIconFromAssembly (Assembly.GetExecutingAssembly (), name, out image))
+			return true;
+
+		// Maybe we can find the icon in the resource of a different assembly (e.g. Plugin)
+		foreach (var asm in AppDomain.CurrentDomain.GetAssemblies ())
+			if (TryGetIconFromAssembly (asm, name, out image))
 				return true;
 
-			// Maybe we can find the icon in the resource of a different assembly (e.g. Plugin)
-			foreach (var asm in AppDomain.CurrentDomain.GetAssemblies ())
-				if (TryGetIconFromAssembly (asm, name, out image))
-					return true;
+		return false;
+	}
 
-			return false;
-		}
+	private static bool TryGetIconFromAssembly (Assembly assembly, string name, [NotNullWhen (true)] out Texture? image)
+	{
+		image = null;
 
-		private static bool TryGetIconFromAssembly (Assembly assembly, string name, [NotNullWhen (true)] out Texture? image)
-		{
-			image = null;
+		try {
+			if (HasResource (assembly, name)) {
+				using var stream = assembly.GetManifestResourceStream (name)!;
+				var buffer = new byte[stream.Length];
+				stream.Read (buffer, 0, buffer.Length);
 
-			try {
-				if (HasResource (assembly, name)) {
-					using var stream = assembly.GetManifestResourceStream (name)!;
-					var buffer = new byte[stream.Length];
-					stream.Read (buffer, 0, buffer.Length);
-
-					var bytes = GLib.Bytes.From (buffer);
-					image = Gdk.Texture.NewFromBytes (bytes);
-				}
-			} catch (Exception ex) {
-				Console.Error.WriteLine (ex.Message);
-				image = null;
+				var bytes = GLib.Bytes.From (buffer);
+				image = Gdk.Texture.NewFromBytes (bytes);
 			}
-
-			return image != null;
+		} catch (Exception ex) {
+			Console.Error.WriteLine (ex.Message);
+			image = null;
 		}
 
-		private static bool HasResource (Assembly asm, string name)
-		{
-			return asm.GetManifestResourceNames ().Any (n => n == name);
-		}
+		return image != null;
+	}
 
-		// From MonoDevelop:
-		// https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/gtk-gui/generated.cs
-		private static Texture CreateMissingImage (int size)
-		{
-			var surf = new Cairo.ImageSurface (Cairo.Format.Argb32, size, size);
-			var g = new Cairo.Context (surf);
-			g.SetSourceRgb (1, 1, 1);
-			g.Rectangle (0, 0, size, size);
-			g.Fill ();
+	private static bool HasResource (Assembly asm, string name)
+	{
+		return asm.GetManifestResourceNames ().Any (n => n == name);
+	}
 
-			g.SetSourceRgb (0, 0, 0);
-			g.Rectangle (0, 0, size - 1, size - 1);
-			g.Fill ();
+	// From MonoDevelop:
+	// https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/gtk-gui/generated.cs
+	private static Texture CreateMissingImage (int size)
+	{
+		var surf = new Cairo.ImageSurface (Cairo.Format.Argb32, size, size);
+		var g = new Cairo.Context (surf);
+		g.SetSourceRgb (1, 1, 1);
+		g.Rectangle (0, 0, size, size);
+		g.Fill ();
 
-			g.LineWidth = 3;
-			g.LineCap = Cairo.LineCap.Round;
-			g.LineJoin = Cairo.LineJoin.Round;
-			g.SetSourceRgb (1, 0, 0);
-			g.MoveTo (size / 4, size / 4);
-			g.LineTo ((size - 1) - (size / 4), (size - 1) - (size / 4));
-			g.MoveTo ((size - 1) - (size / 4), size / 4);
-			g.LineTo (size / 4, (size - 1) - (size / 4));
+		g.SetSourceRgb (0, 0, 0);
+		g.Rectangle (0, 0, size - 1, size - 1);
+		g.Fill ();
 
-			return Texture.NewForPixbuf (Gdk.Functions.PixbufGetFromSurface (surf, 0, 0, surf.Width, surf.Height)!);
-		}
+		g.LineWidth = 3;
+		g.LineCap = Cairo.LineCap.Round;
+		g.LineJoin = Cairo.LineJoin.Round;
+		g.SetSourceRgb (1, 0, 0);
+		g.MoveTo (size / 4, size / 4);
+		g.LineTo ((size - 1) - (size / 4), (size - 1) - (size / 4));
+		g.MoveTo ((size - 1) - (size / 4), size / 4);
+		g.LineTo (size / 4, (size - 1) - (size / 4));
+
+		return Texture.NewForPixbuf (Gdk.Functions.PixbufGetFromSurface (surf, 0, 0, surf.Width, surf.Height)!);
 	}
 }


### PR DESCRIPTION
From what I understand in #310, all switches to file-scoped namespaces are fine, so long as they happen in their own commit and the line numbers are not changed (even if an indentation level is decreased)