### PR TITLE
Sealed some classes that only have `private` or `internal` constructors

### DIFF
--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -29,7 +29,7 @@ using System.Collections.Generic;
 
 namespace Pinta.Core
 {
-	public class DocumentHistory
+	public sealed class DocumentHistory
 	{
 		private readonly Document document;
 		private readonly List<BaseHistoryItem> history = new ();

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -301,7 +301,7 @@ namespace Pinta.Core
 		#endregion
 
 		#region Private Methods
-		protected internal void OnCanvasInvalidated (CanvasInvalidatedEventArgs e)
+		private void OnCanvasInvalidated (CanvasInvalidatedEventArgs e)
 		{
 			if (CanvasInvalidated != null)
 				CanvasInvalidated (this, e);

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace Pinta.Core
 {
-	public class DocumentWorkspace
+	public sealed class DocumentWorkspace
 	{
 		private readonly Document document;
 		private Size view_size;

--- a/Pinta.Core/Classes/SurfaceDiff.cs
+++ b/Pinta.Core/Classes/SurfaceDiff.cs
@@ -33,7 +33,7 @@ using Cairo;
 
 namespace Pinta.Core
 {
-	public class SurfaceDiff
+	public sealed class SurfaceDiff
 	{
 		private struct DiffBounds
 		{

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -400,7 +400,7 @@ namespace Pinta.Core
 			text.SetActivatesDefault (activates);
 		}
 
-		internal class TextWrapper : Gtk.Text
+		internal sealed class TextWrapper : Gtk.Text
 		{
 			internal TextWrapper (IntPtr ptr, bool ownedRef) : base (ptr, ownedRef)
 			{

--- a/Pinta.Core/Managers/EffectsManager.cs
+++ b/Pinta.Core/Managers/EffectsManager.cs
@@ -33,7 +33,7 @@ namespace Pinta.Core
 	/// <summary>
 	/// Provides methods for registering and unregistering effects and adjustments.
 	/// </summary>
-	public class EffectsManager
+	public sealed class EffectsManager
 	{
 		private readonly Dictionary<BaseEffect, Command> adjustments;
 		private readonly Dictionary<BaseEffect, Command> effects;

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -36,7 +36,7 @@ using Debug = System.Diagnostics.Debug;
 namespace Pinta.Core
 {
 
-	public class LivePreviewManager
+	public sealed class LivePreviewManager
 	{
 		// NRT - These are set in Start(). This should be rewritten to be provably non-null.
 		bool live_preview_enabled;
@@ -300,7 +300,7 @@ namespace Pinta.Core
 			renderer.Start (effect, layer.Surface, live_preview_surface, render_bounds);
 		}
 
-		class Renderer : AsyncEffectRenderer
+		private sealed class Renderer : AsyncEffectRenderer
 		{
 			readonly LivePreviewManager manager;
 

--- a/Pinta/AddinSetupService.cs
+++ b/Pinta/AddinSetupService.cs
@@ -30,7 +30,7 @@ using Pinta.Core;
 
 namespace Pinta
 {
-	public class AddinSetupService : SetupService
+	public sealed class AddinSetupService : SetupService
 	{
 		internal AddinSetupService (AddinRegistry r) : base (r)
 		{


### PR DESCRIPTION
It still compiles and there is no way for users of the library to inherit from them even if they are `public`