### PR TITLE
Reduced scope of `List<PointI>` variable being used in `OtherExtensions.CreatePolygonSet`

### DIFF
--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -100,7 +100,6 @@ namespace Pinta.Core
 			var polygons = new List<PointI[]> ();
 
 			PointI start = bounds.Location ().ToInt ();
-			var pts = new List<PointI> ();
 			int count = 0;
 
 			// find all islands
@@ -127,7 +126,7 @@ namespace Pinta.Core
 				if (!startFound)
 					break;
 
-				pts.Clear ();
+				var pts = new List<PointI> ();
 
 				PointI last = new (start.X, start.Y + 1);
 				PointI curr = new (start.X, start.Y);

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -97,9 +97,10 @@ namespace Pinta.Core
 			if (stencil.IsEmpty)
 				return Array.Empty<PointI[]> ();
 
-			var polygons = new List<PointI[]> ();
+			var polygons = new List<IReadOnlyList<PointI>> ();
 
 			PointI start = bounds.Location ().ToInt ();
+			var pts = new List<PointI> ();
 			int count = 0;
 
 			// find all islands
@@ -126,7 +127,7 @@ namespace Pinta.Core
 				if (!startFound)
 					break;
 
-				var pts = new List<PointI> ();
+				pts.Clear ();
 
 				PointI last = new (start.X, start.Y + 1);
 				PointI curr = new (start.X, start.Y);


### PR DESCRIPTION
It was being `Clear`ed`()` in each cycle of the `while` loop, which is one more thing that we were required to keep in mind as we read it.

If no values from the previous iteration will be used, we may as well create a new `List<PointI>` each time and let the previous one be garbage-collected.