### PR TITLE
Removed dangerous cast in `DocumentSelection.ConvertToPolygons`

### DIFF
--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -135,18 +135,14 @@ public sealed class DocumentSelection
 	/// <returns>A Clipper Polygon collection.</returns>
 	public static List<List<IntPoint>> ConvertToPolygons (IReadOnlyList<IReadOnlyList<PointI>> pintaPolygonSet)
 	{
-		List<List<IntPoint>> newPolygons = new List<List<IntPoint>> ();
-
-		foreach (PointI[] pA in pintaPolygonSet) {
-			List<IntPoint> newPolygon = new List<IntPoint> ();
-
+		List<List<IntPoint>> newPolygons = new (pintaPolygonSet.Count);
+		foreach (var pA in pintaPolygonSet) {
+			List<IntPoint> newPolygon = new (pA.Count);
 			foreach (PointI p in pA) {
 				newPolygon.Add (new IntPoint ((long) p.X, (long) p.Y));
 			}
-
 			newPolygons.Add (newPolygon);
 		}
-
 		return newPolygons;
 	}
 


### PR DESCRIPTION
Originally opened in #412 , but rebase messed up the diff