### PR TITLE
Replaced `DllImportAttribute` with `LibraryImportAttribute` in order to generate P/Invoke marshalling code at compile time

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -67,7 +67,7 @@ namespace Cairo
 
 namespace Pinta.Core
 {
-	public static class CairoExtensions
+	public static partial class CairoExtensions
 	{
 		private const string CairoLibraryName = "cairo-graphics";
 
@@ -1103,20 +1103,20 @@ namespace Pinta.Core
 			public readonly RectangleI ToRectangleI () => new (X, Y, Width, Height);
 		}
 
-		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_create_rectangle")]
-		private static extern Cairo.Internal.RegionOwnedHandle RegionCreateRectangle (ref CairoRectangleInt rect);
+		[LibraryImport (CairoLibraryName, EntryPoint = "cairo_region_create_rectangle")]
+		private static partial Cairo.Internal.RegionOwnedHandle RegionCreateRectangle (ref CairoRectangleInt rect);
 
 		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_contains_point")]
 		private static extern bool RegionContainsPoint (Cairo.Internal.RegionHandle handle, int x, int y);
 
-		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_xor")]
-		private static extern Status RegionXor (Cairo.Internal.RegionHandle handle, Cairo.Internal.RegionHandle other);
+		[LibraryImport (CairoLibraryName, EntryPoint = "cairo_region_xor")]
+		private static partial Status RegionXor (Cairo.Internal.RegionHandle handle, Cairo.Internal.RegionHandle other);
 
-		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_num_rectangles")]
-		private static extern int RegionNumRectangles (Cairo.Internal.RegionHandle handle);
+		[LibraryImport (CairoLibraryName, EntryPoint = "cairo_region_num_rectangles")]
+		private static partial int RegionNumRectangles (Cairo.Internal.RegionHandle handle);
 
-		[DllImport (CairoLibraryName, EntryPoint = "cairo_region_get_rectangle")]
-		private static extern int RegionGetRectangle (Cairo.Internal.RegionHandle handle, int i, out CairoRectangleInt rect);
+		[LibraryImport (CairoLibraryName, EntryPoint = "cairo_region_get_rectangle")]
+		private static partial int RegionGetRectangle (Cairo.Internal.RegionHandle handle, int i, out CairoRectangleInt rect);
 
 		public static Region CreateRegion (in RectangleI rect)
 		{

--- a/Pinta.Core/Extensions/GdkPixbufExtensions.cs
+++ b/Pinta.Core/Extensions/GdkPixbufExtensions.cs
@@ -30,7 +30,7 @@ using GdkPixbuf;
 
 namespace Pinta.Core;
 
-public static class GdkPixbufExtensions
+public static partial class GdkPixbufExtensions
 {
 	private const string PixbufLibraryName = "GdkPixbuf";
 
@@ -91,11 +91,11 @@ public static class GdkPixbufExtensions
 		return GLib.Internal.StringHelper.ToStringArrayUtf8 (resultNative);
 	}
 
-	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_format_get_mime_types")]
-	private static extern IntPtr GetMimeTypes (GdkPixbuf.Internal.PixbufFormatHandle format);
+	[LibraryImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_format_get_mime_types")]
+	private static partial IntPtr GetMimeTypes (GdkPixbuf.Internal.PixbufFormatHandle format);
 
-	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_get_formats")]
-	private static extern GLib.Internal.SListUnownedHandle GetFormatsNative ();
+	[LibraryImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_get_formats")]
+	private static partial GLib.Internal.SListUnownedHandle GetFormatsNative ();
 
 	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_save_to_bufferv")]
 	private static extern bool SaveToBufferv (IntPtr pixbuf, out IntPtr buffer, out uint buffer_size, [MarshalAs (UnmanagedType.LPUTF8Str)] string type, IntPtr option_keys, IntPtr option_values, out GLib.Internal.ErrorOwnedHandle error);

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -57,7 +57,7 @@ public static class AdwaitaStyles
 	public const string Warning = "warning";
 };
 
-public static class GtkExtensions
+public static partial class GtkExtensions
 {
 	private const string GtkLibraryName = "Gtk";
 
@@ -424,8 +424,8 @@ public static class GtkExtensions
 		color = new Cairo.Color (gdk_color.Red, gdk_color.Green, gdk_color.Blue, gdk_color.Alpha);
 	}
 
-	[DllImport (GtkLibraryName, EntryPoint = "gtk_style_context_get_color")]
-	private static extern void StyleContextGetColor (IntPtr handle, out GdkRGBA color);
+	[LibraryImport (GtkLibraryName, EntryPoint = "gtk_style_context_get_color")]
+	private static partial void StyleContextGetColor (IntPtr handle, out GdkRGBA color);
 
 	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
 	public static void SetColor (this Gtk.ColorChooserDialog dialog, Cairo.Color color)
@@ -438,8 +438,8 @@ public static class GtkExtensions
 		});
 	}
 
