### PR TITLE
File-scoped namespaces for some pinta actions

### DIFF
--- a/Pinta/Actions/Addins/AddinManagerAction.cs
+++ b/Pinta/Actions/Addins/AddinManagerAction.cs
@@ -28,27 +28,26 @@ using System;
 using Pinta.Core;
 using Pinta.Gui.Addins;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class AddinManagerAction : IActionHandler
 {
-	class AddinManagerAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.Addins.AddinManager.Activated += Activated;
-		}
+		PintaCore.Actions.Addins.AddinManager.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.Addins.AddinManager.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.Addins.AddinManager.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			var service = new AddinSetupService (Mono.Addins.AddinManager.Registry);
-			var dialog = new AddinManagerDialog (PintaCore.Chrome.MainWindow, service);
-			dialog.Show ();
-		}
+	private void Activated (object sender, EventArgs e)
+	{
+		var service = new AddinSetupService (Mono.Addins.AddinManager.Registry);
+		var dialog = new AddinManagerDialog (PintaCore.Chrome.MainWindow, service);
+		dialog.Show ();
 	}
 }

--- a/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
@@ -27,23 +27,22 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class PasteIntoNewImageAction : IActionHandler
 {
-	class PasteIntoNewImageAction : IActionHandler
+	public void Initialize () => PintaCore.Actions.Edit.PasteIntoNewImage.Activated += Activated;
+
+	public void Uninitialize () => PintaCore.Actions.Edit.PasteIntoNewImage.Activated -= Activated;
+
+	private async void Activated (object sender, EventArgs e)
 	{
-		public void Initialize () => PintaCore.Actions.Edit.PasteIntoNewImage.Activated += Activated;
+		var cb = GdkExtensions.GetDefaultClipboard ();
+		Gdk.Texture? cb_texture = await cb.ReadTextureAsync ();
 
-		public void Uninitialize () => PintaCore.Actions.Edit.PasteIntoNewImage.Activated -= Activated;
-
-		private async void Activated (object sender, EventArgs e)
-		{
-			var cb = GdkExtensions.GetDefaultClipboard ();
-			Gdk.Texture? cb_texture = await cb.ReadTextureAsync ();
-
-			if (cb_texture is not null)
-				PintaCore.Workspace.NewDocumentFromImage (cb_texture.ToSurface ());
-			else
-				PasteAction.ShowClipboardEmptyDialog ();
-		}
+		if (cb_texture is not null)
+			PintaCore.Workspace.NewDocumentFromImage (cb_texture.ToSurface ());
+		else
+			PasteAction.ShowClipboardEmptyDialog ();
 	}
 }

