### PR TITLE
Update to the latest version of gir.core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0-preview.1" />
-    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0-preview.1" />
-    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0-preview.1" />
+    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0-preview.2" />
+    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0-preview.2" />
+    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0-preview.2" />
     <!-- Note: at least 1.4.2-alpha3 is required for fixes to uninstalling addins, from https://github.com/mono/mono-addins/pull/198 -->
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GirCore.Adw-1" Version="0.4.0" />
-    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.4.0" />
-    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.4.0" />
+    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0-preview.1" />
+    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0-preview.1" />
+    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0-preview.1" />
     <!-- Note: at least 1.4.2-alpha3 is required for fixes to uninstalling addins, from https://github.com/mono/mono-addins/pull/198 -->
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -208,7 +208,7 @@ public sealed class LayerActions
 
 				using var fs = file.Read (null);
 				try {
-					var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null);
+					var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when an error is thrown
 					var context = new Cairo.Context (layer.Surface);
 					context.DrawPixbuf (bg, 0, 0);
 				} finally {

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -72,7 +72,7 @@ public sealed class TextEngine
 			State = State,
 			current_pos = current_pos,
 			selection_start = selection_start,
-			Font = Font.Copy (),
+			Font = Font.Copy ()!, // NRT: pango_font_description_copy only returns null when given nullptr
 			Alignment = Alignment,
 			Underline = Underline,
 			Origin = new PointI (Origin.X, Origin.Y)

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -254,4 +254,16 @@ public static class GdkExtensions
 
 		return result;
 	}
+
+	/// <summary>
+	/// Wrapper for Gdk.Cursor.NewFromName which handles errors instead of returning null.
+	/// </summary>
+	public static Gdk.Cursor CursorFromName (string name)
+	{
+		var cursor = Gdk.Cursor.NewFromName (name, null);
+		if (cursor is null)
+			throw new ArgumentException ("Cursor does not exist", nameof (name));
+
+		return cursor;
+	}
 }

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -183,7 +183,8 @@ public static class GdkExtensions
 
 		Gdk.Internal.Clipboard.ReadTextAsync (clipboard.Handle, IntPtr.Zero, new Gio.Internal.AsyncReadyCallbackAsyncHandler ((_, args, _) => {
 			string? result = Gdk.Internal.Clipboard.ReadTextFinish (clipboard.Handle, args.Handle, out var error).ConvertToString ();
-			GLib.Error.ThrowOnError (error);
+			if (!error.IsInvalid)
+				throw new GLib.GException (error);
 
 			tcs.SetResult (result);
 		}).NativeCallback, IntPtr.Zero);
@@ -201,11 +202,8 @@ public static class GdkExtensions
 
 			Texture? texture = texture = GObject.Internal.ObjectWrapper.WrapNullableHandle<Texture> (result, ownedRef: true);
 
-			try {
-				GLib.Error.ThrowOnError (error);
-			} catch (Exception) {
+			if (!error.IsInvalid)
 				texture = null;
-			}
 
 			tcs.SetResult (texture);
 		}).NativeCallback, IntPtr.Zero);
@@ -243,24 +241,16 @@ public static class GdkExtensions
 		return surf;
 	}
 
-	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
-	public static nuint GetFileListGType () => Gdk.Internal.FileList.GetGType ();
-
-	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
-	public static Gio.File[] GetFiles (this Gdk.FileList file_list)
+	// TODO-GTK4 (bindings) - struct methods are not generated (https://github.com/gircore/gir.core/issues/622)
+	public static Gio.File[] GetFilesHelper (this Gdk.FileList file_list)
 	{
-		// FIXME: this is needed to avoid errors because SListOwnedHandle doesn't have a free function.
-		var slist_owned_handle = Gdk.Internal.FileList.GetFiles (file_list.Handle);
-		var slist_handle = new GLib.Internal.SListUnownedHandle (slist_owned_handle.DangerousGetHandle ());
-		slist_owned_handle.SetHandleAsInvalid ();
+		var slist = file_list.GetFiles ();
 
-		uint n = GLib.Internal.SList.Length (slist_handle);
+		uint n = GLib.Internal.SList.Length (slist.Handle);
 		var result = new Gio.File[n];
 		for (uint i = 0; i < n; ++i) {
-			result[i] = new Gio.FileHelper (GLib.Internal.SList.NthData (slist_handle, i), ownedRef: false);
+			result[i] = new Gio.FileHelper (GLib.Internal.SList.NthData (slist.Handle, i), ownedRef: false);
 		}
-
-		GLib.Internal.SList.Free (slist_handle);
 
 		return result;
 	}

