### PR TITLE
Creating `Angle` structure

### DIFF
--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace Pinta.Core.Classes;
+
+public readonly struct Angle
+{
+	public double Magnitude { get; }
+	public AngleUnit UnitType { get; }
+
+	private Angle (double magnitude, AngleUnit unitType)
+	{
+		Magnitude = magnitude;
+		UnitType = unitType;
+	}
+
+	private const double MAX_RADIANS = Math.PI * 2;
+	private const double MAX_DEGREES = 360;
+	private const double MAX_REVOLUTIONS = 1;
+
+	public static Angle Radians (double radians)
+	{
+		return radians switch {
+			>= 0 => new Angle (radians % MAX_RADIANS, AngleUnit.Radian),
+			_ => new Angle (MAX_RADIANS - (radians % MAX_RADIANS), AngleUnit.Radian)
+		};
+	}
+
+	public static Angle Degrees (double degrees)
+	{
+		return degrees switch {
+			>= 0 => new Angle (degrees % MAX_DEGREES, AngleUnit.Degree),
+			_ => new Angle (MAX_DEGREES - (degrees % MAX_DEGREES), AngleUnit.Radian)
+		};
+	}
+
+	public static Angle Revolutions (double revolutions)
+	{
+		return revolutions switch {
+			>= 0 => new Angle (revolutions % MAX_REVOLUTIONS, AngleUnit.Revolution),
+			_ => new Angle (MAX_REVOLUTIONS - (revolutions % MAX_REVOLUTIONS), AngleUnit.Revolution)
+		};
+	}
+
+	public static Angle operator + (Angle augend, Angle addend)
+	{
+		if (augend.UnitType == addend.UnitType) {
+			return new Angle (augend.Magnitude + addend.Magnitude, augend.UnitType);
+		} else {
+			var normalizedAddendMagnitude = ChangeUnit (addend.Magnitude, addend.UnitType, augend.UnitType);
+			return new Angle (augend.Magnitude + normalizedAddendMagnitude, augend.UnitType);
+		}
+	}
+
+	public static Angle operator - (Angle minuend, Angle subtrahend)
+	{
+		if (minuend.UnitType == subtrahend.UnitType) {
+			return new Angle (minuend.Magnitude + subtrahend.Magnitude, minuend.UnitType);
+		} else {
+			var normalizedSubtrahendMagnitude = ChangeUnit (subtrahend.Magnitude, subtrahend.UnitType, minuend.UnitType);
+			return new Angle (minuend.Magnitude - normalizedSubtrahendMagnitude, minuend.UnitType);
+		}
+	}
+
+	const double RADIANS_TO_DEGREES = 180d / Math.PI;
+	const double DEGREES_TO_RADIANS = Math.PI / 180d;
+
+	const double REVOLUTIONS_TO_RADIANS = Math.PI * 2d;
+	const double RADIANS_TO_REVOLUTIONS = 1d / (Math.PI * 2);
+
+	const double REVOLUTIONS_TO_DEGREES = 360d;
+	const double DEGREES_TO_REVOLUTIONS = 1d / 360d;
+
+	private static double ChangeUnit (double magnitude, AngleUnit originalUnit, AngleUnit destinationUnit)
+	{
+		return originalUnit switch {
+			AngleUnit.Radian => destinationUnit switch {
+				AngleUnit.Degree => magnitude * RADIANS_TO_DEGREES,
+				AngleUnit.Revolution => magnitude * RADIANS_TO_REVOLUTIONS,
+				AngleUnit.Radian => magnitude,
+				_ => throw new NotSupportedException ()
+			},
+			AngleUnit.Degree => destinationUnit switch {
+				AngleUnit.Radian => magnitude * DEGREES_TO_RADIANS,
+				AngleUnit.Revolution => magnitude * DEGREES_TO_REVOLUTIONS,
+				AngleUnit.Degree => magnitude,
+				_ => throw new NotSupportedException ()
+			},
+			AngleUnit.Revolution => destinationUnit switch {
+				AngleUnit.Radian => magnitude * REVOLUTIONS_TO_RADIANS,
+				AngleUnit.Degree => magnitude * REVOLUTIONS_TO_DEGREES,
+				AngleUnit.Revolution => magnitude,
+				_ => throw new NotSupportedException ()
+			},
+			_ => throw new NotSupportedException (),
+		};
+	}
+}
+
+public enum AngleUnit
+{
+	Radian,
+	Degree,
+	Revolution,
+}