--- a/Pinta/Actions/Edit/PasteIntoNewLayerAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewLayerAction.cs
@@ -28,36 +28,35 @@ using System;
 using Gtk;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class PasteIntoNewLayerAction : IActionHandler
 {
-	class PasteIntoNewLayerAction : IActionHandler
+	public void Initialize () => PintaCore.Actions.Edit.PasteIntoNewLayer.Activated += Activated;
+
+	public void Uninitialize () => PintaCore.Actions.Edit.PasteIntoNewLayer.Activated -= Activated;
+
+	private void Activated (object sender, EventArgs e)
 	{
-		public void Initialize () => PintaCore.Actions.Edit.PasteIntoNewLayer.Activated += Activated;
-
-		public void Uninitialize () => PintaCore.Actions.Edit.PasteIntoNewLayer.Activated -= Activated;
-
-		private void Activated (object sender, EventArgs e)
-		{
-			// If no documents are open, activate the
-			// PasteIntoNewImage action and abort this Paste action.
-			if (!PintaCore.Workspace.HasOpenDocuments) {
-				PintaCore.Actions.Edit.PasteIntoNewImage.Activate ();
-				return;
-			}
-
-			var doc = PintaCore.Workspace.ActiveDocument;
-
-			// Get the scroll position in canvas coordinates
-			var view = (Viewport) doc.Workspace.Canvas.Parent!;
-
-			var canvasPos = doc.Workspace.ViewPointToCanvas (
-				view.Hadjustment!.Value,
-				view.Vadjustment!.Value);
-
-			// Paste into the active document.
-			// The 'true' argument indicates that paste should be
-			// performed into a new layer.
-			PasteAction.Paste (doc, true, (int) canvasPos.X, (int) canvasPos.Y);
+		// If no documents are open, activate the
+		// PasteIntoNewImage action and abort this Paste action.
+		if (!PintaCore.Workspace.HasOpenDocuments) {
+			PintaCore.Actions.Edit.PasteIntoNewImage.Activate ();
+			return;
 		}
+
+		var doc = PintaCore.Workspace.ActiveDocument;
+
+		// Get the scroll position in canvas coordinates
+		var view = (Viewport) doc.Workspace.Canvas.Parent!;
+
+		var canvasPos = doc.Workspace.ViewPointToCanvas (
+			view.Hadjustment!.Value,
+			view.Vadjustment!.Value);
+
+		// Paste into the active document.
+		// The 'true' argument indicates that paste should be
+		// performed into a new layer.
+		PasteAction.Paste (doc, true, (int) canvasPos.X, (int) canvasPos.Y);
 	}
 }

--- a/Pinta/Actions/Edit/ResizePaletteAction.cs
+++ b/Pinta/Actions/Edit/ResizePaletteAction.cs
@@ -28,36 +28,35 @@ using System;
 using Gtk;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ResizePaletteAction : IActionHandler
 {
-	class ResizePaletteAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.Edit.ResizePalette.Activated += Activated;
-		}
+		PintaCore.Actions.Edit.ResizePalette.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.Edit.ResizePalette.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.Edit.ResizePalette.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			var dialog = new SpinButtonEntryDialog (Translations.GetString ("Resize Palette"),
-					PintaCore.Chrome.MainWindow, Translations.GetString ("New palette size:"), 1, 96,
-					PintaCore.Palette.CurrentPalette.Count);
+	private void Activated (object sender, EventArgs e)
+	{
+		var dialog = new SpinButtonEntryDialog (Translations.GetString ("Resize Palette"),
+				PintaCore.Chrome.MainWindow, Translations.GetString ("New palette size:"), 1, 96,
+				PintaCore.Palette.CurrentPalette.Count);
 
-			dialog.OnResponse += (_, args) => {
-				if (args.ResponseId == (int) ResponseType.Ok)
-					PintaCore.Palette.CurrentPalette.Resize (dialog.GetValue ());
+		dialog.OnResponse += (_, args) => {
+			if (args.ResponseId == (int) ResponseType.Ok)
+				PintaCore.Palette.CurrentPalette.Resize (dialog.GetValue ());
 
-				dialog.Destroy ();
-			};
+			dialog.Destroy ();
+		};
 
-			dialog.Present ();
-		}
+		dialog.Present ();
 	}
 }

--- a/Pinta/Actions/File/ExitAction.cs
+++ b/Pinta/Actions/File/ExitAction.cs
@@ -27,39 +27,38 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ExitProgramAction : IActionHandler
 {
-	class ExitProgramAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.App.Exit.Activated += Activated;
+		PintaCore.Actions.App.Exit.Activated += Activated;
+	}
+
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.App.Exit.Activated -= Activated;
+	}
+	#endregion
+
+	private void Activated (object sender, EventArgs e)
+	{
+		while (PintaCore.Workspace.HasOpenDocuments) {
+			int count = PintaCore.Workspace.OpenDocuments.Count;
+
+			PintaCore.Actions.File.Close.Activate ();
+
+			// If we still have the same number of open documents,
+			// the user cancelled on a Save prompt.
+			if (count == PintaCore.Workspace.OpenDocuments.Count)
+				return;
 		}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.App.Exit.Activated -= Activated;
-		}
-		#endregion
+		// Let everyone know we are quitting
+		PintaCore.Actions.App.RaiseBeforeQuit ();
 
