### PR TITLE
Array used for temporary calculations in `HistogramWidget.DrawChannel` is now allocated on the stack

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -34,6 +34,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -102,7 +103,7 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 		if (!FlipVertical)
 			Utility.Swap (ref t, ref b);
 
-		var points = new PointD[entries + 2];
+		Span<PointD> points = stackalloc PointD[entries + 2];
 
 		points[entries] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (t, b, 20));
 		points[entries + 1] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (b, t, 20));


### PR DESCRIPTION
Originally opened in #409 , but rebase messed up the diff.

It seems that the number of values will always be small, so the change seems safe (against a stack overflow).

Let's trace it all the way back to the origin:
* The number of items in `points` is based on the variable `entries`
* The variable `entries` is a snapshot of `Histogram.Entries`
* `Histogram` is a property of `HistogramWidget`, with a type of `HistogramRGB`. However, the `Entries` property belongs to the parent class `Histogram`
* The body of `Histogram.Entries` reads like this: `public int Entries => this.histogram[0].Length;`. `histogram` is an array of arrays
* `histogram` can be set from these places:
    * Constructor with signature `Histogram (int channels, int entries)`, which is only called through the constructor of `HistogramRGB` with pretty a pretty safe value of `256`: `public HistogramRgb () : base (3, 256) {...}`
    * `Histogram` property of `Histogram`, whose setter is never used, but even if it were, it checks that lengths of new arrays match existing lengths