### PR TITLE
Removed mutation-based `RectangleD.Inflate` and `RectangleI.Inflate` methods

### DIFF
--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -181,12 +181,13 @@ public record struct RectangleI
 		return FromLTRB (left, top, right, bottom);
 	}
 
-	public void Inflate (int width, int height)
+	public readonly RectangleI Inflated (int width, int height)
 	{
-		X -= width;
-		Y -= height;
-		Width += width * 2;
-		Height += height * 2;
+		var newX = X - width;
+		var newY = Y - height;
+		var newWidth = Width + (width * 2);
+		var newHeight = Height + (height * 2);
+		return new (newX, newY, newWidth, newHeight);
 	}
 }
 

--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -74,19 +74,13 @@ public record struct RectangleD
 	public readonly PointD Location () => new (X, Y);
 	public readonly PointD GetCenter () => new (X + 0.5 * Width, Y + 0.5 * Height);
 
-	public void Inflate (double width, double height)
-	{
-		X -= width;
-		Y -= height;
-		Width += width * 2;
-		Height += height * 2;
-	}
-
 	public readonly RectangleD Inflated (double width, double height)
 	{
-		RectangleD copy = this;
-		copy.Inflate (width, height);
-		return copy;
+		var newX = X - width;
+		var newY = Y - height;
+		var newWidth = Width + (width * 2);
+		var newHeight = Height + (height * 2);
+		return new (newX, newY, newWidth, newHeight);
 	}
 
 	public readonly RectangleD Clamp ()

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1073,7 +1073,7 @@ namespace Pinta.Core
 			var y2 = Math.Max (a.Y, b.Y);
 
 			var rect = new RectangleI (x1, y1, x2 - x1, y2 - y1);
-			rect.Inflate (inflate, inflate);
+			rect = rect.Inflated (inflate, inflate);
 
 			return rect;
 		}

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -118,7 +118,7 @@ public static class GdkExtensions
 			shapeWidth);
 
 		// Inflate shape bounding box to allow for anti-aliasing
-		shapeBBox.Inflate (2, 2);
+		shapeBBox = shapeBBox.Inflated (2, 2);
 
 		// To determine required size of icon,
 		// find union of the image and shape bounding boxes

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
@@ -68,7 +68,7 @@ public class AnglePickerGraphic : Gtk.DrawingArea
 	private RectangleD GetDrawBounds ()
 	{
 		var rect = new RectangleD (0, 0, GetAllocatedWidth (), GetAllocatedHeight ());
-		rect.Inflate (-1, -1);
+		rect = rect.Inflated (-1, -1);
 		return rect;
 	}
 

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -54,7 +54,7 @@ public sealed class PlainBrush : BasePaintBrush
 
 		// For some reason (?!) we need to inflate the dirty
 		// rectangle for small brush widths in zoomed images
-		dirty.Inflate (1, 1);
+		dirty = dirty.Inflated (1, 1);
 
 		return dirty;
 	}

--- a/Pinta.Tools/Handles/MoveHandle.cs
+++ b/Pinta.Tools/Handles/MoveHandle.cs
@@ -36,7 +36,7 @@ public sealed class MoveHandle : IToolHandle
 		const int tolerance = 5;
 
 		var bounds = ComputeWindowRect ();
-		bounds.Inflate (tolerance, tolerance);
+		bounds = bounds.Inflated (tolerance, tolerance);
 		return bounds.ContainsPoint (window_point);
 	}
 

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -141,7 +141,7 @@ public sealed class GradientTool : BaseTool
 		context.Operator = Operator.Source;
 		context.Paint ();
 
-		selection_bounds.Inflate (5, 5);
+		selection_bounds = selection_bounds.Inflated (5, 5);
 		document.Workspace.Invalidate (selection_bounds);
 	}
 

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -320,7 +320,7 @@ public abstract class SelectTool : BaseTool
 
 		// Figure out a bounding box for everything that was drawn, and add a bit of padding.
 		var dirty = rect.ToInt ();
-		dirty.Inflate (2, 2);
+		dirty = dirty.Inflated (2, 2);
 		return dirty;
 	}
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -881,7 +881,7 @@ public class TextTool : BaseTool
 	private void RedrawText (bool showCursor, bool useTextLayer)
 	{
 		RectangleI r = CurrentTextLayout.GetLayoutBounds ();
-		r.Inflate (10 + OutlineWidth, 10 + OutlineWidth);
+		r = r.Inflated (10 + OutlineWidth, 10 + OutlineWidth);
 		InflateAndInvalidate (r);
 		CurrentTextBounds = r;
 
@@ -956,7 +956,7 @@ public class TextTool : BaseTool
 					color, 1);
 
 			cursorBounds = loc;
-			cursorBounds.Inflate (2, 10);
+			cursorBounds = cursorBounds.Inflated (2, 10);
 		}
 
 		g.Restore ();
@@ -1044,7 +1044,7 @@ public class TextTool : BaseTool
 		//Create a new instance to preserve the passed Rectangle.
 		var r = new RectangleI (passedRectangle.Location, passedRectangle.Size);
 
-		r.Inflate (2, 2);
+		r = r.Inflated (2, 2);
 		PintaCore.Workspace.Invalidate (r);
 	}
 	#endregion


### PR DESCRIPTION
Those places where these methods are called are now using variable reassignment, and calling `RectangleD.Inflated()` and `RectangleI.Inflate()` instead