### PR TITLE
Algebraic simplification in `SquaresBrush`

### DIFF
--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -37,7 +37,7 @@ public sealed class SquaresBrush : BasePaintBrush
 	// ...its sine is clearly 1
 	private const double Theta_sin = 1;
 
-	// ...and its cosine is clearly
+	// ...and its cosine is clearly 0
 	private const double Theta_cos = 0;
 
 	public override string Name => Translations.GetString ("Squares");

--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
 using Cairo;
 
 using Pinta.Core;
@@ -33,10 +32,13 @@ namespace Pinta.Tools.Brushes;
 
 public sealed class SquaresBrush : BasePaintBrush
 {
-	private const double Theta = Math.PI / 2;
+	// Let's take theta to be Pi / 2...
 
-	private static readonly double theta_sin = Math.Sin (Theta);
-	private static readonly double theta_cos = Math.Cos (Theta);
+	// ...its sine is clearly 1
+	private const double Theta_sin = 1;
+
+	// ...and its cosine is clearly
+	private const double Theta_cos = 0;
 
 	public override string Name => Translations.GetString ("Squares");
 
@@ -51,8 +53,8 @@ public sealed class SquaresBrush : BasePaintBrush
 	{
 		int dx = x - lastX;
 		int dy = y - lastY;
-		double px = theta_cos * dx - theta_sin * dy;
-		double py = theta_sin * dx + theta_cos * dy;
+		double px = Theta_cos * dx - Theta_sin * dy;
+		double py = Theta_sin * dx + Theta_cos * dy;
 
 		g.MoveTo (lastX - px, lastY - py);
 		g.LineTo (lastX + px, lastY + py);

--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -33,17 +33,26 @@ namespace Pinta.Tools.Brushes;
 
 public sealed class SquaresBrush : BasePaintBrush
 {
-	private static readonly double theta = Math.PI / 2;
+	private const double Theta = Math.PI / 2;
+
+	private static readonly double theta_sin = Math.Sin (Theta);
+	private static readonly double theta_cos = Math.Cos (Theta);
 
 	public override string Name => Translations.GetString ("Squares");
 
-	protected override RectangleI OnMouseMove (Context g, Color strokeColor, ImageSurface surface,
-						      int x, int y, int lastX, int lastY)
+	protected override RectangleI OnMouseMove (
+		Context g,
+		Color strokeColor,
+		ImageSurface surface,
+		int x,
+		int y,
+		int lastX,
+		int lastY)
 	{
 		int dx = x - lastX;
 		int dy = y - lastY;
-		double px = Math.Cos (theta) * dx - Math.Sin (theta) * dy;
-		double py = Math.Sin (theta) * dx + Math.Cos (theta) * dy;
+		double px = theta_cos * dx - theta_sin * dy;
+		double py = theta_sin * dx + theta_cos * dy;
 
 		g.MoveTo (lastX - px, lastY - py);
 		g.LineTo (lastX + px, lastY + py);

--- a/Pinta.Tools/Brushes/SquaresBrush.cs
+++ b/Pinta.Tools/Brushes/SquaresBrush.cs
@@ -32,14 +32,6 @@ namespace Pinta.Tools.Brushes;
 
 public sealed class SquaresBrush : BasePaintBrush
 {
-	// Let's take theta to be Pi / 2...
-
-	// ...its sine is clearly 1
-	private const double Theta_sin = 1;
-
-	// ...and its cosine is clearly 0
-	private const double Theta_cos = 0;
-
 	public override string Name => Translations.GetString ("Squares");
 
 	protected override RectangleI OnMouseMove (
@@ -53,8 +45,10 @@ public sealed class SquaresBrush : BasePaintBrush
 	{
 		int dx = x - lastX;
 		int dy = y - lastY;
-		double px = Theta_cos * dx - Theta_sin * dy;
-		double py = Theta_sin * dx + Theta_cos * dy;
+
+		// 90-degree rotation
+		double px = -dy;
+		double py = +dx;
 
 		g.MoveTo (lastX - px, lastY - py);
 		g.LineTo (lastX + px, lastY + py);


### PR DESCRIPTION
Theta is a constant, so its sine and cosine are constants too.

I don't know if this effect will be tweaked in the future (and possibly other values of theta would be needed), but for now it should be fine because I left comments that explain what the reasoning behind the constants is.