### PR TITLE
Introduced local variable to help make statement shorter

### DIFF
--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -29,7 +29,7 @@ using Pinta.Core;
 
 namespace Pinta.Tools
 {
-	public class MoveSelectedTool : BaseTransformTool
+	public sealed class MoveSelectedTool : BaseTransformTool
 	{
 		private MovePixelsHistoryItem? hist;
 		private DocumentSelection? original_selection;
@@ -64,8 +64,8 @@ namespace Pinta.Tools
 
 			// If there is no selection, select the whole image.
 			if (document.Selection.SelectionPolygons.Count == 0) {
-				document.Selection.CreateRectangleSelection (
-					new RectangleD (0, 0, document.ImageSize.Width, document.ImageSize.Height));
+				RectangleD imageBounds = new (0, 0, document.ImageSize.Width, document.ImageSize.Height);
+				document.Selection.CreateRectangleSelection (imageBounds);
 			}
 
 			original_selection = document.Selection.Clone ();


### PR DESCRIPTION
⚠️➡️ I actually opened this to briefly discuss a behavior of the move tool.

When using the application, a history item is created by merely _clicking_ on the canvas when the move tool is selected, even if the cursor did not move.

My question would be if this behavior is intended or if it's accidental (there was no time to get it right).

I would like to change it so that the history item is only created if the cursor actually moved.