### PR TITLE
(Pilot improvement) `HueSaturationEffect.op` is now being calculated every time

### DIFF
--- a/Pinta.Effects/Adjustments/HueSaturationEffect.cs
+++ b/Pinta.Effects/Adjustments/HueSaturationEffect.cs
@@ -15,8 +15,6 @@ namespace Pinta.Effects;
 
 public sealed class HueSaturationEffect : BaseEffect
 {
-	UnaryPixelOp? op;
-
 	public override string Icon => Pinta.Resources.Icons.AdjustmentsHueSaturation;
 
 	public override string Name => Translations.GetString ("Hue / Saturation");
@@ -41,12 +39,11 @@ public sealed class HueSaturationEffect : BaseEffect
 		int sat_delta = Data.Saturation;
 		int lightness = Data.Lightness;
 
-		if (op == null) {
-			if (hue_delta == 0 && sat_delta == 100 && lightness == 0)
-				op = new UnaryPixelOps.Identity ();
-			else
-				op = new UnaryPixelOps.HueSaturationLightness (hue_delta, sat_delta, lightness);
-		}
+		UnaryPixelOp op;
+		if (hue_delta == 0 && sat_delta == 100 && lightness == 0)
+			op = new UnaryPixelOps.Identity ();
+		else
+			op = new UnaryPixelOps.HueSaturationLightness (hue_delta, sat_delta, lightness);
 
 		op.Apply (dest, src, rois);
 	}

--- a/Pinta.Effects/Adjustments/HueSaturationEffect.cs
+++ b/Pinta.Effects/Adjustments/HueSaturationEffect.cs
@@ -39,11 +39,7 @@ public sealed class HueSaturationEffect : BaseEffect
 		int sat_delta = Data.Saturation;
 		int lightness = Data.Lightness;
 
-		UnaryPixelOp op;
-		if (hue_delta == 0 && sat_delta == 100 && lightness == 0)
-			op = new UnaryPixelOps.Identity ();
-		else
-			op = new UnaryPixelOps.HueSaturationLightness (hue_delta, sat_delta, lightness);
+		UnaryPixelOp op = Data.IsDefault ? new UnaryPixelOps.Identity () : new UnaryPixelOps.HueSaturationLightness (hue_delta, sat_delta, lightness);
 
 		op.Apply (dest, src, rois);
 	}


### PR DESCRIPTION
The reason for this is that, if the data changes, the chosen `UnaryPixelOp` will be invalid every subsequent time. I think this is a potential source of bugs.

This pull request is intended to bring to attention the fact that there is something similar happening in many other effects, and ask if it's intended or not. My guess is that it's not intended that way. I see that when effects are used, care is taken to alter the initial `EffectData` _before_ calling the `Render()` method.

The answer to this question will inform my future changes.