### PR TITLE
Array used in calculation inside `MotionBlurEffect.Render` is now being allocated on the stack

### DIFF
--- a/Pinta.Effects/Effects/MotionBlurEffect.cs
+++ b/Pinta.Effects/Effects/MotionBlurEffect.cs
@@ -52,7 +52,7 @@ public sealed class MotionBlurEffect : BaseEffect
 			end.Y /= 2.0f;
 		}
 
-		PointD[] points = new PointD[((1 + Data.Distance) * 3) / 2];
+		Span<PointD> points = stackalloc PointD[(1 + Data.Distance) * 3 / 2];
 
 		if (points.Length == 1) {
 			points[0] = new PointD (0, 0);


### PR DESCRIPTION
In `MotionBlurData` we can see that the maximum value for `Distance` is 200:

```csharp
[Caption ("Distance"), MinimumValue (1), MaximumValue (200)]
public int Distance = 10;
```

So in the worst-case scenario, the number of items will be 301, because it's calculated as `(1 + Data.Distance) * 3 / 2`. If a `PointD` has a size of 16-bytes, the total number of bytes allocated on the stack is 4816, which is not too bad.