### PR TITLE
`visualColors` array in `Histogram` is now required in `Histogram`'s constructor

### DIFF
--- a/Pinta.Core/Effects/Histogram.cs
+++ b/Pinta.Core/Effects/Histogram.cs
@@ -6,7 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Collections.Immutable;
 using Cairo;
 
 namespace Pinta.Core;
@@ -36,13 +35,8 @@ public abstract class Histogram
 
 	public int Entries => this.histogram[0].Length;
 
-	protected internal Histogram (int channels, int entries, ImmutableArray<ColorBgra> visualColors)
+	protected internal Histogram (int channels, int entries)
 	{
-		if (visualColors.IsDefault)
-			throw new ArgumentException ("Not initialized", nameof (visualColors));
-
-		this.visual_colors = visualColors;
-
 		this.histogram = new long[channels][];
 
 		for (int channel = 0; channel < channels; ++channel) {
@@ -58,10 +52,10 @@ public abstract class Histogram
 		}
 	}
 
-	protected readonly ImmutableArray<ColorBgra> visual_colors;
+	protected ColorBgra[] visualColors = null!; // NRT - Set by constructor of only subclass
 	public ColorBgra GetVisualColor (int channel)
 	{
-		return visual_colors[channel];
+		return visualColors[channel];
 	}
 
 	public long GetOccurrences (int channel, int val)

--- a/Pinta.Core/Effects/Histogram.cs
+++ b/Pinta.Core/Effects/Histogram.cs
@@ -6,6 +6,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections.Immutable;
 using Cairo;
 
 namespace Pinta.Core;
@@ -35,8 +36,13 @@ public abstract class Histogram
 
 	public int Entries => this.histogram[0].Length;
 
-	protected internal Histogram (int channels, int entries)
+	protected internal Histogram (int channels, int entries, ImmutableArray<ColorBgra> visualColors)
 	{
+		if (visualColors.IsDefault)
+			throw new ArgumentException ("Not initialized", nameof (visualColors));
+
+		this.visual_colors = visualColors;
+
 		this.histogram = new long[channels][];
 
 		for (int channel = 0; channel < channels; ++channel) {
@@ -52,10 +58,10 @@ public abstract class Histogram
 		}
 	}
 
-	protected ColorBgra[] visualColors = null!; // NRT - Set by constructor of only subclass
+	protected readonly ImmutableArray<ColorBgra> visual_colors;
 	public ColorBgra GetVisualColor (int channel)
 	{
-		return visualColors[channel];
+		return visual_colors[channel];
 	}
 
 	public long GetOccurrences (int channel, int val)

--- a/Pinta.Core/Effects/HistogramRGB.cs
+++ b/Pinta.Core/Effects/HistogramRGB.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Immutable;
-using Adw;
 using Cairo;
 
 namespace Pinta.Core;

--- a/Pinta.Core/Effects/HistogramRGB.cs
+++ b/Pinta.Core/Effects/HistogramRGB.cs
@@ -6,8 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Collections.Immutable;
-using Adw;
 using Cairo;
 
 namespace Pinta.Core;
@@ -17,14 +15,18 @@ namespace Pinta.Core;
 /// if desired). This can then be used to retrieve percentile, average, peak,
 /// and distribution information.
 /// </summary>
-public sealed class HistogramRgb : Histogram
+public sealed class HistogramRgb
+    : Histogram
 {
-	public HistogramRgb () : base (3, 256, rgb_visual_colors)
+	public HistogramRgb ()
+	    : base (3, 256)
 	{
+		visualColors = new ColorBgra[]{
+				      ColorBgra.Blue,
+				      ColorBgra.Green,
+				      ColorBgra.Red
+				  };
 	}
-
-	private static ImmutableArray<ColorBgra> CreateVisualColors () => ImmutableArray.CreateRange (new[] { ColorBgra.Blue, ColorBgra.Green, ColorBgra.Red });
-	private static readonly ImmutableArray<ColorBgra> rgb_visual_colors = CreateVisualColors ();
 
 	public override ColorBgra GetMeanColor ()
 	{

--- a/Pinta.Core/Effects/HistogramRGB.cs
+++ b/Pinta.Core/Effects/HistogramRGB.cs
@@ -6,6 +6,8 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections.Immutable;
+using Adw;
 using Cairo;
 
 namespace Pinta.Core;
@@ -15,18 +17,14 @@ namespace Pinta.Core;
 /// if desired). This can then be used to retrieve percentile, average, peak,
 /// and distribution information.
 /// </summary>
-public sealed class HistogramRgb
-    : Histogram
+public sealed class HistogramRgb : Histogram
 {
-	public HistogramRgb ()
-	    : base (3, 256)
+	public HistogramRgb () : base (3, 256, rgb_visual_colors)
 	{
-		visualColors = new ColorBgra[]{
-				      ColorBgra.Blue,
-				      ColorBgra.Green,
-				      ColorBgra.Red
-				  };
 	}
+
+	private static ImmutableArray<ColorBgra> CreateVisualColors () => ImmutableArray.CreateRange (new[] { ColorBgra.Blue, ColorBgra.Green, ColorBgra.Red });
+	private static readonly ImmutableArray<ColorBgra> rgb_visual_colors = CreateVisualColors ();
 
 	public override ColorBgra GetMeanColor ()
 	{


### PR DESCRIPTION
This gets rid of a null-forgiving operator