--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -12,7 +12,7 @@ public readonly struct RadiansAngle
 		Radians = radians switch {
 			0 => 0,
 			>= 0 => radians % MAX_RADIANS,
-			_ => MAX_RADIANS + (radians % MAX_RADIANS)
+			_ => (MAX_RADIANS + (radians % MAX_RADIANS)) % MAX_RADIANS
 		};
 	}
 
@@ -36,7 +36,7 @@ public readonly struct DegreesAngle
 		Degrees = degrees switch {
 			0 => 0,
 			>= 0 => degrees % MAX_DEGREES,
-			_ => MAX_DEGREES + (degrees % MAX_DEGREES)
+			_ => (MAX_DEGREES + (degrees % MAX_DEGREES)) % MAX_DEGREES
 		};
 	}
 
@@ -60,7 +60,7 @@ public readonly struct RevolutionsAngle
 		Revolutions = revolutions switch {
 			0 => 0,
 			>= 0 => revolutions % MAX_REVOLUTIONS,
-			_ => MAX_REVOLUTIONS + (revolutions % MAX_REVOLUTIONS)
+			_ => (MAX_REVOLUTIONS + (revolutions % MAX_REVOLUTIONS)) % MAX_REVOLUTIONS
 		};
 	}
 

--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -2,101 +2,74 @@ using System;
 
 namespace Pinta.Core.Classes;
 