--- a/Pinta.Core/Extensions/GdkPixbufExtensions.cs
+++ b/Pinta.Core/Extensions/GdkPixbufExtensions.cs
@@ -87,13 +87,12 @@ public static class GdkPixbufExtensions
 	// TODO-GTK4 (bindings) - record methods are not generated (https://github.com/gircore/gir.core/issues/743)
 	public static string[] GetMimeTypes (this PixbufFormat format)
 	{
-		IntPtr resultNative = GetMimeTypes (format.Handle);
-		// FIXME - this does not free the result!
-		return GLib.Internal.StringHelper.ToStringArrayUtf8 (resultNative);
+		var result = GetMimeTypes (format.Handle);
+		return result.ConvertToStringArray () ?? Array.Empty<string> ();
 	}
 
 	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_format_get_mime_types")]
-	private static extern IntPtr GetMimeTypes (GdkPixbuf.Internal.PixbufFormatHandle format);
+	private static extern GLib.Internal.Utf8StringArrayNullTerminatedOwnedHandle GetMimeTypes (GdkPixbuf.Internal.PixbufFormatHandle format);
 
 	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_get_formats")]
 	private static extern GLib.Internal.SListUnownedHandle GetFormatsNative ();

--- a/Pinta.Core/Extensions/GdkPixbufExtensions.cs
+++ b/Pinta.Core/Extensions/GdkPixbufExtensions.cs
@@ -47,7 +47,8 @@ public static class GdkPixbufExtensions
 	public static byte[] SaveToBuffer (this Pixbuf pixbuf, string type)
 	{
 		SaveToBufferv (pixbuf.Handle, out IntPtr buffer, out uint buffer_size, type, IntPtr.Zero, IntPtr.Zero, out var error);
-		GLib.Error.ThrowOnError (error);
+		if (!error.IsInvalid)
+			throw new GLib.GException (error);
 
 		var result = new byte[buffer_size];
 		Marshal.Copy (buffer, result, 0, (int) buffer_size);

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -89,7 +89,7 @@ public static class GtkExtensions
 	}
 
 	// TODO-GTK4 (bindings) - add pre-defined VariantType's to gir.core (https://github.com/gircore/gir.core/issues/843)
-	public static readonly GLib.VariantType IntVariantType = new ("i");
+	public static readonly GLib.VariantType IntVariantType = GLib.VariantType.New ("i");
 
 	/// <summary>
 	/// In GTK4, toolbars are just a Box with a different CSS style class.
