### PR TITLE
Removed unnecessary `null` check in `Effects.LevelsDialog.cs`

### DIFF
--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -209,19 +209,13 @@ public partial class LevelsDialog : Gtk.Dialog
 	}
 
 	private UnaryPixelOps.Level Levels {
-		get {
-			if (EffectData == null)
-				throw new InvalidOperationException ("Effect data not set on levels dialog.");
-
-			return EffectData.Levels;
-		}
-
-		set => EffectData.Levels = value ?? throw new ArgumentNullException (nameof (value));
+		get => EffectData.Levels;
+		set => EffectData.Levels = value;
 	}
 
 	private void UpdateLivePreview ()
 	{
-		EffectData?.FirePropertyChanged (nameof (Levels));
+		EffectData.FirePropertyChanged (nameof (Levels));
 	}
 
 	private void UpdateInputHistogram ()


### PR DESCRIPTION
The project is being compiled with `<Nullable>`, so some checks are not necessary