### PR TITLE
Extracted code from `BaseEditEngine.HandleKeyDown()` into several smaller methods, and reduced nesting levels in a lambda

### DIFF
--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -465,32 +465,27 @@ public abstract class BaseEditEngine
 				return true;
 			case Gdk.Key.Return:
 			case Gdk.Key.KP_Enter:
-				//Finalize every editable shape not yet finalized.
 				FinalizeAllShapes ();
 				return true;
 			case Gdk.Key.space:
 				HandleSpace (e);
 				return true;
 			case Gdk.Key.Up:
-				//Make sure a control point is selected.
 				HandleUp ();
 				return true;
 			case Gdk.Key.Down:
-				//Make sure a control point is selected.
 				HandleDown ();
 				return true;
 			case Gdk.Key.Left:
-				//Make sure a control point is selected.
 				HandleLeft (e);
 				return true;
 			case Gdk.Key.Right:
-				//Make sure a control point is selected.
 				HandleRight (e);
 				return true;
 			default:
 				if (keyPressed.IsControlKey ()) {
 					// Redraw since the Ctrl key affects the hover cursor, etc
-					HandleControls (e);
+					DrawActiveShape (false, false, true, e.IsShiftPressed, false, true);
 					return true;
 				}
 				break;
@@ -498,13 +493,10 @@ public abstract class BaseEditEngine
 		return false;
 	}
 
-	private void HandleControls (ToolKeyEventArgs e)
-	{
-		DrawActiveShape (false, false, true, e.IsShiftPressed, false, true);
-	}
-
 	private void HandleRight (ToolKeyEventArgs e)
 	{
+		//Make sure a control point is selected.
+
 		if (SelectedPointIndex < 0)
 			return;
 
@@ -531,6 +523,8 @@ public abstract class BaseEditEngine
 
 	private void HandleLeft (ToolKeyEventArgs e)
 	{
+		//Make sure a control point is selected.
+
 		if (SelectedPointIndex < 0)
 			return;
 
@@ -557,6 +551,8 @@ public abstract class BaseEditEngine
 
 	private void HandleDown ()
 	{
+		//Make sure a control point is selected.
+
 		if (SelectedPointIndex < 0)
 			return;
 
@@ -569,6 +565,8 @@ public abstract class BaseEditEngine
 
 	private void HandleUp ()
 	{
+		//Make sure a control point is selected.
+
 		if (SelectedPointIndex < 0)
 			return;
 
@@ -1304,6 +1302,8 @@ public abstract class BaseEditEngine
 	/// </summary>
 	protected void FinalizeAllShapes ()
 	{
+		//Finalize every editable shape not yet finalized.
+
 		if (SEngines.Count == 0)
 			return;
 


### PR DESCRIPTION
Also, I haven't done it so far, but I've seen places in the code that would benefit from the occasional, carefully-placed `goto` inside small methods. I would like to know what you think about it... It feels weird to even ask 😅 but I don't say it lightly.

Understandably, you might want an example, so consider what happens it we turned...

```csharp
private void HandleRight (ToolKeyEventArgs e)
{
	if (SelectedPointIndex < 0)
		return;

	if (e.IsControlPressed) {
		//Change the selected control point to be the following one.

		ShapeEngine? activeEngine = ActiveShapeEngine;

		if (activeEngine != null) {
			++SelectedPointIndex;

			if (SelectedPointIndex > activeEngine.ControlPoints.Count - 1) {
				SelectedPointIndex = 0;
			}
		}
	} else {
		//Move the selected control point.
		var originalPosition = SelectedPoint!.Position; // NRT - Checked by SelectedPointIndex
		SelectedPoint.Position = originalPosition with { X = originalPosition.X + 1d };
	}

	DrawActiveShape (true, false, true, false, false);
}
```

...into this:

```csharp
private void HandleRight (ToolKeyEventArgs e)
{
	if (SelectedPointIndex < 0)
		return;

	if (!e.IsControlPressed) {
		//Move the selected control point.
		var originalPosition = SelectedPoint!.Position; // NRT - Checked by SelectedPointIndex
		SelectedPoint.Position = originalPosition with { X = originalPosition.X + 1d };
		goto PerformDraw;
	}

	//Change the selected control point to be the following one.

	ShapeEngine? activeEngine = ActiveShapeEngine;

	if (activeEngine == null)
		goto PerformDraw;

	++SelectedPointIndex;

	if (SelectedPointIndex < activeEngine.ControlPoints.Count)
		goto PerformDraw;

	SelectedPointIndex = 0;

PerformDraw:
	DrawActiveShape (true, false, true, false, false);
}
```

In these kinds of procedural code, an operation should be performed at the very end of the method no matter what. As for the body before the operation, it encodes a very simple pattern, namely a sequence of state changes that must happen before the operation is ready to start. The `goto` would then mean "the changes stop here, let's proceed to the operation". I don't think it would be too bad, as the required way of thinking is procedural anyway. Another possibility would be extracting the logic for the state changes into its own methods, but then the programmer would have to jump around the code instead of having everything in a single place, not to mention that this doesn't really apply when the changes happen on local variables, _unless_ we use `ref` parameters or things of the sort; in other words, an unholy mess.

Or if you still don't like the `goto` solution, then how about this (which doesn't always apply!)?

```csharp
private void HandleRight (ToolKeyEventArgs e)
{
	if (SelectedPointIndex < 0)
		return;
	
	if (e.IsControlPressed)
		ChangePointToFollowing();
	else
		MovePoint();
	
	DrawActiveShape (true, false, true, false, false);
}
```