### PR TITLE
Creation of RGB table in `BrightnessContrastEffect` happens every time the effect is `Render()`ed

### DIFF
--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -134,6 +134,17 @@ public sealed class BrightnessContrastEffect : BaseEffect
 		[Caption ("Contrast")]
 		public int Contrast { get; set; } = 0;
 
+		public override bool Equals (object? obj)
+		{
+			if (obj is not BrightnessContrastData brightnessContrast) return false;
+			return brightnessContrast.Brightness == Brightness && brightnessContrast.Contrast == Contrast;
+		}
+
+		public override int GetHashCode ()
+		{
+			return Brightness ^ Contrast;
+		}
+
 		[Skip]
 		public override bool IsDefault => Brightness == 0 && Contrast == 0;
 	}

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -53,7 +53,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 				if (fraction.Divide == 0) {
 					for (int i = 0; i < src_row.Length; ++i) {
 						ref readonly ColorBgra col = ref src_row[i];
-						uint c = rgbTable![col.GetIntensityByte ()]; // NRT - Set in Calculate
+						uint c = rgbTable[col.GetIntensityByte ()];
 						dst_row[i].Bgra = (col.Bgra & 0xff000000) | c | (c << 8) | (c << 16);
 					}
 				} else {
@@ -62,7 +62,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 						int intensity = col.GetIntensityByte ();
 						int shiftIndex = intensity * 256;
 
-						col.R = rgbTable![shiftIndex + col.R];
+						col.R = rgbTable[shiftIndex + col.R];
 						col.G = rgbTable[shiftIndex + col.G];
 						col.B = rgbTable[shiftIndex + col.B];
 

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -39,7 +39,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 	{
 		var fraction = GetFraction (Data);
 
-		var rgb_table = CreateRgbTable (fraction.Multiply, fraction.Divide);
+		var rgbTable = CreateRgbTable (fraction.Multiply, fraction.Divide);
 
 		var src_data = src.GetReadOnlyPixelData ();
 		var dst_data = dest.GetPixelData ();
@@ -53,7 +53,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 				if (fraction.Divide == 0) {
 					for (int i = 0; i < src_row.Length; ++i) {
 						ref readonly ColorBgra col = ref src_row[i];
-						uint c = rgb_table![col.GetIntensityByte ()]; // NRT - Set in Calculate
+						uint c = rgbTable![col.GetIntensityByte ()]; // NRT - Set in Calculate
 						dst_row[i].Bgra = (col.Bgra & 0xff000000) | c | (c << 8) | (c << 16);
 					}
 				} else {
@@ -62,9 +62,9 @@ public sealed class BrightnessContrastEffect : BaseEffect
 						int intensity = col.GetIntensityByte ();
 						int shiftIndex = intensity * 256;
 
-						col.R = rgb_table![shiftIndex + col.R];
-						col.G = rgb_table[shiftIndex + col.G];
-						col.B = rgb_table[shiftIndex + col.B];
+						col.R = rgbTable![shiftIndex + col.R];
+						col.G = rgbTable[shiftIndex + col.G];
+						col.B = rgbTable[shiftIndex + col.B];
 
 						dst_row[i] = col;
 					}
@@ -94,14 +94,14 @@ public sealed class BrightnessContrastEffect : BaseEffect
 
 	private byte[] CreateRgbTable (int multiply, int divide)
 	{
-		var rgb_table = new byte[65536];
+		var rgbTable = new byte[65536];
 
 		if (divide == 0) {
 			for (int intensity = 0; intensity < 256; intensity++) {
 				if (intensity + Data.Brightness < 128)
-					rgb_table[intensity] = 0;
+					rgbTable[intensity] = 0;
 				else
-					rgb_table[intensity] = 255;
+					rgbTable[intensity] = 255;
 			}
 		} else if (divide == 100) {
 			for (int intensity = 0; intensity < 256; intensity++) {
@@ -109,7 +109,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 
 				for (int col = 0; col < 256; ++col) {
 					int index = (intensity * 256) + col;
-					rgb_table[index] = Utility.ClampToByte (col + shift);
+					rgbTable[index] = Utility.ClampToByte (col + shift);
 				}
 			}
 		} else {
@@ -118,12 +118,12 @@ public sealed class BrightnessContrastEffect : BaseEffect
 
 				for (int col = 0; col < 256; ++col) {
 					int index = (intensity * 256) + col;
-					rgb_table[index] = Utility.ClampToByte (col + shift);
+					rgbTable[index] = Utility.ClampToByte (col + shift);
 				}
 			}
 		}
 
-		return rgb_table;
+		return rgbTable;
 	}
 
 	public sealed class BrightnessContrastData : EffectData


### PR DESCRIPTION
One benefit of this is that property changes do not need to be watched (they used to, in order to invalidate `BrightnessContrastEffect`'s RGB table every time they happened. Now, since previous values are not re-used this has become irrelevant.

There are quite a few changes going on here, so it merits its own pull request.