### PR TITLE
Default colors were moved to a generator in `Palette`

### DIFF
--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -87,59 +87,64 @@ public sealed class Palette
 	{
 		colors.Clear ();
 
-		colors.Add (new Color (255 / 255f, 255 / 255f, 255 / 255f));
-		colors.Add (new Color (0 / 255f, 0 / 255f, 0 / 255f));
-
-		colors.Add (new Color (160 / 255f, 160 / 255f, 160 / 255f));
-		colors.Add (new Color (128 / 255f, 128 / 255f, 128 / 255f));
-
-		colors.Add (new Color (64 / 255f, 64 / 255f, 64 / 255f));
-		colors.Add (new Color (48 / 255f, 48 / 255f, 48 / 255f));
-
-		colors.Add (new Color (255 / 255f, 0 / 255f, 0 / 255f));
-		colors.Add (new Color (255 / 255f, 127 / 255f, 127 / 255f));
-
-		colors.Add (new Color (255 / 255f, 106 / 255f, 0 / 255f));
-		colors.Add (new Color (255 / 255f, 178 / 255f, 127 / 255f));
-
-		colors.Add (new Color (255 / 255f, 216 / 255f, 0 / 255f));
-		colors.Add (new Color (255 / 255f, 233 / 255f, 127 / 255f));
-
-		colors.Add (new Color (182 / 255f, 255 / 255f, 0 / 255f));
-		colors.Add (new Color (218 / 255f, 255 / 255f, 127 / 255f));
-
-		colors.Add (new Color (76 / 255f, 255 / 255f, 0 / 255f));
-		colors.Add (new Color (165 / 255f, 255 / 255f, 127 / 255f));
-
-		colors.Add (new Color (0 / 255f, 255 / 255f, 33 / 255f));
-		colors.Add (new Color (127 / 255f, 255 / 255f, 142 / 255f));
-
-		colors.Add (new Color (0 / 255f, 255 / 255f, 144 / 255f));
-		colors.Add (new Color (127 / 255f, 255 / 255f, 197 / 255f));
-
-		colors.Add (new Color (0 / 255f, 255 / 255f, 255 / 255f));
-		colors.Add (new Color (127 / 255f, 255 / 255f, 255 / 255f));
-
-		colors.Add (new Color (0 / 255f, 148 / 255f, 255 / 255f));
-		colors.Add (new Color (127 / 255f, 201 / 255f, 255 / 255f));
-
-		colors.Add (new Color (0 / 255f, 38 / 255f, 255 / 255f));
-		colors.Add (new Color (127 / 255f, 146 / 255f, 255 / 255f));
-
-		colors.Add (new Color (72 / 255f, 0 / 255f, 255 / 255f));
-		colors.Add (new Color (161 / 255f, 127 / 255f, 255 / 255f));
-
-		colors.Add (new Color (178 / 255f, 0 / 255f, 255 / 255f));
-		colors.Add (new Color (214 / 255f, 127 / 255f, 255 / 255f));
-
-		colors.Add (new Color (255 / 255f, 0 / 255f, 220 / 255f));
-		colors.Add (new Color (255 / 255f, 127 / 255f, 237 / 255f));
-
-		colors.Add (new Color (255 / 255f, 0 / 255f, 110 / 255f));
-		colors.Add (new Color (255 / 255f, 127 / 255f, 182 / 255f));
+		colors.AddRange (EnumerateDefaultColors ());
 
 		colors.TrimExcess ();
 		OnPaletteChanged ();
+	}
+
+	private static IEnumerable<Color> EnumerateDefaultColors ()
+	{
+		yield return new Color (255 / 255f, 255 / 255f, 255 / 255f);
+		yield return new Color (0 / 255f, 0 / 255f, 0 / 255f);
+
+		yield return new Color (160 / 255f, 160 / 255f, 160 / 255f);
+		yield return new Color (128 / 255f, 128 / 255f, 128 / 255f);
+
+		yield return new Color (64 / 255f, 64 / 255f, 64 / 255f);
+		yield return new Color (48 / 255f, 48 / 255f, 48 / 255f);
+
+		yield return new Color (255 / 255f, 0 / 255f, 0 / 255f);
+		yield return new Color (255 / 255f, 127 / 255f, 127 / 255f);
+
+		yield return new Color (255 / 255f, 106 / 255f, 0 / 255f);
+		yield return new Color (255 / 255f, 178 / 255f, 127 / 255f);
+
+		yield return new Color (255 / 255f, 216 / 255f, 0 / 255f);
+		yield return new Color (255 / 255f, 233 / 255f, 127 / 255f);
+
+		yield return new Color (182 / 255f, 255 / 255f, 0 / 255f);
+		yield return new Color (218 / 255f, 255 / 255f, 127 / 255f);
+
+		yield return new Color (76 / 255f, 255 / 255f, 0 / 255f);
+		yield return new Color (165 / 255f, 255 / 255f, 127 / 255f);
+
+		yield return new Color (0 / 255f, 255 / 255f, 33 / 255f);
+		yield return new Color (127 / 255f, 255 / 255f, 142 / 255f);
+
+		yield return new Color (0 / 255f, 255 / 255f, 144 / 255f);
+		yield return new Color (127 / 255f, 255 / 255f, 197 / 255f);
+
+		yield return new Color (0 / 255f, 255 / 255f, 255 / 255f);
+		yield return new Color (127 / 255f, 255 / 255f, 255 / 255f);
+
+		yield return new Color (0 / 255f, 148 / 255f, 255 / 255f);
+		yield return new Color (127 / 255f, 201 / 255f, 255 / 255f);
+
+		yield return new Color (0 / 255f, 38 / 255f, 255 / 255f);
+		yield return new Color (127 / 255f, 146 / 255f, 255 / 255f);
+
+		yield return new Color (72 / 255f, 0 / 255f, 255 / 255f);
+		yield return new Color (161 / 255f, 127 / 255f, 255 / 255f);
+
+		yield return new Color (178 / 255f, 0 / 255f, 255 / 255f);
+		yield return new Color (214 / 255f, 127 / 255f, 255 / 255f);
+
+		yield return new Color (255 / 255f, 0 / 255f, 220 / 255f);
+		yield return new Color (255 / 255f, 127 / 255f, 237 / 255f);
+
+		yield return new Color (255 / 255f, 0 / 255f, 110 / 255f);
+		yield return new Color (255 / 255f, 127 / 255f, 182 / 255f);
 	}
 
 	public void Load (Gio.File file)


### PR DESCRIPTION
This is in order to make `LoadDefault` clearer, and to prepare the code for more changes to come