### PR TITLE
Removed commented-out code from `ScaleFactor`

### DIFF
--- a/Pinta.Core/Classes/ScaleFactor.cs
+++ b/Pinta.Core/Classes/ScaleFactor.cs
@@ -124,20 +124,6 @@ public struct ScaleFactor
 		return numerator.GetHashCode () ^ denominator.GetHashCode ();
 	}
 
-	//private static string percentageFormat = PdnResources.GetString("ScaleFactor.Percentage.Format");
-	//public override string ToString()
-	//{
-	//    try
-	//    {
-	//        return string.Format(percentageFormat, unchecked(Math.Round(unchecked(100 * Ratio))));
-	//    }
-
-	//    catch (ArithmeticException)
-	//    {
-	//        return "--";
-	//    }
-	//}
-
 	public readonly int ScaleScalar (int x)
 	{
 		return (int) (((long) x * numerator) / denominator);
@@ -228,16 +214,6 @@ public struct ScaleFactor
 		return new PointI (p.X, UnscaleScalar (p.Y));
 	}
 
-	//public SizeF ScaleSize(C s)
-	//{
-	//    return new SizeF(ScaleScalar(s.Width), ScaleScalar(s.Height));
-	//}
-
-	//public SizeF UnscaleSize(SizeF s)
-	//{
-	//    return new SizeF(UnscaleScalar(s.Width), UnscaleScalar(s.Height));
-	//}
-
 	public readonly Size ScaleSize (Size s)
 	{
 		return new Size (ScaleScalar (s.Width), ScaleScalar (s.Height));
@@ -247,16 +223,6 @@ public struct ScaleFactor
 	{
 		return new Size (UnscaleScalar (s.Width), UnscaleScalar (s.Height));
 	}
-
-	//public RectangleF ScaleRectangle(RectangleF rectF)
-	//{
-	//    return new RectangleF(ScalePoint(rectF.Location), ScaleSize(rectF.Size));
-	//}
-
-	//public RectangleF UnscaleRectangle(RectangleF rectF)
-	//{
-	//    return new RectangleF(UnscalePoint(rectF.Location), UnscaleSize(rectF.Size));
-	//}
 
 	public readonly RectangleI ScaleRectangle (RectangleI rect)
 	{
@@ -269,10 +235,10 @@ public struct ScaleFactor
 	}
 
 	private static readonly double[] scales =
-    {
-	0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.08, 0.12, 0.16, 0.25, 0.33, 0.50, 0.66, 1,
-	2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32
-    };
+	{
+		0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.08, 0.12, 0.16, 0.25, 0.33, 0.50, 0.66, 1,
+		2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32
+	};
 
 	/// <summary>
 	/// Gets a list of values that GetNextLarger() and GetNextSmaller() will cycle through.


### PR DESCRIPTION
Also, I noticed there are many methods with 0 references. Maybe I should remove them too?