### PR TITLE
`RgbColor` member fields were made `readonly`

### DIFF
--- a/Pinta.Core/Effects/RgbColor.cs
+++ b/Pinta.Core/Effects/RgbColor.cs
@@ -18,12 +18,12 @@ namespace Pinta.Core;
 /// should be using it!
 /// </summary>
 [Serializable]
-public struct RgbColor
+public readonly struct RgbColor
 {
 	// All values are between 0 and 255.
-	public int Red;
-	public int Green;
-	public int Blue;
+	public readonly int Red;
+	public readonly int Green;
+	public readonly int Blue;
 
 	public RgbColor (int R, int G, int B)
 	{


### PR DESCRIPTION
There is no code modifying them

After that I was able to make the `struct` itself `readonly`.