### PR TITLE
`Options.AddSeparators` was converted to a generator `GenerateSeparators`

### DIFF
--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -222,6 +222,16 @@ public class OptionValueCollection : IList, IList<string>
 	}
 	#endregion
 
+	public List<string> ToList ()
+	{
+		return new List<string> (values);
+	}
+
+	public string[] ToArray ()
+	{
+		return values.ToArray ();
+	}
+
 	public override string ToString ()
 	{
 		return string.Join (", ", values.ToArray ());

--- a/Pinta/Options.cs
+++ b/Pinta/Options.cs
@@ -130,10 +130,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -224,16 +222,6 @@ public class OptionValueCollection : IList, IList<string>
 	}
 	#endregion
 
-	public List<string> ToList ()
-	{
-		return new List<string> (values);
-	}
-
-	public string[] ToArray ()
-	{
-		return values.ToArray ();
-	}
-
 	public override string ToString ()
 	{
 		return string.Join (", ", values.ToArray ());
@@ -297,7 +285,7 @@ public abstract class Option
 	protected Option (string prototype, string description, int maxValueCount)
 	{
 		if (prototype.Length == 0)
-			throw new ArgumentException ("Cannot be the empty string.", nameof (prototype));
+			throw new ArgumentException ("String cannot be empty.", nameof (prototype));
 		if (maxValueCount < 0)
 			throw new ArgumentOutOfRangeException (nameof (maxValueCount));
 
@@ -387,7 +375,8 @@ public abstract class Option
 				throw new ArgumentException (
 						$"Conflicting option types: '{type}' vs. '{name[end]}'.",
 						nameof (prototype));
-			AddSeparators (name, end, seps);
+
+			seps.AddRange (GenerateSeparators (name, end));
 		}
 
 		if (type == '\0')
@@ -409,7 +398,7 @@ public abstract class Option
 		return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
 	}
 
-	private static void AddSeparators (string name, int end, ICollection<string> seps)
+	private static IEnumerable<string> GenerateSeparators (string name, int end)
 	{
 		int start = -1;
 		for (int i = end + 1; i < name.Length; ++i) {
@@ -426,12 +415,12 @@ public abstract class Option
 						throw new ArgumentException (
 								$"Ill-formed name/value separator found in \"{name}\".",
 								nameof (prototype));
-					seps.Add (name[start..i]);
+					yield return name[start..i];
 					start = -1;
 					break;
 				default:
 					if (start == -1)
-						seps.Add (name[i].ToString ());
+						yield return name[i].ToString ();
 					break;
 			}
 		}


### PR DESCRIPTION
Also, unused namespace references were removed.

I have to ask about the conditional compilation directives that go like `#if LINQ`. I guess that's a relic from more than a decade ago. I thought about just removing everything related to it (along with methods like `ToList()` and `ToArray()` in `OptionValueCollection`, but _perhaps_ it's there for a reason, so I should get confirmation before doing that.