### PR TITLE
Public fields of `UserLayer` were turned into properties

### DIFF
--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -54,7 +54,7 @@ public class Layer : ObservableObject
 	}
 
 	public ImageSurface Surface { get; set; }
-	public bool Tiled { get; set; }
+	public bool Tiled { get; internal set; }
 	public Matrix Transform { get; set; }
 
 	public static readonly string OpacityProperty = "Opacity";

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -37,7 +37,7 @@ namespace Pinta.Core;
 public sealed class UserLayer : Layer
 {
 	//Special layers to be drawn on to keep things editable by drawing them separately from the UserLayers.
-	public Collection<ReEditableLayer> ReEditableLayers { get; } = new ();
+	internal Collection<ReEditableLayer> ReEditableLayers { get; } = new ();
 	public ReEditableLayer TextLayer { get; }
 
 	//Call the base class constructor and setup the engines.

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -25,7 +25,7 @@
 // THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Cairo;
 
 namespace Pinta.Core;
@@ -37,8 +37,8 @@ namespace Pinta.Core;
 public sealed class UserLayer : Layer
 {
 	//Special layers to be drawn on to keep things editable by drawing them separately from the UserLayers.
-	public List<ReEditableLayer> ReEditableLayers = new ();
-	public ReEditableLayer TextLayer;
+	public Collection<ReEditableLayer> ReEditableLayers { get; } = new ();
+	public ReEditableLayer TextLayer { get; }
 
 	//Call the base class constructor and setup the engines.
 	public UserLayer (ImageSurface surface) : this (surface, false, 1f, "")
@@ -48,16 +48,16 @@ public sealed class UserLayer : Layer
 	//Call the base class constructor and setup the engines.
 	public UserLayer (ImageSurface surface, bool hidden, double opacity, string name) : base (surface, hidden, opacity, name)
 	{
-		tEngine = new TextEngine ();
+		TextEngine = new TextEngine ();
 		TextLayer = new ReEditableLayer (this);
 	}
 
 	//Stores most of the editable text's data, including the text itself.
-	public TextEngine tEngine;
+	public TextEngine TextEngine { get; internal set; }
 
 	//Rectangular boundary surrounding the editable text.
-	public RectangleI textBounds = RectangleI.Zero;
-	public RectangleI previousTextBounds = RectangleI.Zero;
+	public RectangleI TextBounds { get; set; } = RectangleI.Zero;
+	public RectangleI PreviousTextBounds { get; set; } = RectangleI.Zero;
 
 	public override void ApplyTransform (Matrix xform, Size old_size, Size new_size)
 	{

--- a/Pinta.Core/HistoryItems/TextHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/TextHistoryItem.cs
@@ -38,7 +38,7 @@ public sealed class TextHistoryItem : BaseHistoryItem
 	readonly SurfaceDiff? user_surface_diff;
 	ImageSurface? user_surface;
 
-	TextEngine t_engine;
+	TextEngine text_engine;
 	RectangleI text_bounds;
 
 	/// <summary>
@@ -71,9 +71,9 @@ public sealed class TextHistoryItem : BaseHistoryItem
 		}
 
 
-		t_engine = passedTextEngine;
+		text_engine = passedTextEngine;
 
-		text_bounds = new RectangleI (user_layer.textBounds.X, user_layer.textBounds.Y, user_layer.textBounds.Width, user_layer.textBounds.Height);
+		text_bounds = new RectangleI (user_layer.TextBounds.X, user_layer.TextBounds.Y, user_layer.TextBounds.Width, user_layer.TextBounds.Height);
 	}
 
 	public override void Undo ()
@@ -126,15 +126,15 @@ public sealed class TextHistoryItem : BaseHistoryItem
 
 
 		//Store the old text data temporarily.
-		TextEngine oldTEngine = t_engine;
+		TextEngine oldTextEngine = text_engine;
 		RectangleI oldTextBounds = text_bounds;
 
 		//Swap half of the data.
-		t_engine = user_layer.tEngine;
-		text_bounds = user_layer.textBounds;
+		text_engine = user_layer.TextEngine;
+		text_bounds = user_layer.TextBounds;
 
 		//Swap the other half.
-		user_layer.tEngine = oldTEngine;
-		user_layer.textBounds = oldTextBounds;
+		user_layer.TextEngine = oldTextEngine;
+		user_layer.TextBounds = oldTextBounds;
 	}
 }

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -41,12 +41,12 @@ public sealed class TextTool : BaseTool
 	private readonly Pinta.Core.TextLayout layout;
 
 	private static RectangleI CurrentTextBounds {
-		get => PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.textBounds;
+		get => PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextBounds;
 
 		set {
-			PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.previousTextBounds = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.textBounds;
+			PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.PreviousTextBounds = PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextBounds;
 
-			PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.textBounds = value;
+			PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextBounds = value;
 		}
 	}
 
@@ -55,7 +55,7 @@ public sealed class TextTool : BaseTool
 			if (!PintaCore.Workspace.HasOpenDocuments)
 				throw new InvalidOperationException ("Attempting to get CurrentTextEngine when there are no open documents");
 
-			return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.tEngine;
+			return PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextEngine;
 		}
 	}
 
@@ -512,7 +512,7 @@ public sealed class TextTool : BaseTool
 				//Go through every UserLayer.
 				foreach (UserLayer ul in document.Layers.UserLayers) {
 					//Check each UserLayer's editable text boundaries to see if they contain the mouse position.
-					if (ul.textBounds.Contains (pt)) {
+					if (ul.TextBounds.Contains (pt)) {
 						//The mouse clicked on editable text.
 
 						//Change the current UserLayer to the Layer that contains the text that was clicked on.
@@ -595,7 +595,7 @@ public sealed class TextTool : BaseTool
 			//Go through every UserLayer.
 			foreach (UserLayer ul in document.Layers.UserLayers) {
 				//Check each UserLayer's editable text boundaries to see if they contain the mouse position.
-				if (ul.textBounds.Contains (last_mouse_position)) {
+				if (ul.TextBounds.Contains (last_mouse_position)) {
 					//The mouse is over editable text.
 					showNormalCursor = true;
 				}
@@ -867,7 +867,7 @@ public sealed class TextTool : BaseTool
 		PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.TextLayer.Layer.Surface.Clear ();
 
 		//Redraw the previous text boundary.
-		InflateAndInvalidate (PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.previousTextBounds);
+		InflateAndInvalidate (PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.PreviousTextBounds);
 	}
 
 	/// <summary>
@@ -977,7 +977,7 @@ public sealed class TextTool : BaseTool
 			g.Restore ();
 		}
 
-		InflateAndInvalidate (PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.previousTextBounds);
+		InflateAndInvalidate (PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer.PreviousTextBounds);
 		PintaCore.Workspace.Invalidate (old_cursor_bounds);
 		InflateAndInvalidate (r);
 		PintaCore.Workspace.Invalidate (cursorBounds);


### PR DESCRIPTION
And now the accessibility is clearly specified. All of them have `get`ters, but not all of them have `set`ters, or at least their scope is restricted to where they are actually used.

This doesn't mean that it should stay this way, but it will help us track where the values are actually used.