### PR TITLE
Changed signature of `Render()` method in effects so that the `rois` argument is a `ReadOnlySpan<RectangleI>` instead of a `RectangleI[]`

### DIFF
--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -250,7 +250,7 @@ internal abstract class AsyncEffectRenderer
 			// NRT - These are set in Start () before getting here
 			if (!cancel_render_flag) {
 				dest_surface!.Flush ();
-				effect!.Render (source_surface!, dest_surface, new[] { bounds });
+				effect!.Render (source_surface!, dest_surface, stackalloc[] { bounds });
 				dest_surface.MarkDirty (bounds);
 			}
 

--- a/Pinta.Core/Effects/BaseEffect.cs
+++ b/Pinta.Core/Effects/BaseEffect.cs
@@ -114,7 +114,7 @@ public abstract class BaseEffect
 	/// <param name="src">The source surface. DO NOT MODIFY.</param>
 	/// <param name="dst">The destination surface.</param>
 	/// <param name="rois">An array of rectangles of interest (roi) specifying the area(s) to modify. Only these areas should be modified.</param>
-	public virtual void Render (ImageSurface src, ImageSurface dst, RectangleI[] rois)
+	public virtual void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		foreach (var rect in rois)
 			Render (src, dst, rect);

--- a/Pinta.Core/Effects/PixelOp.cs
+++ b/Pinta.Core/Effects/PixelOp.cs
@@ -25,11 +25,10 @@ public abstract class PixelOp //: IPixelOp
 		return (byte) (((la * (256 - (ra + (ra >> 7)))) >> 8) + ra);
 	}
 
-	public void Apply (ImageSurface dst, ImageSurface src, RectangleI[] rois, int startIndex, int length)
+	public void Apply (ImageSurface dst, ImageSurface src, ReadOnlySpan<RectangleI> rois, int startIndex, int length)
 	{
-		for (int i = startIndex; i < startIndex + length; ++i) {
+		for (int i = startIndex; i < startIndex + length; ++i)
 			ApplyBase (dst, rois[i].Location, src, rois[i].Location, rois[i].Size);
-		}
 	}
 
 	public void Apply (ImageSurface dst, PointI dstOffset, ImageSurface src, PointI srcOffset, Size roiSize)

--- a/Pinta.Core/Effects/UnaryPixelOp.cs
+++ b/Pinta.Core/Effects/UnaryPixelOp.cs
@@ -46,7 +46,7 @@ public abstract class UnaryPixelOp : PixelOp
 		}
 	}
 
-	public void Apply (ImageSurface surface, RectangleI[] roi, int startIndex, int length)
+	public void Apply (ImageSurface surface, ReadOnlySpan<RectangleI> roi, int startIndex, int length)
 	{
 		RectangleI regionBounds = Utility.GetRegionBounds (roi, startIndex, length);
 
@@ -57,7 +57,7 @@ public abstract class UnaryPixelOp : PixelOp
 			ApplyRectangle (surface, roi[x]);
 	}
 
-	public void Apply (ImageSurface surface, RectangleI[] roi)
+	public void Apply (ImageSurface surface, ReadOnlySpan<RectangleI> roi)
 	{
 		Apply (surface, roi, 0, roi.Length);
 	}
@@ -80,7 +80,7 @@ public abstract class UnaryPixelOp : PixelOp
 		}
 	}
 
-	public void Apply (ImageSurface dst, ImageSurface src, RectangleI[] rois)
+	public void Apply (ImageSurface dst, ImageSurface src, ReadOnlySpan<RectangleI> rois)
 	{
 		foreach (RectangleI roi in rois)
 			Apply (dst, src, roi);

--- a/Pinta.Effects/Adjustments/AutoLevelEffect.cs
+++ b/Pinta.Effects/Adjustments/AutoLevelEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -22,7 +23,7 @@ public sealed class AutoLevelEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "L";
 
-	public override void Render (ImageSurface src, ImageSurface dest, RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		if (op == null) {
 			HistogramRgb histogram = new HistogramRgb ();

--- a/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
+++ b/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -22,7 +23,7 @@ public sealed class BlackAndWhiteEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "G";
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		op.Apply (dest, src, rois);
 	}

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Krzysztof Marecki <marecki.krzysztof@gmail.com>         //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -49,7 +50,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 		EffectHelper.LaunchSimpleEffectDialog (this);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		if (!table_calculated)
 			Calculate ();

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Krzysztof Marecki <marecki.krzysztof@gmail.com>         //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Cairo;
@@ -48,7 +49,7 @@ public sealed class CurvesEffect : BaseEffect
 		dialog.Present ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		if (Data.ControlPoints == null)
 			return;

--- a/Pinta.Effects/Adjustments/HueSaturationEffect.cs
+++ b/Pinta.Effects/Adjustments/HueSaturationEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Krzysztof Marecki <marecki.krzysztof@gmail.com>         //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -33,7 +34,7 @@ public sealed class HueSaturationEffect : BaseEffect
 		EffectHelper.LaunchSimpleEffectDialog (this);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		int hue_delta = Data.Hue;
 		int sat_delta = Data.Saturation;

--- a/Pinta.Effects/Adjustments/InvertColorsEffect.cs
+++ b/Pinta.Effects/Adjustments/InvertColorsEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -22,7 +23,7 @@ public sealed class InvertColorsEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "I";
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		op.Apply (dest, src, rois);
 	}

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Krzysztof Marecki <marecki.krzysztof@gmail.com>         //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -48,7 +49,7 @@ public sealed class LevelsEffect : BaseEffect
 		dialog.Present ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		Data.Levels.Apply (dest, src, rois);
 	}

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Krzysztof Marecki <marecki.krzysztof@gmail.com>         //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -47,7 +48,7 @@ public sealed class PosterizeEffect : BaseEffect
 		dialog.Present ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		if (op == null)
 			op = new UnaryPixelOps.PosterizePixel (Data.Red, Data.Green, Data.Blue);