@@ -289,7 +289,7 @@ public static class GtkExtensions
 	public static string RunBlocking (this Adw.MessageDialog dialog)
 	{
 		string response = "";
-		GLib.MainLoop loop = new ();
+		var loop = GLib.MainLoop.New (null, false);
 
 		if (!dialog.Modal)
 			dialog.Modal = true;
@@ -314,7 +314,7 @@ public static class GtkExtensions
 	public static ResponseType RunBlocking (this Gtk.NativeDialog dialog)
 	{
 		var response = ResponseType.None;
-		GLib.MainLoop loop = new ();
+		var loop = GLib.MainLoop.New (null, false);
 
 		if (!dialog.Modal)
 			dialog.Modal = true;
@@ -339,7 +339,7 @@ public static class GtkExtensions
 	public static ResponseType RunBlocking (this Gtk.Dialog dialog)
 	{
 		var response = ResponseType.None;
-		GLib.MainLoop loop = new ();
+		var loop = GLib.MainLoop.New (null, false);
 
 		if (!dialog.Modal)
 			dialog.Modal = true;

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -47,7 +47,7 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 		// Handle any EXIF orientation flags
 		using (var fs = file.Read (cancellable: null)) {
 			try {
-				bg = Pixbuf.NewFromStream (fs, cancellable: null);
+				bg = Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when an error is thrown
 			} finally {
 				fs.Close (null);
 			}

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -1,21 +1,21 @@
-// 
+//
 // OraFormat.cs
-//  
+//
 // Author:
 //       Maia Kozheva <sikon@ubuntu.com>
-// 
+//
 // Copyright (c) 2010 Maia Kozheva <sikon@ubuntu.com>
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -102,7 +102,7 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 				layer.Opacity = double.Parse (GetAttribute (layerElement, "opacity", "1"), GetFormat ());
 				layer.BlendMode = StandardToBlendMode (GetAttribute (layerElement, "composite-op", "svg:src-over"));
 
-				var pb = GdkPixbuf.Pixbuf.NewFromFile (tmp_file);
+				var pb = GdkPixbuf.Pixbuf.NewFromFile (tmp_file)!; // NRT: only nullable when an error is thrown
 				var g = new Context (layer.Surface);
 				g.DrawPixbuf (pb, x, y);
 

--- a/Pinta.Gui.Widgets/Widgets/Ruler.cs
+++ b/Pinta.Gui.Widgets/Widgets/Ruler.cs
@@ -92,7 +92,7 @@ public sealed class Ruler : DrawingArea
 		SetDrawFunc ((area, context, width, height) => Draw (context, new Size (width, height)));
 
 		// Determine the size request, based on the font size.
-		int font_size = GetFontSize (GetPangoContext ().GetFontDescription (), ScaleFactor);
+		int font_size = GetFontSize (GetPangoContext ().GetFontDescription ()!, ScaleFactor);
 		int size = 2 + font_size * 2;
 
 		int width = 0;
@@ -210,7 +210,7 @@ public sealed class Ruler : DrawingArea
 		double max_size = scaled_upper - scaled_lower;
 
 		// There must be enough space between the large ticks for the text labels.
-		Pango.FontDescription font = GetPangoContext ().GetFontDescription ();
+		Pango.FontDescription font = GetPangoContext ().GetFontDescription ()!;
 		int font_size = GetFontSize (font, ScaleFactor);
 		int max_digits = ((int) -Math.Abs (max_size)).ToString ().Length;
 		int min_separation = max_digits * font_size * 2;

--- a/Pinta.Resources/ResourceManager.cs
+++ b/Pinta.Resources/ResourceManager.cs
@@ -111,7 +111,7 @@ public static class ResourceLoader
 				var buffer = new byte[stream.Length];
 				stream.Read (buffer, 0, buffer.Length);
 
-				var bytes = GLib.Bytes.From (buffer);
+				var bytes = GLib.Bytes.New (buffer);
 				image = Gdk.Texture.NewFromBytes (bytes);
 			}
 		} catch (Exception ex) {

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // BaseEditEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -176,7 +176,7 @@ public abstract class BaseEditEngine
 		SEngines.SelectMany (engine => engine.ControlPointHandles).Append (hover_handle);
 	private readonly MoveHandle hover_handle = new ();
 
-	private readonly Gdk.Cursor grab_cursor = Gdk.Cursor.NewFromName (Pinta.Resources.StandardCursors.Grab, null);
+	private readonly Gdk.Cursor grab_cursor = GdkExtensions.CursorFromName (Pinta.Resources.StandardCursors.Grab);
 
 	protected bool changing_tension = false;
 	protected PointD last_mouse_pos = new (0d, 0d);
@@ -353,7 +353,7 @@ public abstract class BaseEditEngine
 				int previousSSI = SelectedShapeIndex;
 				ActivateCorrespondingTool (selEngine.ShapeType, true);
 				SelectedShapeIndex = previousSSI;
-				//Draw the updated shape with organized points generation (for mouse detection). 
+				//Draw the updated shape with organized points generation (for mouse detection).
 				DrawActiveShape (true, false, true, false, true);
 			};
 		}

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -391,7 +391,7 @@ public sealed class TextTool : BaseTool
 	private void UpdateFont ()
 	{
 		if (PintaCore.Workspace.HasOpenDocuments) {
-			var font = font_button.GetFontDesc ().Copy ();
+			var font = font_button.GetFontDesc ()!.Copy ()!; // NRT: Only nullable when nullptr is passed.
 			font.SetWeight (bold_btn.Active ? Pango.Weight.Bold : Pango.Weight.Normal);
 			font.SetStyle (italic_btn.Active ? Pango.Style.Italic : Pango.Style.Normal);
 

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ZoomTool.cs
-//  
+//
 // Author:
 //       Olivier Dufour <olivier.duff@gmail.com>
-// 
+//
 // Copyright (c) 2010 Olivier Dufour
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -46,8 +46,8 @@ public sealed class ZoomTool : BaseTool
 	{
 		mouse_down = MouseButton.None;
 
-		cursor_zoom_in = Gdk.Cursor.NewFromName (Pinta.Resources.StandardCursors.ZoomIn, null);
-		cursor_zoom_out = Gdk.Cursor.NewFromName (Pinta.Resources.StandardCursors.ZoomOut, null);
+		cursor_zoom_in = GdkExtensions.CursorFromName (Pinta.Resources.StandardCursors.ZoomIn);
+		cursor_zoom_out = GdkExtensions.CursorFromName (Pinta.Resources.StandardCursors.ZoomOut);
 		cursor_zoom = Gdk.Cursor.NewFromTexture (Resources.GetIcon (Pinta.Resources.Icons.ToolZoom), 0, 0, null);
 		cursor_zoom_pan = Gdk.Cursor.NewFromTexture (Resources.GetIcon (Pinta.Resources.Icons.ToolPan), 0, 0, null);
 	}

--- a/Pinta/Main.cs
+++ b/Pinta/Main.cs
@@ -113,7 +113,7 @@ internal sealed class MainClass
 		};
 
 		// Run with a SynchronizationContext to integrate async methods with GLib.MainLoop.
-		app.RunWithSynchronizationContext ();
+		app.RunWithSynchronizationContext (null);
 	}
 
 	private static void OpenFilesFromCommandLine (IEnumerable<string> files)

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -88,7 +88,7 @@ public sealed class MainWindow
 		PintaCore.Actions.App.BeforeQuit += delegate { SaveUserSettings (); };
 
 		// We support drag and drop for URIs, which are converted into a Gdk.FileList.
-		drop_target = Gtk.DropTarget.New (GdkExtensions.GetFileListGType (), Gdk.DragAction.Copy);
+		drop_target = Gtk.DropTarget.New (Gdk.FileList.GetGType (), Gdk.DragAction.Copy);
 		drop_target.OnDrop += HandleDrop;
 		window_shell.Window.AddController (drop_target);
 
@@ -495,10 +495,10 @@ public sealed class MainWindow
 
 	private bool HandleDrop (DropTarget sender, DropTarget.DropSignalArgs args)
 	{
-		if (args.Value.GetBoxed (GdkExtensions.GetFileListGType ()) is not Gdk.FileList file_list)
+		if (args.Value.GetBoxed (Gdk.FileList.GetGType ()) is not Gdk.FileList file_list)
 			return false;
 
-		foreach (Gio.File file in file_list.GetFiles ()) {
+		foreach (Gio.File file in file_list.GetFilesHelper ()) {
 			PintaCore.Workspace.OpenFile (file);
 
 			if (file.GetUriScheme () is string scheme &&

--- a/tests/Pinta.Effects.Tests/Utilities.cs
+++ b/tests/Pinta.Effects.Tests/Utilities.cs
@@ -21,7 +21,7 @@ internal static class Utilities
 
 		using var fs = file.Read (null);
 		try {
-			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null);
+			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when error is thrown.
 			var surf = CairoExtensions.CreateImageSurface (Format.Argb32, bg.Width, bg.Height);
 			var context = new Cairo.Context (surf);
 			context.DrawPixbuf (bg, 0, 0);

--- a/tests/PintaBenchmarks/Utilities/TestData.cs
+++ b/tests/PintaBenchmarks/Utilities/TestData.cs
@@ -17,7 +17,7 @@ internal class TestData
 
 		using var fs = file.Read (null);
 		try {
-			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null);
+			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when error is thrown.
 			var surf = CairoExtensions.CreateImageSurface (Format.Argb32, bg.Width, bg.Height);
 			var context = new Cairo.Context (surf);
 			context.DrawPixbuf (bg, 0, 0);


### PR DESCRIPTION
- Update for API changes to GError exception handling
- Constructors such as GLib.Bytes.New() are now generated, replacing old manual bindings
- Opaque records such as Gdk.FileList are better supported.

This is blocked on:
- https://github.com/gircore/gir.core/issues/957