### PR TITLE
Array used for temporary calculations in `HistogramWidget.DrawChannel` is now allocated on the stack

### DIFF
--- a/Pinta.Core/Classes/SurfaceDiff.cs
+++ b/Pinta.Core/Classes/SurfaceDiff.cs
@@ -50,12 +50,21 @@ public sealed class SurfaceDiff
 			bottom = -1;
 		}
 
-		public void Merge (DiffBounds other)
+		private DiffBounds (int newLeft, int newRight, int newTop, int newBottom)
 		{
-			this.left = System.Math.Min (this.left, other.left);
-			this.right = System.Math.Max (this.right, other.right);
-			this.top = System.Math.Min (this.top, other.top);
-			this.bottom = System.Math.Max (this.bottom, other.bottom);
+			left = newLeft;
+			right = newRight;
+			top = newTop;
+			bottom = newBottom;
+		}
+
+		public readonly DiffBounds AsMerged (DiffBounds other)
+		{
+			var newLeft = Math.Min (left, other.left);
+			var newRight = Math.Max (right, other.right);
+			var newTop = Math.Min (top, other.top);
+			var newBottom = Math.Max (bottom, other.bottom);
+			return new (newLeft, newRight, newTop, newBottom);
 		}
 	}
 
@@ -98,7 +107,7 @@ public sealed class SurfaceDiff
 
 		// STEP 1 - Find the bounds of the changed pixels.
 		DiffBounds diff_bounds = new DiffBounds (orig_width, orig_height);
-		object diff_bounds_lock = new Object ();
+		object diff_bounds_lock = new ();
 
 		// Split up the work among several threads, each of which processes one row at a time
 		// and updates the bounds of the changed pixels it has seen so far. At the end, the
@@ -129,7 +138,7 @@ public sealed class SurfaceDiff
 
 			     }, (my_bounds) => {
 				     lock (diff_bounds_lock) {
-					     diff_bounds.Merge (my_bounds);
+					     diff_bounds = diff_bounds.AsMerged (my_bounds);
 				     }
 				     return;
 			     });

--- a/Pinta.Core/Effects/ColorDifferenceEffect.cs
+++ b/Pinta.Core/Effects/ColorDifferenceEffect.cs
@@ -5,6 +5,7 @@
 // See license-pdn.txt for full licensing and attribution details.             //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 
 namespace Pinta.Core;