-		private void Activated (object sender, EventArgs e)
-		{
-			while (PintaCore.Workspace.HasOpenDocuments) {
-				int count = PintaCore.Workspace.OpenDocuments.Count;
-
-				PintaCore.Actions.File.Close.Activate ();
-
-				// If we still have the same number of open documents,
-				// the user cancelled on a Save prompt.
-				if (count == PintaCore.Workspace.OpenDocuments.Count)
-					return;
-			}
-
-			// Let everyone know we are quitting
-			PintaCore.Actions.App.RaiseBeforeQuit ();
-
-			PintaCore.Chrome.Application.Quit ();
-		}
+		PintaCore.Chrome.Application.Quit ();
 	}
 }

--- a/Pinta/Actions/File/ModifyCompressionAction.cs
+++ b/Pinta/Actions/File/ModifyCompressionAction.cs
@@ -26,31 +26,30 @@
 
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ModifyCompressionAction : IActionHandler
 {
-	class ModifyCompressionAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.File.ModifyCompression += Activated;
-		}
+		PintaCore.Actions.File.ModifyCompression += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.File.ModifyCompression -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.File.ModifyCompression -= Activated;
+	}
+	#endregion
 
-		private void Activated (object? sender, ModifyCompressionEventArgs e)
-		{
-			var dlg = new JpegCompressionDialog (e.Quality, e.ParentWindow);
-			if (dlg.RunBlocking () == Gtk.ResponseType.Ok)
-				e.Quality = dlg.GetCompressionLevel ();
-			else
-				e.Cancel = true;
+	private void Activated (object? sender, ModifyCompressionEventArgs e)
+	{
+		var dlg = new JpegCompressionDialog (e.Quality, e.ParentWindow);
+		if (dlg.RunBlocking () == Gtk.ResponseType.Ok)
+			e.Quality = dlg.GetCompressionLevel ();
+		else
+			e.Cancel = true;
 
-			dlg.Destroy ();
-		}
+		dlg.Destroy ();
 	}
 }

--- a/Pinta/Actions/File/SaveDocumentAction.cs
+++ b/Pinta/Actions/File/SaveDocumentAction.cs
@@ -27,25 +27,24 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class SaveDocumentAction : IActionHandler
 {
-	class SaveDocumentAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.File.Save.Activated += Activated;
-		}
+		PintaCore.Actions.File.Save.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.File.Save.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.File.Save.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			PintaCore.Workspace.ActiveDocument.Save (false);
-		}
+	private void Activated (object sender, EventArgs e)
+	{
+		PintaCore.Workspace.ActiveDocument.Save (false);
 	}
 }

--- a/Pinta/Actions/File/SaveDocumentAsAction.cs
+++ b/Pinta/Actions/File/SaveDocumentAsAction.cs
@@ -27,25 +27,24 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class SaveDocumentAsAction : IActionHandler
 {
-	class SaveDocumentAsAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.File.SaveAs.Activated += Activated;
-		}
+		PintaCore.Actions.File.SaveAs.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.File.SaveAs.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.File.SaveAs.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			PintaCore.Workspace.ActiveDocument.Save (true);
-		}
+	private void Activated (object sender, EventArgs e)
+	{
+		PintaCore.Workspace.ActiveDocument.Save (true);
 	}
 }

--- a/Pinta/Actions/Image/ResizeCanvasAction.cs
+++ b/Pinta/Actions/Image/ResizeCanvasAction.cs
@@ -27,34 +27,33 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ResizeCanvasAction : IActionHandler
 {
-	class ResizeCanvasAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.Image.CanvasSize.Activated += Activated;
-		}
+		PintaCore.Actions.Image.CanvasSize.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.Image.CanvasSize.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.Image.CanvasSize.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			var dialog = new ResizeCanvasDialog ();
+	private void Activated (object sender, EventArgs e)
+	{
+		var dialog = new ResizeCanvasDialog ();
 
-			dialog.OnResponse += (_, args) => {
-				if (args.ResponseId == (int) Gtk.ResponseType.Ok)
-					dialog.SaveChanges ();
+		dialog.OnResponse += (_, args) => {
+			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
+				dialog.SaveChanges ();
 
-				dialog.Destroy ();
-			};
+			dialog.Destroy ();
+		};
 
-			dialog.Show ();
-		}
+		dialog.Show ();
 	}
 }

