### PR TITLE
Added `-` and `+` operators to `PointI` and `PointD`

### DIFF
--- a/Pinta.Core/Classes/Point.cs
+++ b/Pinta.Core/Classes/Point.cs
@@ -39,6 +39,18 @@ public readonly record struct PointI (int X, int Y)
 		double y = Y;
 		return Math.Sqrt (x * x + y * y);
 	}
+
+	public static PointI operator + (PointI left, PointI right)
+		=> new (
+			X: left.X + right.X,
+			Y: left.Y + right.Y
+		);
+
+	public static PointI operator - (PointI left, PointI right)
+		=> new (
+			X: left.X - right.X,
+			Y: left.Y - right.Y
+		);
 }
 
 public readonly record struct PointD (double X, double Y)
@@ -59,6 +71,18 @@ public readonly record struct PointD (double X, double Y)
 	public static PointD operator + (in PointD a, in PointD b) => new (a.X + b.X, a.Y + b.Y);
 
 	public static explicit operator PointD (PointI p) => new (p.X, p.Y);
+
+	public static PointD operator + (PointD left, PointD right)
+	=> new (
+		X: left.X + right.X,
+		Y: left.Y + right.Y
+	);
+
+	public static PointD operator - (PointD left, PointD right)
+		=> new (
+			X: left.X - right.X,
+			Y: left.Y - right.Y
+		);
 }
 
 public readonly record struct Size (int Width, int Height)


### PR DESCRIPTION
The point to the right side of the operator is treated as a vector of sorts.

One idea I have is passing `PointI` to the various `OnMouseMove` methods, although I wonder if it's a good idea, given that classes like `BasePaintBrush` are marked with the attribute `Mono.Addins.TypeExtensionPoint`. I know that there's a project (Pinta-Community-Addins) that encourages Pinta add-in to register their add-ins there, but would that breaking change be worth it?

If the above is not a viable option, feel free to just close this pull request.