@@ -20,7 +21,7 @@ namespace Pinta.Core;
 /// </summary>
 public abstract class ColorDifferenceEffect : BaseEffect
 {
-	public void RenderColorDifferenceEffect (double[][] weights, ImageSurface src, ImageSurface dest, RectangleI[] rois)
+	public void RenderColorDifferenceEffect (double[][] weights, ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		RectangleI src_rect = src.GetBounds ();
 

--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -101,7 +101,7 @@ public abstract class GradientRenderer
 		endAlpha = (byte) (255 - endColor.A);
 	}
 
-	public void Render (ImageSurface surface, RectangleI[] rois)
+	public void Render (ImageSurface surface, ReadOnlySpan<RectangleI> rois)
 	{
 		byte startAlpha;
 		byte endAlpha;

--- a/Pinta.Core/Effects/HistogramRGB.cs
+++ b/Pinta.Core/Effects/HistogramRGB.cs
@@ -43,9 +43,9 @@ public sealed class HistogramRgb
 
 	protected override void AddSurfaceRectangleToHistogram (ImageSurface surface, RectangleI rect)
 	{
-		long[] histogramB = histogram[0];
-		long[] histogramG = histogram[1];
-		long[] histogramR = histogram[2];
+		var histogramB = histogram[0];
+		var histogramG = histogram[1];
+		var histogramR = histogram[2];
 
 		var data = surface.GetReadOnlyPixelData ();
 		int rect_right = rect.Right;
@@ -70,8 +70,8 @@ public sealed class HistogramRgb
 
 		Clear ();
 
-		float[] before = new float[3];
-		float[] slopes = new float[3];
+		Span<float> before = stackalloc float[3];
+		Span<float> slopes = stackalloc float[3];
 
 		for (int c = 0; c < 3; c++) {
 			long[] channelHistogramOutput = histogram[c];

--- a/Pinta.Core/Effects/RgbColor.cs
+++ b/Pinta.Core/Effects/RgbColor.cs
@@ -18,12 +18,12 @@ namespace Pinta.Core;
 /// should be using it!
 /// </summary>
 [Serializable]
-public struct RgbColor
+public readonly struct RgbColor
 {
 	// All values are between 0 and 255.
-	public int Red;
-	public int Green;
-	public int Blue;
+	public readonly int Red;
+	public readonly int Green;
+	public readonly int Blue;
 
 	public RgbColor (int R, int G, int B)
 	{

--- a/Pinta.Core/Effects/Scanline.cs
+++ b/Pinta.Core/Effects/Scanline.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace Pinta.Core;
 
-public struct Scanline
+public readonly struct Scanline
 {
 	private readonly int x;
 	private readonly int y;

--- a/Pinta.Core/Effects/UnaryPixelOps.cs
+++ b/Pinta.Core/Effects/UnaryPixelOps.cs
@@ -649,7 +649,7 @@ public sealed class UnaryPixelOps
 			return ret;
 		}
 
-		public void UnApply (ColorBgra after, float[] beforeOut, float[] slopesOut)
+		public void UnApply (ColorBgra after, Span<float> beforeOut, Span<float> slopesOut)
 		{
 			if (beforeOut.Length != 3)
 				throw new ArgumentException ($"{nameof (beforeOut)} must be a float[3]", nameof (beforeOut));

--- a/Pinta.Core/Effects/UserBlendOps.cs
+++ b/Pinta.Core/Effects/UserBlendOps.cs
@@ -23,26 +23,28 @@ namespace Pinta.Core;
 /// </summary>
 public sealed partial class UserBlendOps
 {
-	private static readonly Dictionary<string, BlendMode> blend_modes = new ();
+	private static readonly IReadOnlyDictionary<string, BlendMode> blend_modes;
 
 	static UserBlendOps ()
 	{
-		blend_modes.Add (Translations.GetString ("Normal"), BlendMode.Normal);
-		blend_modes.Add (Translations.GetString ("Multiply"), BlendMode.Multiply);
-		blend_modes.Add (Translations.GetString ("Color Burn"), BlendMode.ColorBurn);
-		blend_modes.Add (Translations.GetString ("Color Dodge"), BlendMode.ColorDodge);
-		blend_modes.Add (Translations.GetString ("Overlay"), BlendMode.Overlay);
-		blend_modes.Add (Translations.GetString ("Difference"), BlendMode.Difference);
-		blend_modes.Add (Translations.GetString ("Lighten"), BlendMode.Lighten);
-		blend_modes.Add (Translations.GetString ("Darken"), BlendMode.Darken);
-		blend_modes.Add (Translations.GetString ("Screen"), BlendMode.Screen);
-		blend_modes.Add (Translations.GetString ("Xor"), BlendMode.Xor);
-		blend_modes.Add (Translations.GetString ("Hard Light"), BlendMode.HardLight);
-		blend_modes.Add (Translations.GetString ("Soft Light"), BlendMode.SoftLight);
-		blend_modes.Add (Translations.GetString ("Color"), BlendMode.Color);
-		blend_modes.Add (Translations.GetString ("Luminosity"), BlendMode.Luminosity);
-		blend_modes.Add (Translations.GetString ("Hue"), BlendMode.Hue);
-		blend_modes.Add (Translations.GetString ("Saturation"), BlendMode.Saturation);
+		blend_modes = new Dictionary<string, BlendMode> {
+			[Translations.GetString ("Normal")] = BlendMode.Normal,
+			[Translations.GetString ("Multiply")] = BlendMode.Multiply,
+			[Translations.GetString ("Color Burn")] = BlendMode.ColorBurn,
+			[Translations.GetString ("Color Dodge")] = BlendMode.ColorDodge,
+			[Translations.GetString ("Overlay")] = BlendMode.Overlay,
+			[Translations.GetString ("Difference")] = BlendMode.Difference,
+			[Translations.GetString ("Lighten")] = BlendMode.Lighten,
+			[Translations.GetString ("Darken")] = BlendMode.Darken,
+			[Translations.GetString ("Screen")] = BlendMode.Screen,
+			[Translations.GetString ("Xor")] = BlendMode.Xor,
+			[Translations.GetString ("Hard Light")] = BlendMode.HardLight,
+			[Translations.GetString ("Soft Light")] = BlendMode.SoftLight,
+			[Translations.GetString ("Color")] = BlendMode.Color,
+			[Translations.GetString ("Luminosity")] = BlendMode.Luminosity,
+			[Translations.GetString ("Hue")] = BlendMode.Hue,
+			[Translations.GetString ("Saturation")] = BlendMode.Saturation,
+		};
 	}
 
 	private UserBlendOps ()

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -6,7 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Pinta.Core;
@@ -243,9 +242,9 @@ public static class Utility
 	public static int FastDivideShortByByte (ushort n, byte d)
 	{
 		int i = d * 3;
-		uint m = masTable[i];
-		uint a = masTable[i + 1];
-		uint s = masTable[i + 2];
+		uint m = mas_table[i];
+		uint a = mas_table[i + 1];
+		uint s = mas_table[i + 2];
 
 		uint nTimesMPlusA = unchecked((n * m) + a);
 		uint shifted = nTimesMPlusA >> (int) s;
@@ -256,7 +255,7 @@ public static class Utility
 
 	// i = z * 3;
 	// (x / z) = ((x * masTable[i]) + masTable[i + 1]) >> masTable[i + 2)
-	private static readonly uint[] masTable =
+	private static readonly uint[] mas_table =
 	{
     0x00000000, 0x00000000, 0,  // 0
             0x00000001, 0x00000000, 0,  // 1

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -371,22 +371,25 @@ public sealed class CurvesDialog : Gtk.Dialog
 		var infos = GetDrawingInfos ();
 		g.Save ();
 
+		Span<PointD> line = stackalloc PointD[size];
+
 		foreach (var controlPoints in ControlPoints) {
 
 			int points = controlPoints.Count;
 			SplineInterpolator interpolator = new SplineInterpolator ();
 			IList<int> xa = controlPoints.Keys;
 			IList<int> ya = controlPoints.Values;
-			PointD[] line = new PointD[size];
 
 			for (int i = 0; i < points; i++) {
 				interpolator.Add (xa[i], ya[i]);
 			}
 
 			for (int i = 0; i < line.Length; i++) {
-				line[i].X = (float) i;
-				line[i].Y = (float) (Math.Clamp (size - 1 - interpolator.Interpolate (i), 0, size - 1));
-
+				PointD linePoint = new (
+					x: (float) i,
+					y: (float) (Math.Clamp (size - 1 - interpolator.Interpolate (i), 0, size - 1))
+				);
+				line[i] = linePoint;
 			}
 
 			g.LineWidth = 2;

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -8,6 +8,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections.Immutable;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -49,14 +50,14 @@ public sealed class AddNoiseEffect : BaseEffect
 	[ThreadStatic]
 	private static Random thread_rand = new ();
 	private const int TableSize = 16384;
-	private static readonly int[] lookup;
+	private static readonly ImmutableArray<int> lookup;
 
 	private static double NormalCurve (double x, double scale)
 	{
 		return scale * Math.Exp (-x * x / 2);
 	}
 
-	private static int[] CreateLookup ()
+	private static ImmutableArray<int> CreateLookup ()
 	{
 		double l = 5;
 		double r = 10;
@@ -84,7 +85,8 @@ public sealed class AddNoiseEffect : BaseEffect
 			}
 		}
 
-		var result = new int[TableSize];
+		var result = ImmutableArray.CreateBuilder<int> (TableSize);
+		result.Count = TableSize;
 		sum = 0;
 		int roundedSum = 0, lastRoundedSum;
 
@@ -98,7 +100,7 @@ public sealed class AddNoiseEffect : BaseEffect
 			}
 		}
 
-		return result;
+		return result.ToImmutable ();
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
@@ -116,7 +118,7 @@ public sealed class AddNoiseEffect : BaseEffect
 		}
 
 		Random localRand = thread_rand;
-		ReadOnlySpan<int> localLookup = lookup;
+		ReadOnlySpan<int> localLookup = lookup.AsSpan ();
 
 		ReadOnlySpan<ColorBgra> src_data = src.GetReadOnlyPixelData ();
 		Span<ColorBgra> dst_data = dst.GetPixelData ();

--- a/Pinta.Effects/Effects/EdgeDetectEffect.cs
+++ b/Pinta.Effects/Effects/EdgeDetectEffect.cs
@@ -8,7 +8,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -17,8 +16,6 @@ namespace Pinta.Effects;
 
 public sealed class EdgeDetectEffect : ColorDifferenceEffect
 {
-	private double[][]? weights;
-
 	public override string Icon => Pinta.Resources.Icons.EffectsStylizeEdgeDetect;
 
 	public override string Name => Translations.GetString ("Edge Detect");
@@ -41,16 +38,15 @@ public sealed class EdgeDetectEffect : ColorDifferenceEffect
 
 	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
 	{
-		SetWeights ();
+		var weights = ComputeWeights ();
 		base.RenderColorDifferenceEffect (weights, src, dest, rois);
 	}
 
-	[MemberNotNull (nameof (weights))]
-	private void SetWeights ()
+	private double[][] ComputeWeights ()
 	{
-		weights = new double[3][];
-		for (int i = 0; i < this.weights.Length; ++i) {
-			this.weights[i] = new double[3];
+		var weights = new double[3][];
+		for (int i = 0; i < weights.Length; ++i) {
+			weights[i] = new double[3];
 		}
 
 		// adjust and convert angle to radians
@@ -61,17 +57,19 @@ public sealed class EdgeDetectEffect : ColorDifferenceEffect
 
 		// for r = 0 this builds an edge detect filter pointing straight left
 
-		this.weights[0][0] = Math.Cos (r + dr);
-		this.weights[0][1] = Math.Cos (r + 2.0 * dr);
-		this.weights[0][2] = Math.Cos (r + 3.0 * dr);
+		weights[0][0] = Math.Cos (r + dr);
+		weights[0][1] = Math.Cos (r + 2.0 * dr);
+		weights[0][2] = Math.Cos (r + 3.0 * dr);
 
-		this.weights[1][0] = Math.Cos (r);
-		this.weights[1][1] = 0;
-		this.weights[1][2] = Math.Cos (r + 4.0 * dr);
+		weights[1][0] = Math.Cos (r);
+		weights[1][1] = 0;
+		weights[1][2] = Math.Cos (r + 4.0 * dr);
 
-		this.weights[2][0] = Math.Cos (r - dr);
-		this.weights[2][1] = Math.Cos (r - 2.0 * dr);
-		this.weights[2][2] = Math.Cos (r - 3.0 * dr);
+		weights[2][0] = Math.Cos (r - dr);
+		weights[2][1] = Math.Cos (r - 2.0 * dr);
+		weights[2][2] = Math.Cos (r - 3.0 * dr);
+
+		return weights;
 	}
 }
 

--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -34,6 +34,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -102,7 +103,7 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 		if (!FlipVertical)
 			Utility.Swap (ref t, ref b);
 
-		var points = new PointD[entries + 2];
+		Span<PointD> points = stackalloc PointD[entries + 2];
 
 		points[entries] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (t, b, 20));
 		points[entries + 1] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (b, t, 20));

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -132,7 +132,8 @@ public sealed class GradientTool : BaseTool
 			g.Paint ();
 		}
 
-		gr.Render (scratch_layer, new[] { selection_bounds });
+		ReadOnlySpan<RectangleI> selection_bounds_array = stackalloc[] { selection_bounds };
+		gr.Render (scratch_layer, selection_bounds_array);
 
 		// Transfer the result back to the current layer.
 		var context = document.CreateClippedContext ();

--- a/Pinta/Actions/File/DBus/ScreenshotPortal.cs
+++ b/Pinta/Actions/File/DBus/ScreenshotPortal.cs
@@ -24,17 +24,12 @@ interface IScreenshot : IDBusObject
 }
 
 [Dictionary]
-class ScreenshotProperties
+internal sealed class ScreenshotProperties
 {
-	private uint _version = default (uint);
-	public uint Version {
-		get => _version;
-
-		set => _version = (value);
-	}
+	public uint Version { get; set; }
 }
 
-static class ScreenshotExtensions
+internal static class ScreenshotExtensions
 {
 	public static Task<uint> GetVersionAsync (this IScreenshot o) => o.GetAsync<uint> ("version");
 }

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -246,7 +246,7 @@ internal static class Carbon
 }
 
 [StructLayout (LayoutKind.Sequential, Pack = 2, Size = 80)]
-struct FSRef
+readonly struct FSRef
 {
 	//this is an 80-char opaque byte array
 #pragma warning disable 0169
@@ -511,7 +511,7 @@ struct CarbonHICommand //technically HICommandExtended, but they're compatible
 }
 
 [StructLayout (LayoutKind.Sequential, Pack = 2)]
-struct HIMenuItem
+readonly struct HIMenuItem
 {
 	readonly IntPtr menuRef;
 	readonly ushort index;
@@ -534,7 +534,7 @@ enum CarbonHICommandAttributes : uint
 	FromWindow = 1 << 2,
 }
 
-struct OSType
+readonly struct OSType
 {
 	readonly int value;
 

--- a/tests/Pinta.Core.Tests/UtilityTest.cs
+++ b/tests/Pinta.Core.Tests/UtilityTest.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class UtilityTest
+{
+	[Test]
+	public void ClampToByte_Single_TransparentWithinRange ()
+	{
+		const float MIN = byte.MinValue;
+		const float MAX = byte.MaxValue;
+		for (float i = MIN; i <= MAX; i++) {
+			byte clamped = Utility.ClampToByte (i);
+			float convertedBack = clamped;
+			Assert.AreEqual (i, convertedBack);
+		}
+	}
+
+	[TestCase (-1f)]
+	[TestCase (-0.1f)]
+	[TestCase (float.MinValue)]
+	public void ClampToByte_Single_LessThanMinBecomesMin (float n)
+	{
+		byte clamped = Utility.ClampToByte (n);
+		Assert.AreEqual (clamped, byte.MinValue);
+	}
+
+	[TestCase (256f)]
+	[TestCase (255.1f)]
+	[TestCase (float.MaxValue)]
+	public void ClampToByte_Single_MoreThanMaxBecomesMax (float n)
+	{
+		byte clamped = Utility.ClampToByte (n);
+		Assert.AreEqual (clamped, byte.MaxValue);
+	}
+
+	[Test]
+	public void ClampToByte_Double_TransparentWithinRange ()
+	{
+		const double MIN = byte.MinValue;
+		const double MAX = byte.MaxValue;
+		for (double i = MIN; i <= MAX; i++) {
+			byte clamped = Utility.ClampToByte (i);
+			double convertedBack = clamped;
+			Assert.AreEqual (i, convertedBack);
+		}
+	}
+
+	[TestCase (-1d)]
+	[TestCase (-0.1d)]
+	[TestCase (double.MinValue)]
+	public void ClampToByte_Double_LessThanMinBecomesMin (double n)
+	{
+		byte clamped = Utility.ClampToByte (n);
+		Assert.AreEqual (clamped, byte.MinValue);
+	}
+
+	[TestCase (256d)]
+	[TestCase (255.1d)]
+	[TestCase (double.MaxValue)]
+	public void ClampToByte_Double_MoreThanMaxBecomesMax (double n)
+	{
+		byte clamped = Utility.ClampToByte (n);
+		Assert.AreEqual (clamped, byte.MaxValue);
+	}
+
+	[Test]
+	public void ClampToByte_Int32_TransparentWithinRange ()
+	{
+		const int MIN = byte.MinValue;
+		const int MAX = byte.MaxValue;
+		for (int i = MIN; i <= MAX; i++) {
+			byte clamped = Utility.ClampToByte (i);
+			double convertedBack = clamped;
+			Assert.AreEqual (i, convertedBack);
+		}
+	}
+
+	[TestCase (-1)]
+	[TestCase (int.MinValue)]
+	public void ClampToByte_Int32_LessThanMinBecomesMin (int n)
+	{
+		byte clamped = Utility.ClampToByte (n);
+		Assert.AreEqual (clamped, byte.MinValue);
+	}
+
+	[TestCase (256)]
+	[TestCase (int.MaxValue)]
+	public void ClampToByte_Int32_MoreThanMaxBecomesMax (int n)
+	{
+		byte clamped = Utility.ClampToByte (n);
+		Assert.AreEqual (clamped, byte.MaxValue);
+	}
+}


### PR DESCRIPTION
It seems that the number of values will always be small, so it seems safe (against a stack overflow)