--- a/Pinta.Effects/Adjustments/SepiaEffect.cs
+++ b/Pinta.Effects/Adjustments/SepiaEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -34,7 +35,7 @@ public sealed class SepiaEffect : BaseEffect
 			ColorBgra.White);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		desat.Apply (dest, src, rois);
 		level.Apply (dest, dest, rois);

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -103,7 +103,7 @@ public sealed class AddNoiseEffect : BaseEffect
 		return result.ToImmutable ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		this.intensity = Data.Intensity;
 		this.color_saturation = Data.ColorSaturation;

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -37,7 +37,7 @@ public sealed class BulgeEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		float bulge = (float) Data.Amount;
 

--- a/Pinta.Effects/Effects/EdgeDetectEffect.cs
+++ b/Pinta.Effects/Effects/EdgeDetectEffect.cs
@@ -36,7 +36,7 @@ public sealed class EdgeDetectEffect : ColorDifferenceEffect
 		EffectHelper.LaunchSimpleEffectDialog (this);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		var weights = ComputeWeights ();
 		base.RenderColorDifferenceEffect (weights, src, dest, rois);

--- a/Pinta.Effects/Effects/EmbossEffect.cs
+++ b/Pinta.Effects/Effects/EmbossEffect.cs
@@ -37,7 +37,7 @@ public sealed class EmbossEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		double[,] weights = ComputeWeights ();
 

--- a/Pinta.Effects/Effects/FragmentEffect.cs
+++ b/Pinta.Effects/Effects/FragmentEffect.cs
@@ -58,7 +58,7 @@ public sealed class FragmentEffect : BaseEffect
 		return pointOffsets.MoveToImmutable ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		var pointOffsets = RecalcPointOffsets (Data.Fragments, Data.Rotation, Data.Distance);
 

--- a/Pinta.Effects/Effects/FrostedGlassEffect.cs
+++ b/Pinta.Effects/Effects/FrostedGlassEffect.cs
@@ -39,7 +39,7 @@ public sealed class FrostedGlassEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		int width = src.Width;
 		int height = src.Height;

--- a/Pinta.Effects/Effects/GaussianBlurEffect.cs
+++ b/Pinta.Effects/Effects/GaussianBlurEffect.cs
@@ -54,7 +54,7 @@ public sealed class GaussianBlurEffect : BaseEffect
 		return weights.MoveToImmutable ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		if (Data.Radius == 0) {
 			// Copy src to dest

--- a/Pinta.Effects/Effects/GlowEffect.cs
+++ b/Pinta.Effects/Effects/GlowEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -44,7 +45,7 @@ public sealed class GlowEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		blur_effect.Data.Radius = Data.Radius;
 		blur_effect.Render (src, dest, rois);

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -62,7 +63,7 @@ public sealed class InkSketchEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		// Glow background 
 		glow_effect.Data.Radius = 6;

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -55,7 +55,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 		return c;
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		const double jr = 0.3125;
 		const double ji = 0.03;

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -66,7 +66,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		return c - Math.Log (y * y + x * x) * inv_log_max;
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		int w = dst.Width;
 		int h = dst.Height;

--- a/Pinta.Effects/Effects/MedianEffect.cs
+++ b/Pinta.Effects/Effects/MedianEffect.cs
@@ -40,7 +40,7 @@ public sealed class MedianEffect : LocalHistogramEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		this.radius = Data.Radius;
 		this.percentile = Data.Percentile;

--- a/Pinta.Effects/Effects/MotionBlurEffect.cs
+++ b/Pinta.Effects/Effects/MotionBlurEffect.cs
@@ -37,7 +37,7 @@ public sealed class MotionBlurEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		PointD start = new PointD (0, 0);
 		double theta = ((double) (Data.Angle + 180) * 2 * Math.PI) / 360.0;

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -37,7 +37,7 @@ public sealed class OilPaintingEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dest, RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		int width = src.Width;
 		int height = src.Height;

--- a/Pinta.Effects/Effects/OutlineEffect.cs
+++ b/Pinta.Effects/Effects/OutlineEffect.cs
@@ -117,7 +117,7 @@ public sealed class OutlineEffect : LocalHistogramEffect
 		    (byte) (a2));
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		this.thickness = Data.Thickness;
 		this.intensity = Data.Intensity;