-	[DllImport (GtkLibraryName, EntryPoint = "gtk_color_chooser_set_rgba")]
-	private static extern void ColorChooserSetRgba (IntPtr handle, GdkRGBA color);
+	[LibraryImport (GtkLibraryName, EntryPoint = "gtk_color_chooser_set_rgba")]
+	private static partial void ColorChooserSetRgba (IntPtr handle, GdkRGBA color);
 
 	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
 	public static void GetColor (this Gtk.ColorChooserDialog dialog, out Cairo.Color color)
@@ -448,8 +448,8 @@ public static class GtkExtensions
 		color = new Cairo.Color (gdk_color.Red, gdk_color.Green, gdk_color.Blue, gdk_color.Alpha);
 	}
 
-	[DllImport (GtkLibraryName, EntryPoint = "gtk_color_chooser_get_rgba")]
-	private static extern void ColorChooserGetRgba (IntPtr handle, out GdkRGBA color);
+	[LibraryImport (GtkLibraryName, EntryPoint = "gtk_color_chooser_get_rgba")]
+	private static partial void ColorChooserGetRgba (IntPtr handle, out GdkRGBA color);
 
 	private static readonly Signal<Entry> EntryChangedSignal = new (
 	    unmanagedName: "changed",

--- a/Pinta.Core/Extensions/PangoExtensions.cs
+++ b/Pinta.Core/Extensions/PangoExtensions.cs
@@ -31,7 +31,7 @@ using Pango;
 namespace Pinta.Core;
 
 // TODO-GTK4 - these need a proper binding in gir.core
-public static class PangoExtensions
+public static partial class PangoExtensions
 {
 	private const string PangoLibraryName = "Pango";
 
@@ -69,8 +69,8 @@ public static class PangoExtensions
 		weak_pos = weak_pos_pango.ToRectangleI ();
 	}
 
-	[DllImport (PangoLibraryName, EntryPoint = "pango_layout_get_cursor_pos")]
-	private static extern void InternalGetCursorPos (IntPtr layout, int index, out PangoRectangle strong_pos, out PangoRectangle weak_pos);
+	[LibraryImport (PangoLibraryName, EntryPoint = "pango_layout_get_cursor_pos")]
+	private static partial void InternalGetCursorPos (IntPtr layout, int index, out PangoRectangle strong_pos, out PangoRectangle weak_pos);
 
 	public static void GetPixelExtents (this Layout layout, out RectangleI ink_rect, out RectangleI logical_rect)
 	{
@@ -79,8 +79,8 @@ public static class PangoExtensions
 		logical_rect = logical_rect_pango.ToRectangleI ();
 	}
 
-	[DllImport (PangoLibraryName, EntryPoint = "pango_layout_get_pixel_extents")]
-	private static extern void InternalGetPixelExtents (IntPtr layout, out PangoRectangle ink_rect, out PangoRectangle logical_rect);
+	[LibraryImport (PangoLibraryName, EntryPoint = "pango_layout_get_pixel_extents")]
+	private static partial void InternalGetPixelExtents (IntPtr layout, out PangoRectangle ink_rect, out PangoRectangle logical_rect);
 
 	public static void IndexToPos (this Layout layout, int index, out RectangleI pos)
 	{
@@ -88,16 +88,16 @@ public static class PangoExtensions
 		pos = pos_pango.ToRectangleI ();
 	}
 
-	[DllImport (PangoLibraryName, EntryPoint = "pango_layout_index_to_pos")]
-	private static extern void InternalIndexToPos (IntPtr layout, int index, out PangoRectangle pos);
+	[LibraryImport (PangoLibraryName, EntryPoint = "pango_layout_index_to_pos")]
+	private static partial void InternalIndexToPos (IntPtr layout, int index, out PangoRectangle pos);
 
 	public static void XyToIndex (this Layout layout, int x, int y, out int index, out int trailing)
 	{
 		InternalXyToIndex (layout.Handle, x, y, out index, out trailing);
 	}
 
-	[DllImport (PangoLibraryName, EntryPoint = "pango_layout_xy_to_index")]
-	private static extern void InternalXyToIndex (IntPtr layout, int x, int y, out int index, out int trailing);
+	[LibraryImport (PangoLibraryName, EntryPoint = "pango_layout_xy_to_index")]
+	private static partial void InternalXyToIndex (IntPtr layout, int x, int y, out int index, out int trailing);
 
 	[StructLayout (LayoutKind.Sequential)]
 	private struct PangoRectangle

--- a/Pinta/MacInterop/AppleEvent.cs
+++ b/Pinta/MacInterop/AppleEvent.cs
@@ -29,46 +29,46 @@ using System.Runtime.InteropServices;
 
 namespace Pinta.MacInterop;
 
-internal static class AppleEvent
+internal static partial class AppleEvent
 {
 	const string AELib = Carbon.CarbonLib;
 
 	//FIXME: is "int" correct for size?
-	[DllImport (AELib)]
-	static extern AEDescStatus AECreateDesc (OSType typeCode, IntPtr dataPtr, int dataSize, out AEDesc desc);
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AECreateDesc (OSType typeCode, IntPtr dataPtr, int dataSize, out AEDesc desc);
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AECreateDesc (OSType typeCode, byte[] data, int dataSize, out AEDesc desc);
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AECreateDesc (OSType typeCode, byte[] data, int dataSize, out AEDesc desc);
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AEGetNthPtr (ref AEDesc descList, int index, OSType desiredType, uint keyword,
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AEGetNthPtr (ref AEDesc descList, int index, OSType desiredType, uint keyword,
 						out CarbonEventParameterType actualType, IntPtr buffer, int bufferSize, out int actualSize);
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AEGetNthPtr (ref AEDesc descList, int index, OSType desiredType, uint keyword,
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AEGetNthPtr (ref AEDesc descList, int index, OSType desiredType, uint keyword,
 						uint zero, IntPtr buffer, int bufferSize, int zero2);
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AECountItems (ref AEDesc descList, out int count); //return an OSErr
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AECountItems (ref AEDesc descList, out int count); //return an OSErr
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AEGetNthPtr (ref AEDesc descList, int index, OSType desiredType, uint keyword,
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AEGetNthPtr (ref AEDesc descList, int index, OSType desiredType, uint keyword,
 						uint zero, out IntPtr outPtr, int bufferSize, int zero2);
 
-	[DllImport (AELib)]
-	public static extern AEDescStatus AEDisposeDesc (ref AEDesc desc);
+	[LibraryImport (AELib)]
+	public static partial AEDescStatus AEDisposeDesc (ref AEDesc desc);
 
-	[DllImport (AELib)]
-	public static extern AEDescStatus AESizeOfNthItem (ref AEDesc descList, int index, ref OSType type, out int size);
+	[LibraryImport (AELib)]
+	public static partial AEDescStatus AESizeOfNthItem (ref AEDesc descList, int index, ref OSType type, out int size);
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AEGetDescData (ref AEDesc desc, IntPtr ptr, int maximumSize);
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AEGetDescData (ref AEDesc desc, IntPtr ptr, int maximumSize);
 
-	[DllImport (AELib)]
-	static extern int AEGetDescDataSize (ref AEDesc desc);
+	[LibraryImport (AELib)]
+	private static partial int AEGetDescDataSize (ref AEDesc desc);
 
-	[DllImport (AELib)]
-	static extern AEDescStatus AECoerceDesc (ref AEDesc theAEDesc, DescType toType, ref AEDesc result);
+	[LibraryImport (AELib)]
+	private static partial AEDescStatus AECoerceDesc (ref AEDesc theAEDesc, DescType toType, ref AEDesc result);
 
 	public static void AECreateDesc (OSType typeCode, byte[] data, out AEDesc result)
 	{

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -35,12 +35,12 @@ namespace Pinta.MacInterop;
 internal delegate CarbonEventHandlerStatus EventDelegate (IntPtr callRef, IntPtr eventRef, IntPtr userData);
 internal delegate CarbonEventHandlerStatus AEHandlerDelegate (IntPtr inEvnt, IntPtr outEvt, uint refConst);
 
-internal static class Carbon
+internal static partial class Carbon
 {
 	public const string CarbonLib = "/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon";
 
-	[DllImport (CarbonLib)]
-	static extern int Gestalt (int selector, out int result);
+	[LibraryImport (CarbonLib)]
+	private static partial int Gestalt (int selector, out int result);
 
 	public static int Gestalt (string selector)
 	{
@@ -50,32 +50,32 @@ internal static class Carbon
 		return result;
 	}
 
-	[DllImport (CarbonLib)]
-	public static extern IntPtr GetApplicationEventTarget ();
+	[LibraryImport (CarbonLib)]
+	public static partial IntPtr GetApplicationEventTarget ();
 
-	[DllImport (CarbonLib)]
-	public static extern IntPtr GetControlEventTarget (IntPtr control);
+	[LibraryImport (CarbonLib)]
+	public static partial IntPtr GetControlEventTarget (IntPtr control);
 
-	[DllImport (CarbonLib)]
-	public static extern IntPtr GetWindowEventTarget (IntPtr window);
+	[LibraryImport (CarbonLib)]
+	public static partial IntPtr GetWindowEventTarget (IntPtr window);
 
-	[DllImport (CarbonLib)]
-	public static extern IntPtr GetMenuEventTarget (IntPtr menu);
+	[LibraryImport (CarbonLib)]
+	public static partial IntPtr GetMenuEventTarget (IntPtr menu);
 
-	[DllImport (CarbonLib)]
-	public static extern CarbonEventClass GetEventClass (IntPtr eventref);
+	[LibraryImport (CarbonLib)]
+	public static partial CarbonEventClass GetEventClass (IntPtr eventref);
 
-	[DllImport (CarbonLib)]
-	public static extern uint GetEventKind (IntPtr eventref);
+	[LibraryImport (CarbonLib)]
+	public static partial uint GetEventKind (IntPtr eventref);
 
 	#region Event handler installation
 
-	[DllImport (CarbonLib)]
-	static extern EventStatus InstallEventHandler (IntPtr target, EventDelegate handler, uint count,
+	[LibraryImport (CarbonLib)]
+	private static partial EventStatus InstallEventHandler (IntPtr target, EventDelegate handler, uint count,
 						       CarbonEventTypeSpec[] types, IntPtr user_data, out IntPtr handlerRef);
 
-	[DllImport (CarbonLib)]
-	public static extern EventStatus RemoveEventHandler (IntPtr handlerRef);
+	[LibraryImport (CarbonLib)]
+	public static partial EventStatus RemoveEventHandler (IntPtr handlerRef);
 
 	public static IntPtr InstallEventHandler (IntPtr target, EventDelegate handler, CarbonEventTypeSpec[] types)
 	{
@@ -102,8 +102,8 @@ internal static class Carbon
 
 	#region Event parameter extraction
 
-	[DllImport (CarbonLib)]
-	public static extern EventStatus GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType,
+	[LibraryImport (CarbonLib)]
+	public static partial EventStatus GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType,
 							    out CarbonEventParameterType actualType, uint size, ref uint outSize, ref IntPtr outPtr);
 
 	public static IntPtr GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType)
@@ -114,12 +114,12 @@ internal static class Carbon
 		return val;
 	}
 
-	[DllImport (CarbonLib)]
-	static extern EventStatus GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType,
+	[LibraryImport (CarbonLib)]
+	private static partial EventStatus GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType,
 						     out CarbonEventParameterType actualType, uint size, ref uint outSize, IntPtr dataBuffer);
 
-	[DllImport (CarbonLib)]
-	static extern EventStatus GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType,
+	[LibraryImport (CarbonLib)]
+	private static partial EventStatus GetEventParameter (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType,
 						     uint zero, uint size, uint zero2, IntPtr dataBuffer);
 
 	public static T GetEventParameter<T> (IntPtr eventRef, CarbonEventParameterName name, CarbonEventParameterType desiredType) where T : struct
@@ -136,15 +136,15 @@ internal static class Carbon
 
 	#region Sending events
 
-	[DllImport (CarbonLib)]
-	static extern EventStatus SendEventToEventTarget (IntPtr eventRef, IntPtr eventTarget);
+	[LibraryImport (CarbonLib)]
+	private static partial EventStatus SendEventToEventTarget (IntPtr eventRef, IntPtr eventTarget);
 
-	[DllImport (CarbonLib)]
-	static extern EventStatus CreateEvent (IntPtr allocator, CarbonEventClass classID, uint kind, double eventTime,
+	[LibraryImport (CarbonLib)]
+	private static partial EventStatus CreateEvent (IntPtr allocator, CarbonEventClass classID, uint kind, double eventTime,
 					       CarbonEventAttributes flags, out IntPtr eventHandle);
 
-	[DllImport (CarbonLib)]
-	static extern void ReleaseEvent (IntPtr eventHandle);
+	[LibraryImport (CarbonLib)]
+	static partial void ReleaseEvent (IntPtr eventHandle);
 
 	static EventStatus SendApplicationEvent (CarbonEventClass classID, uint kind, CarbonEventAttributes flags)
 	{
@@ -156,8 +156,8 @@ internal static class Carbon
 		return s;
 	}
 
-	[DllImport (CarbonLib)]
-	public static extern CarbonEventHandlerStatus ProcessHICommand (ref CarbonHICommand command);
+	[LibraryImport (CarbonLib)]
+	public static partial CarbonEventHandlerStatus ProcessHICommand (ref CarbonHICommand command);
 
 	#endregion
 

--- a/Pinta/MacInterop/Carbon.cs
+++ b/Pinta/MacInterop/Carbon.cs
@@ -144,7 +144,7 @@ internal static partial class Carbon
 					       CarbonEventAttributes flags, out IntPtr eventHandle);
 
 	[LibraryImport (CarbonLib)]
-	static partial void ReleaseEvent (IntPtr eventHandle);
+	private static partial void ReleaseEvent (IntPtr eventHandle);
 
 	static EventStatus SendApplicationEvent (CarbonEventClass classID, uint kind, CarbonEventAttributes flags)
 	{

--- a/Pinta/MacInterop/CoreFoundation.cs
+++ b/Pinta/MacInterop/CoreFoundation.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 
 namespace Pinta.MacInterop;
 
-internal static class CoreFoundation
+internal static partial class CoreFoundation
 {
 	const string CFLib = "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation";
 	const string LSLib = "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices";
@@ -44,8 +44,8 @@ internal static class CoreFoundation
 		return CFStringCreateWithCString (IntPtr.Zero, s, 0x08000100);
 	}
 
-	[DllImport (CFLib, EntryPoint = "CFRelease")]
-	public static extern void Release (IntPtr cfRef);
+	[LibraryImport (CFLib, EntryPoint = "CFRelease")]
+	public static partial void Release (IntPtr cfRef);
 
 	struct CFRange
 	{
@@ -57,14 +57,14 @@ internal static class CoreFoundation
 		}
 	}
 
-	[DllImport (CFLib, CharSet = CharSet.Unicode)]
-	extern static int CFStringGetLength (IntPtr handle);
+	[LibraryImport (CFLib)]
+	private static partial int CFStringGetLength (IntPtr handle);
 
-	[DllImport (CFLib, CharSet = CharSet.Unicode)]
-	extern static IntPtr CFStringGetCharactersPtr (IntPtr handle);
+	[LibraryImport (CFLib)]
+	private static partial IntPtr CFStringGetCharactersPtr (IntPtr handle);
 
-	[DllImport (CFLib, CharSet = CharSet.Unicode)]
-	extern static IntPtr CFStringGetCharacters (IntPtr handle, CFRange range, IntPtr buffer);
+	[LibraryImport (CFLib)]
+	private static partial IntPtr CFStringGetCharacters (IntPtr handle, CFRange range, IntPtr buffer);
 
 	public static string? FetchString (IntPtr handle)
 	{
@@ -112,11 +112,11 @@ internal static class CoreFoundation
 		}
 	}
 
-	[DllImport (CFLib)]
-	extern static IntPtr CFURLCreateFromFSRef (IntPtr allocator, ref FSRef fsref);
+	[LibraryImport (CFLib)]
+	private static partial IntPtr CFURLCreateFromFSRef (IntPtr allocator, ref FSRef fsref);
 
-	[DllImport (CFLib)]
-	extern static IntPtr CFURLCopyFileSystemPath (IntPtr urlRef, CFUrlPathStyle pathStyle);
+	[LibraryImport (CFLib)]
+	private static partial IntPtr CFURLCopyFileSystemPath (IntPtr urlRef, CFUrlPathStyle pathStyle);
 
 	enum CFUrlPathStyle
 	{
@@ -129,18 +129,18 @@ internal static class CoreFoundation
 	extern static IntPtr CFURLCreateWithFileSystemPath (IntPtr allocator, IntPtr filePathString,
 		CFUrlPathStyle pathStyle, bool isDirectory);
 
-	[DllImport (LSLib)]
-	extern static IntPtr LSCopyApplicationURLsForURL (IntPtr urlRef, LSRolesMask roleMask); //CFArrayRef
+	[LibraryImport (LSLib)]
+	private static partial IntPtr LSCopyApplicationURLsForURL (IntPtr urlRef, LSRolesMask roleMask); //CFArrayRef
 
-	[DllImport (LSLib)]
-	extern static int LSGetApplicationForURL (IntPtr url, LSRolesMask roleMask, IntPtr fsRefZero,
+	[LibraryImport (LSLib)]
+	private static partial int LSGetApplicationForURL (IntPtr url, LSRolesMask roleMask, IntPtr fsRefZero,
 		ref IntPtr appUrl);
 
-	[DllImport (CFLib)]
-	extern static int CFArrayGetCount (IntPtr theArray);
+	[LibraryImport (CFLib)]
+	private static partial int CFArrayGetCount (IntPtr theArray);
 
-	[DllImport (CFLib)]
-	extern static IntPtr CFArrayGetValueAtIndex (IntPtr theArray, int idx);
+	[LibraryImport (CFLib)]
+	private static partial IntPtr CFArrayGetValueAtIndex (IntPtr theArray, int idx);
 
 	[Flags]
 	public enum LSRolesMask : uint


### PR DESCRIPTION
Following suggestion of analyzer `SYSLIB1054`, specifically those methods that don't need charset information (those that do were left as is for now, with `DllImportAttribute`)

It works on my Ubuntu environment, so let's see if the GitHub actions work too