--- a/Pinta/Actions/Image/ResizeImageAction.cs
+++ b/Pinta/Actions/Image/ResizeImageAction.cs
@@ -27,34 +27,33 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ResizeImageAction : IActionHandler
 {
-	class ResizeImageAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.Image.Resize.Activated += Activated;
-		}
+		PintaCore.Actions.Image.Resize.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.Image.Resize.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.Image.Resize.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			var dialog = new ResizeImageDialog ();
+	private void Activated (object sender, EventArgs e)
+	{
+		var dialog = new ResizeImageDialog ();
 
-			dialog.OnResponse += (_, args) => {
-				if (args.ResponseId == (int) Gtk.ResponseType.Ok)
-					dialog.SaveChanges ();
+		dialog.OnResponse += (_, args) => {
+			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
+				dialog.SaveChanges ();
 
-				dialog.Destroy ();
-			};
+			dialog.Destroy ();
+		};
 
-			dialog.Show ();
-		}
+		dialog.Show ();
 	}
 }

--- a/Pinta/Actions/View/ImageTabsToggledAction.cs
+++ b/Pinta/Actions/View/ImageTabsToggledAction.cs
@@ -26,26 +26,25 @@
 
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ImageTabsToggledAction : IActionHandler
 {
-	class ImageTabsToggledAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.View.ImageTabs.Toggled += Activated;
-		}
+		PintaCore.Actions.View.ImageTabs.Toggled += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.View.ImageTabs.Toggled -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.View.ImageTabs.Toggled -= Activated;
+	}
+	#endregion
 
-		private void Activated (bool value)
-		{
-			var notebook = (Docking.DockNotebook) PintaCore.Chrome.ImageTabsNotebook;
-			notebook.EnableTabs = value;
-		}
+	private void Activated (bool value)
+	{
+		var notebook = (Docking.DockNotebook) PintaCore.Chrome.ImageTabsNotebook;
+		notebook.EnableTabs = value;
 	}
 }

--- a/Pinta/Actions/View/StatusBarToggledAction.cs
+++ b/Pinta/Actions/View/StatusBarToggledAction.cs
@@ -26,25 +26,24 @@
 
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class StatusBarToggledAction : IActionHandler
 {
-	class StatusBarToggledAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.View.StatusBar.Toggled += Activated;
-		}
+		PintaCore.Actions.View.StatusBar.Toggled += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.View.StatusBar.Toggled -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.View.StatusBar.Toggled -= Activated;
+	}
+	#endregion
 
-		private void Activated (bool value)
-		{
-			PintaCore.Chrome.StatusBar.Visible = value;
-		}
+	private void Activated (bool value)
+	{
+		PintaCore.Chrome.StatusBar.Visible = value;
 	}
 }

--- a/Pinta/Actions/View/ToolBarToggledAction.cs
+++ b/Pinta/Actions/View/ToolBarToggledAction.cs
@@ -26,25 +26,24 @@
 
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ToolBarToggledAction : IActionHandler
 {
-	class ToolBarToggledAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.View.ToolBar.Toggled += Activated;
-		}
+		PintaCore.Actions.View.ToolBar.Toggled += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.View.ToolBar.Toggled -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.View.ToolBar.Toggled -= Activated;
+	}
+	#endregion
 
-		private void Activated (bool value)
-		{
-			PintaCore.Chrome.MainToolBar.Visible = value;
-		}
+	private void Activated (bool value)
+	{
+		PintaCore.Chrome.MainToolBar.Visible = value;
 	}
 }