-public readonly struct Angle
+public readonly struct RadiansAngle
 {
-	public double Magnitude { get; }
-	public AngleUnit UnitType { get; }
-
-	private Angle (double magnitude, AngleUnit unitType)
-	{
-		Magnitude = magnitude;
-		UnitType = unitType;
-	}
-
 	private const double MAX_RADIANS = Math.PI * 2;
-	private const double MAX_DEGREES = 360;
-	private const double MAX_REVOLUTIONS = 1;
+	public double Radians { get; }
 
-	public static Angle Radians (double radians)
+	public RadiansAngle (double radians)
 	{
-		return radians switch {
-			>= 0 => new Angle (radians % MAX_RADIANS, AngleUnit.Radian),
-			_ => new Angle (MAX_RADIANS - (radians % MAX_RADIANS), AngleUnit.Radian)
+		Radians = radians switch {
+			0 => 0,
+			>= 0 => radians % MAX_RADIANS,
+			_ => MAX_RADIANS + (radians % MAX_RADIANS)
 		};
-	}
-
-	public static Angle Degrees (double degrees)
-	{
-		return degrees switch {
-			>= 0 => new Angle (degrees % MAX_DEGREES, AngleUnit.Degree),
-			_ => new Angle (MAX_DEGREES - (degrees % MAX_DEGREES), AngleUnit.Degree)
-		};
-	}
-
-	public static Angle Revolutions (double revolutions)
-	{
-		return revolutions switch {
-			>= 0 => new Angle (revolutions % MAX_REVOLUTIONS, AngleUnit.Revolution),
-			_ => new Angle (MAX_REVOLUTIONS - (revolutions % MAX_REVOLUTIONS), AngleUnit.Revolution)
-		};
-	}
-
-	public static Angle operator + (Angle augend, Angle addend)
-	{
-		if (augend.UnitType == addend.UnitType) {
-			return new Angle (augend.Magnitude + addend.Magnitude, augend.UnitType);
-		} else {
-			var normalizedAddendMagnitude = ChangeUnit (addend.Magnitude, addend.UnitType, augend.UnitType);
-			return new Angle (augend.Magnitude + normalizedAddendMagnitude, augend.UnitType);
-		}
-	}
-
-	public static Angle operator - (Angle minuend, Angle subtrahend)
-	{
-		if (minuend.UnitType == subtrahend.UnitType) {
-			return new Angle (minuend.Magnitude - subtrahend.Magnitude, minuend.UnitType);
-		} else {
-			var normalizedSubtrahendMagnitude = ChangeUnit (subtrahend.Magnitude, subtrahend.UnitType, minuend.UnitType);
-			return new Angle (minuend.Magnitude - normalizedSubtrahendMagnitude, minuend.UnitType);
-		}
 	}
 
 	const double RADIANS_TO_DEGREES = 180d / Math.PI;
-	const double DEGREES_TO_RADIANS = Math.PI / 180d;
-
-	const double REVOLUTIONS_TO_RADIANS = Math.PI * 2d;
 	const double RADIANS_TO_REVOLUTIONS = 1d / (Math.PI * 2);
 
-	const double REVOLUTIONS_TO_DEGREES = 360d;
-	const double DEGREES_TO_REVOLUTIONS = 1d / 360d;
+	public DegreesAngle ToDegrees () => new (Radians * RADIANS_TO_DEGREES);
+	public RevolutionsAngle ToRevolutions () => new (Radians * RADIANS_TO_REVOLUTIONS);
 
-	private static double ChangeUnit (double magnitude, AngleUnit originalUnit, AngleUnit destinationUnit)
-	{
-		if (originalUnit == destinationUnit) return magnitude;
-		return originalUnit switch {
-			AngleUnit.Radian => destinationUnit switch {
-				AngleUnit.Degree => magnitude * RADIANS_TO_DEGREES,
-				AngleUnit.Revolution => magnitude * RADIANS_TO_REVOLUTIONS,
-				_ => throw new NotSupportedException ()
-			},
-			AngleUnit.Degree => destinationUnit switch {
-				AngleUnit.Radian => magnitude * DEGREES_TO_RADIANS,
-				AngleUnit.Revolution => magnitude * DEGREES_TO_REVOLUTIONS,
-				_ => throw new NotSupportedException ()
-			},
-			AngleUnit.Revolution => destinationUnit switch {
-				AngleUnit.Radian => magnitude * REVOLUTIONS_TO_RADIANS,
-				AngleUnit.Degree => magnitude * REVOLUTIONS_TO_DEGREES,
-				_ => throw new NotSupportedException ()
-			},
-			_ => throw new NotSupportedException (),
-		};
-	}
+	public static RadiansAngle operator + (RadiansAngle a, RadiansAngle b) => new (a.Radians + b.Radians);
+	public static RadiansAngle operator - (RadiansAngle a, RadiansAngle b) => new (a.Radians - b.Radians);
 }
 
-public enum AngleUnit
+public readonly struct DegreesAngle
 {
-	Radian,
-	Degree,
-	Revolution,
+	private const double MAX_DEGREES = 360;
+	public double Degrees { get; }
+
+	public DegreesAngle (double degrees)
+	{
+		Degrees = degrees switch {
+			0 => 0,
+			>= 0 => degrees % MAX_DEGREES,
+			_ => MAX_DEGREES + (degrees % MAX_DEGREES)
+		};
+	}
+
+	const double DEGREES_TO_RADIANS = Math.PI / 180d;
+	const double DEGREES_TO_REVOLUTIONS = 1d / 360d;
+
+	public RadiansAngle ToRadians () => new (Degrees * DEGREES_TO_RADIANS);
+	public RevolutionsAngle ToRevolutions () => new (Degrees * DEGREES_TO_REVOLUTIONS);
+
+	public static DegreesAngle operator + (DegreesAngle a, DegreesAngle b) => new (a.Degrees + b.Degrees);
+	public static DegreesAngle operator - (DegreesAngle a, DegreesAngle b) => new (a.Degrees - b.Degrees);
+}
+
+public readonly struct RevolutionsAngle
+{
+	private const double MAX_REVOLUTIONS = 1;
+	public double Revolutions { get; }
+
+	public RevolutionsAngle (double revolutions)
+	{
+		Revolutions = revolutions switch {
+			0 => 0,
+			>= 0 => revolutions % MAX_REVOLUTIONS,
+			_ => MAX_REVOLUTIONS + (revolutions % MAX_REVOLUTIONS)
+		};
+	}
+
+	const double REVOLUTIONS_TO_RADIANS = Math.PI * 2d;
+	const double REVOLUTIONS_TO_DEGREES = 360d;
+
+	public RadiansAngle ToRadians () => new (Revolutions * REVOLUTIONS_TO_RADIANS);
+	public DegreesAngle ToDegrees () => new (Revolutions * REVOLUTIONS_TO_DEGREES);
+
+	public static RevolutionsAngle operator + (RevolutionsAngle a, RevolutionsAngle b) => new (a.Revolutions + b.Revolutions);
+	public static RevolutionsAngle operator - (RevolutionsAngle a, RevolutionsAngle b) => new (a.Revolutions - b.Revolutions);
 }

--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -29,7 +29,7 @@ public readonly struct Angle
 	{
 		return degrees switch {
 			>= 0 => new Angle (degrees % MAX_DEGREES, AngleUnit.Degree),
-			_ => new Angle (MAX_DEGREES - (degrees % MAX_DEGREES), AngleUnit.Radian)
+			_ => new Angle (MAX_DEGREES - (degrees % MAX_DEGREES), AngleUnit.Degree)
 		};
 	}
 
@@ -54,7 +54,7 @@ public readonly struct Angle
 	public static Angle operator - (Angle minuend, Angle subtrahend)
 	{
 		if (minuend.UnitType == subtrahend.UnitType) {
-			return new Angle (minuend.Magnitude + subtrahend.Magnitude, minuend.UnitType);
+			return new Angle (minuend.Magnitude - subtrahend.Magnitude, minuend.UnitType);
 		} else {
 			var normalizedSubtrahendMagnitude = ChangeUnit (subtrahend.Magnitude, subtrahend.UnitType, minuend.UnitType);
 			return new Angle (minuend.Magnitude - normalizedSubtrahendMagnitude, minuend.UnitType);
@@ -72,23 +72,21 @@ public readonly struct Angle
 
 	private static double ChangeUnit (double magnitude, AngleUnit originalUnit, AngleUnit destinationUnit)
 	{
+		if (originalUnit == destinationUnit) return magnitude;
 		return originalUnit switch {
 			AngleUnit.Radian => destinationUnit switch {
 				AngleUnit.Degree => magnitude * RADIANS_TO_DEGREES,
 				AngleUnit.Revolution => magnitude * RADIANS_TO_REVOLUTIONS,
-				AngleUnit.Radian => magnitude,
 				_ => throw new NotSupportedException ()
 			},
 			AngleUnit.Degree => destinationUnit switch {
 				AngleUnit.Radian => magnitude * DEGREES_TO_RADIANS,
 				AngleUnit.Revolution => magnitude * DEGREES_TO_REVOLUTIONS,
-				AngleUnit.Degree => magnitude,
 				_ => throw new NotSupportedException ()
 			},
 			AngleUnit.Revolution => destinationUnit switch {
 				AngleUnit.Radian => magnitude * REVOLUTIONS_TO_RADIANS,
 				AngleUnit.Degree => magnitude * REVOLUTIONS_TO_DEGREES,
-				AngleUnit.Revolution => magnitude,
 				_ => throw new NotSupportedException ()
 			},
 			_ => throw new NotSupportedException (),

--- a/tests/Pinta.Core.Tests/AngleTest.cs
+++ b/tests/Pinta.Core.Tests/AngleTest.cs
@@ -119,4 +119,76 @@ internal sealed class AngleTest
 		var result = left - right;
 		Assert.AreEqual (result.Revolutions, expectedResult);
 	}
+
+	[TestCase (0d, 0d)]
+	[TestCase (Math.PI * 0.5d, 90d)]
+	[TestCase (Math.PI, 180d)]
+	[TestCase (Math.PI * 1.5d, 270d)]
+	[TestCase (-Math.PI, 180d)]
+	public void Radians_To_Degrees (double radians, double expectedDegrees)
+	{
+		RadiansAngle radiansAngle = new (radians);
+		DegreesAngle degreesAngle = radiansAngle.ToDegrees ();
+		Assert.AreEqual (degreesAngle.Degrees, expectedDegrees);
+	}
+
+	[TestCase (0d, 0d)]
+	[TestCase (Math.PI * 0.5d, 0.25d)]
+	[TestCase (Math.PI, 0.5d)]
+	[TestCase (Math.PI * 1.5d, 0.75d)]
+	[TestCase (-Math.PI, 0.5d)]
+	public void Radians_To_Revolutions (double radians, double expectedRevolutions)
+	{
+		RadiansAngle radiansAngle = new (radians);
+		RevolutionsAngle revolutionsAngle = radiansAngle.ToRevolutions ();
+		Assert.AreEqual (revolutionsAngle.Revolutions, expectedRevolutions);
+	}
+
+	[TestCase (0d, 0d)]
+	[TestCase (90d, Math.PI * 0.5d)]
+	[TestCase (180d, Math.PI)]
+	[TestCase (270d, Math.PI * 1.5d)]
+	[TestCase (-180d, Math.PI)]
+	public void Degrees_To_Radians (double degrees, double expectedRadians)
+	{
+		DegreesAngle degreesAngle = new (degrees);
+		RadiansAngle radiansAngle = degreesAngle.ToRadians ();
+		Assert.AreEqual (radiansAngle.Radians, expectedRadians);
+	}
+
+	[TestCase (0d, 0d)]
+	[TestCase (90d, 0.25d)]
+	[TestCase (180d, 0.5d)]
+	[TestCase (270d, 0.75d)]
+	[TestCase (-180d, 0.5)]
+	public void Degrees_To_Revolutions (double degrees, double expectedRevolutions)
+	{
+		DegreesAngle degreesAngle = new (degrees);
+		RevolutionsAngle revolutionsAngle = degreesAngle.ToRevolutions ();
+		Assert.AreEqual (revolutionsAngle.Revolutions, expectedRevolutions);
+	}
+
+	[TestCase (0d, 0d)]
+	[TestCase (0.25d, Math.PI * 0.5d)]
+	[TestCase (0.5d, Math.PI)]
+	[TestCase (0.75d, Math.PI * 1.5d)]
+	[TestCase (-0.5d, Math.PI)]
+	public void Revolutions_To_Radians (double revolutions, double expectedRadians)
+	{
+		RevolutionsAngle revolutionsAngle = new (revolutions);
+		RadiansAngle radiansAngle = revolutionsAngle.ToRadians ();
+		Assert.AreEqual (radiansAngle.Radians, expectedRadians);
+	}
+
+	[TestCase (0d, 0d)]
+	[TestCase (0.25d, 90d)]
+	[TestCase (0.5d, 180d)]
+	[TestCase (0.75d, 270d)]
+	[TestCase (-0.5, 180d)]
+	public void Revolutions_To_Degrees (double revolutions, double expectedDegrees)
+	{
+		RevolutionsAngle revolutionsAngle = new (revolutions);
+		DegreesAngle degreesAngle = revolutionsAngle.ToDegrees ();
+		Assert.AreEqual (degreesAngle.Degrees, expectedDegrees);
+	}
 }

--- a/tests/Pinta.Core.Tests/AngleTest.cs
+++ b/tests/Pinta.Core.Tests/AngleTest.cs
@@ -1,0 +1,122 @@
+using System;
+using NUnit.Framework;
+using Pinta.Core.Classes;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class AngleTest
+{
+	[TestCase (1d, 1d)]
+	[TestCase (Math.PI, Math.PI)]
+	[TestCase (Math.PI * 2d, 0d)]
+	[TestCase (-Math.PI, Math.PI)]
+	[TestCase (-(Math.PI * 2d), 0d)]
+	[TestCase (0d, 0d)]
+	public void RadiansAngle_Creation (double constructorArgument, double expectedPropertyValue)
+	{
+		RadiansAngle angle = new (constructorArgument);
+		Assert.AreEqual (angle.Radians, expectedPropertyValue);
+	}
+
+	[TestCase (1d, 1d)]
+	[TestCase (180d, 180d)]
+	[TestCase (360d, 0)]
+	[TestCase (-180d, 180d)]
+	[TestCase (-360d, 0d)]
+	[TestCase (0d, 0d)]
+	public void DegreesAngle_Creation (double constructorArgument, double expectedPropertyValue)
+	{
+		DegreesAngle angle = new (constructorArgument);
+		Assert.AreEqual (angle.Degrees, expectedPropertyValue);
+	}
+
+	[TestCase (0.5d, 0.5d)]
+	[TestCase (1d, 0d)]
+	[TestCase (-0.5d, 0.5d)]
+	[TestCase (-1d, 0d)]
+	[TestCase (0d, 0d)]
+	public void RevolutionsAngle_Creation (double constructorArgument, double expectedPropertyValue)
+	{
+		RevolutionsAngle angle = new (constructorArgument);
+		Assert.AreEqual (angle.Revolutions, expectedPropertyValue);
+	}
+
+	[TestCase (1d, 1d, 2d)]
+	[TestCase (Math.PI, Math.PI, 0)]
+	[TestCase (Math.PI * 1.5d, Math.PI * 1.5d, Math.PI)]
+	[TestCase (0d, 0d, 0d)]
+	[TestCase (Math.PI * 2d, Math.PI * 2d, 0d)]
+	[TestCase (-Math.PI, Math.PI * 2d, Math.PI)]
+	public void RadiansAngle_Addition (double leftArgument, double rightArgument, double expectedResult)
+	{
+		RadiansAngle left = new (leftArgument);
+		RadiansAngle right = new (rightArgument);
+		var result = left + right;
+		Assert.AreEqual (result.Radians, expectedResult);
+	}
+
+	[TestCase (1d, 1d, 2d)]
+	[TestCase (180d, 180d, 0d)]
+	[TestCase (270d, 270d, 180d)]
+	[TestCase (0d, 0d, 0d)]
+	[TestCase (360d, 360d, 0d)]
+	[TestCase (-180d, 360d, 180d)]
+	public void DegreesAngle_Addition (double leftArgument, double rightArgument, double expectedResult)
+	{
+		DegreesAngle left = new (leftArgument);
+		DegreesAngle right = new (rightArgument);
+		var result = left + right;
+		Assert.AreEqual (result.Degrees, expectedResult);
+	}
+
+	[TestCase (0.125d, 0.125d, 0.25d)]
+	[TestCase (0.5d, 0.5d, 0d)]
+	[TestCase (0.75d, 0.75d, 0.5d)]
+	[TestCase (0d, 0d, 0d)]
+	[TestCase (1d, 1d, 0d)]
+	[TestCase (-0.5d, 1d, 0.5d)]
+	public void RevolutionsAngle_Addition (double leftArgument, double rightArgument, double expectedResult)
+	{
+		RevolutionsAngle left = new (leftArgument);
+		RevolutionsAngle right = new (rightArgument);
+		var result = left + right;
+		Assert.AreEqual (result.Revolutions, expectedResult);
+	}
+
+	[TestCase (Math.PI * 0.5, Math.PI, Math.PI * 1.5)]
+	[TestCase (0d, Math.PI, Math.PI)]
+	[TestCase (0d, Math.PI * 2, 0d)]
+	[TestCase (Math.PI, Math.PI * 0.5, Math.PI * 0.5)]
+	public void RadiansAngle_Subtraction (double leftArgument, double rightArgument, double expectedResult)
+	{
+		RadiansAngle left = new (leftArgument);
+		RadiansAngle right = new (rightArgument);
+		var result = left - right;
+		Assert.AreEqual (result.Radians, expectedResult);
+	}
+
+	[TestCase (90d, 180d, 270d)]
+	[TestCase (0d, 180d, 180d)]
+	[TestCase (0d, 360d, 0d)]
+	[TestCase (180d, 90d, 90d)]
+	public void DegreesAngle_Subtraction (double leftArgument, double rightArgument, double expectedResult)
+	{
+		DegreesAngle left = new (leftArgument);
+		DegreesAngle right = new (rightArgument);
+		var result = left - right;
+		Assert.AreEqual (result.Degrees, expectedResult);
+	}
+
+	[TestCase (0.25d, 0.5d, 0.75d)]
+	[TestCase (0d, 0.5d, 0.5d)]
+	[TestCase (0d, 1d, 0d)]
+	[TestCase (0.5d, 0.25d, 0.25d)]
+	public void RevolutionsAngle_Subtraction (double leftArgument, double rightArgument, double expectedResult)
+	{
+		RevolutionsAngle left = new (leftArgument);
+		RevolutionsAngle right = new (rightArgument);
+		var result = left - right;
+		Assert.AreEqual (result.Revolutions, expectedResult);
+	}
+}


### PR DESCRIPTION
An idea I've got is to have this data type (especially, but not exclusively) in the effect data objects, instead of a `double`, in order to represent angles.

A potential issue is that the rounding errors that we get when converting from one unit to another could give us false negatives if we want to compare angles of different units for equality. One possibility could be making it a `class` instead of a `struct`, and use inheritance to make them unit-safe at the type level, although comparisons would require a prior conversion.

Also, if we make it into a `class` it would require heap allocations, but this might be fine still.