--- a/Pinta.Effects/Effects/PencilSketchEffect.cs
+++ b/Pinta.Effects/Effects/PencilSketchEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Jonathan Pobst <monkey@jpobst.com>                      //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -48,7 +49,7 @@ public sealed class PencilSketchEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		bac_adjustment.Data.Brightness = -Data.ColorRange;
 		bac_adjustment.Data.Contrast = -Data.ColorRange;

--- a/Pinta.Effects/Effects/PixelateEffect.cs
+++ b/Pinta.Effects/Effects/PixelateEffect.cs
@@ -67,7 +67,7 @@ public sealed class PixelateEffect : BaseEffect
 	}
 
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		var cellSize = Data.CellSize;
 

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -48,7 +48,7 @@ public sealed class RadialBlurEffect : BaseEffect
 		fy = cy + ((cx >> 8) * fr >> 8) - ((cy >> 14) * (fr * fr >> 11) >> 8);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		if (Data.Angle == 0) {
 			// Copy src to dest

--- a/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
+++ b/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Krzysztof Marecki <marecki.krzysztof@gmail.com>         //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
@@ -35,7 +36,7 @@ public sealed class RedEyeRemoveEffect : BaseEffect
 		EffectHelper.LaunchSimpleEffectDialog (this);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		var op = new UnaryPixelOps.RedEyeRemove (Data.Tolerance, Data.Saturation);
 		op.Apply (dest, src, rois);

--- a/Pinta.Effects/Effects/ReduceNoiseEffect.cs
+++ b/Pinta.Effects/Effects/ReduceNoiseEffect.cs
@@ -70,7 +70,7 @@ public sealed class ReduceNoiseEffect : LocalHistogramEffect
 		return ColorBgra.FromBgr ((byte) bc, (byte) gc, (byte) rc);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		this.radius = Data.Radius;
 		this.strength = -0.2 * Data.Strength;

--- a/Pinta.Effects/Effects/ReliefEffect.cs
+++ b/Pinta.Effects/Effects/ReliefEffect.cs
@@ -36,7 +36,7 @@ public sealed class ReliefEffect : ColorDifferenceEffect
 	public override string Name => Translations.GetString ("Relief");
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (Cairo.ImageSurface src, Cairo.ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (Cairo.ImageSurface src, Cairo.ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		var weights = ComputeWeights ();
 		base.RenderColorDifferenceEffect (weights, src, dst, rois);

--- a/Pinta.Effects/Effects/SharpenEffect.cs
+++ b/Pinta.Effects/Effects/SharpenEffect.cs
@@ -36,7 +36,7 @@ public sealed class SharpenEffect : LocalHistogramEffect
 		EffectHelper.LaunchSimpleEffectDialog (this);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		foreach (var rect in rois)
 			RenderRect (Data.Amount, src, dest, rect);

--- a/Pinta.Effects/Effects/SoftenPortraitEffect.cs
+++ b/Pinta.Effects/Effects/SoftenPortraitEffect.cs
@@ -72,7 +72,7 @@ public sealed class SoftenPortraitEffect : BaseEffect
 		EffectHelper.LaunchSimpleEffectDialog (this);
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		int warmth = Data.Warmth;
 		float redAdjust = 1.0f + (warmth / 100.0f);

--- a/Pinta.Effects/Effects/TileEffect.cs
+++ b/Pinta.Effects/Effects/TileEffect.cs
@@ -37,7 +37,7 @@ public sealed class TileEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		int width = dst.Width;
 		int height = dst.Height;

--- a/Pinta.Effects/Effects/TwistEffect.cs
+++ b/Pinta.Effects/Effects/TwistEffect.cs
@@ -37,7 +37,7 @@ public sealed class TwistEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		float twist = Data.Amount;
 

--- a/Pinta.Effects/Effects/UnfocusEffect.cs
+++ b/Pinta.Effects/Effects/UnfocusEffect.cs
@@ -39,7 +39,7 @@ public sealed class UnfocusEffect : LocalHistogramEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dest, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{
 		this.radius = Data.Radius;
 

--- a/Pinta.Effects/Effects/WarpEffect.cs
+++ b/Pinta.Effects/Effects/WarpEffect.cs
@@ -54,7 +54,7 @@ public abstract class WarpEffect : BaseEffect
 	protected double DefaultRadius2 => this.default_radius_2;
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		var selection = PintaCore.LivePreview.RenderBounds;
 		this.default_radius = Math.Min (selection.Width, selection.Height) * 0.5;

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -37,7 +37,7 @@ public sealed class ZoomBlurEffect : BaseEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	public override void Render (ImageSurface src, ImageSurface dst, Core.RectangleI[] rois)
+	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
 	{
 		if (Data.Amount == 0) {
 			// Copy src to dest


### PR DESCRIPTION
Also for `PixelOp` and `UnaryPixelOp`