--- a/Pinta/Actions/View/ToolBoxToggledAction.cs
+++ b/Pinta/Actions/View/ToolBoxToggledAction.cs
@@ -26,25 +26,24 @@
 
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class ToolBoxToggledAction : IActionHandler
 {
-	class ToolBoxToggledAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.View.ToolBox.Toggled += Activated;
-		}
+		PintaCore.Actions.View.ToolBox.Toggled += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.View.ToolBox.Toggled -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.View.ToolBox.Toggled -= Activated;
+	}
+	#endregion
 
-		private void Activated (bool value)
-		{
-			PintaCore.Chrome.ToolBox.Visible = value;
-		}
+	private void Activated (bool value)
+	{
+		PintaCore.Chrome.ToolBox.Visible = value;
 	}
 }

--- a/Pinta/Actions/Window/CloseAllDocumentsAction.cs
+++ b/Pinta/Actions/Window/CloseAllDocumentsAction.cs
@@ -27,34 +27,33 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class CloseAllDocumentsAction : IActionHandler
 {
-	class CloseAllDocumentsAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.Window.CloseAll.Activated += Activated;
-		}
+		PintaCore.Actions.Window.CloseAll.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.Window.CloseAll.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.Window.CloseAll.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			while (PintaCore.Workspace.HasOpenDocuments) {
-				int count = PintaCore.Workspace.OpenDocuments.Count;
+	private void Activated (object sender, EventArgs e)
+	{
+		while (PintaCore.Workspace.HasOpenDocuments) {
+			int count = PintaCore.Workspace.OpenDocuments.Count;
 
-				PintaCore.Actions.File.Close.Activate ();
+			PintaCore.Actions.File.Close.Activate ();
 
-				// If we still have the same number of open documents,
-				// the user cancelled on a Save prompt.
-				if (count == PintaCore.Workspace.OpenDocuments.Count)
-					return;
-			}
+			// If we still have the same number of open documents,
+			// the user cancelled on a Save prompt.
+			if (count == PintaCore.Workspace.OpenDocuments.Count)
+				return;
 		}
 	}
 }

--- a/Pinta/Actions/Window/SaveAllDocumentsAction.cs
+++ b/Pinta/Actions/Window/SaveAllDocumentsAction.cs
@@ -27,34 +27,33 @@
 using System;
 using Pinta.Core;
 
-namespace Pinta.Actions
+namespace Pinta.Actions;
+
+internal sealed class SaveAllDocumentsAction : IActionHandler
 {
-	class SaveAllDocumentsAction : IActionHandler
+	#region IActionHandler Members
+	public void Initialize ()
 	{
-		#region IActionHandler Members
-		public void Initialize ()
-		{
-			PintaCore.Actions.Window.SaveAll.Activated += Activated;
-		}
+		PintaCore.Actions.Window.SaveAll.Activated += Activated;
+	}
 
-		public void Uninitialize ()
-		{
-			PintaCore.Actions.Window.SaveAll.Activated -= Activated;
-		}
-		#endregion
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.Window.SaveAll.Activated -= Activated;
+	}
+	#endregion
 
-		private void Activated (object sender, EventArgs e)
-		{
-			foreach (Document doc in PintaCore.Workspace.OpenDocuments) {
-				if (!doc.IsDirty && doc.HasFile)
-					continue;
+	private void Activated (object sender, EventArgs e)
+	{
+		foreach (Document doc in PintaCore.Workspace.OpenDocuments) {
+			if (!doc.IsDirty && doc.HasFile)
+				continue;
 
-				PintaCore.Workspace.SetActiveDocument (doc);
+			PintaCore.Workspace.SetActiveDocument (doc);
 
-				// Loop through all of these until we get a cancel
-				if (!doc.Save (false))
-					break;
-			}
+			// Loop through all of these until we get a cancel
+			if (!doc.Save (false))
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Not for all of them, just for the short files with more or less obvious implementations.

In order to apply this I would need to know if all switches to file-scoped namespaces are fine, so long as they happen in their own commit and the line numbers are not changed (even if an indentation level is decreased). I would like to know if I understood correctly what was discussed in #310 