### PR TITLE
Changing core services repository (from a dictionary-like structure to a record)

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -45,15 +45,14 @@ public abstract class BaseTool
 	private string ANTIALIAS_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-antialias";
 	private string ALPHABLEND_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-alpha-blend";
 
-	protected static PointI point_empty = new (-500, -500);
+	protected static readonly PointI point_empty = new (-500, -500);
 
-	protected BaseTool (IServiceManager services)
+	protected BaseTool (PintaCoreServices services)
 	{
-		Resources = services.GetService<IResourceService> ();
-		Settings = services.GetService<ISettingsService> ();
-
-		tools = services.GetService<IToolService> ();
-		workspace = services.GetService<IWorkspaceService> ();
+		Resources = services.Resources;
+		Settings = services.Settings;
+		tools = services.Tools;
+		workspace = services.Workspace;
 
 		CurrentCursor = DefaultCursor;
 

--- a/Pinta.Core/Managers/PintaCoreServices.cs
+++ b/Pinta.Core/Managers/PintaCoreServices.cs
@@ -24,42 +24,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-
 namespace Pinta.Core;
 
-public interface IServiceManager
-{
-	T AddService<T> (T implementation) where T : class;
-	T GetService<T> () where T : class;
-	T? GetOptionalService<T> () where T : class;
-}
-
-public sealed class ServiceManager : IServiceManager
-{
-	private readonly Dictionary<Type, object> services = new ();
-
-	public T AddService<T> (T implementation) where T : class
-	{
-		services.Add (typeof (T), implementation);
-
-		return implementation;
-	}
-
-	public T GetService<T> () where T : class
-	{
-		if (services.TryGetValue (typeof (T), out var implementation))
-			return (T) implementation;
-
-		throw new ApplicationException ($"Could not resolve service type {typeof (T)}");
-	}
-
-	public T? GetOptionalService<T> () where T : class
-	{
-		if (services.TryGetValue (typeof (T), out var implementation))
-			return (T) implementation;
-
-		return null;
-	}
-}
+public sealed record PintaCoreServices (
+	IResourceService Resources,
+	ISettingsService Settings,
+	ActionManager Actions,
+	IWorkspaceService Workspace,
+	LayerManager Layers,
+	IPaintBrushService PaintBrushes,
+	IToolService Tools,
+	ImageConverterManager ImageFormats,
+	PaletteFormatManager PaletteFormats,
+	SystemManager System,
+	RecentFileManager RecentFiles,
+	LivePreviewManager LivePreview,
+	IPaletteService Palette,
+	ChromeManager Chrome,
+	EffectsManager Effects
+);

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -32,7 +32,7 @@ public static class PintaCore
 	public static ChromeManager Chrome { get; }
 	public static EffectsManager Effects { get; }
 	public static ImageConverterManager ImageFormats { get; }
-	public static IServiceManager Services { get; }
+	public static PintaCoreServices Services { get; }
 	public static LayerManager Layers { get; }
 	public static LivePreviewManager LivePreview { get; }
 	public static PaintBrushManager PaintBrushes { get; }
@@ -67,24 +67,23 @@ public static class PintaCore
 		Chrome = new ChromeManager ();
 		Effects = new EffectsManager ();
 
-		Services = new ServiceManager ();
-
-		Services.AddService<IResourceService> (Resources);
-		Services.AddService<ISettingsService> (Settings);
-		Services.AddService (Actions);
-		Services.AddService<IWorkspaceService> (Workspace);
-		Services.AddService (Layers);
-		Services.AddService<IPaintBrushService> (PaintBrushes);
-		Services.AddService<IToolService> (Tools);
-		Services.AddService (ImageFormats);
-		Services.AddService (PaletteFormats);
-		Services.AddService (System);
-		Services.AddService (RecentFiles);
-
-		Services.AddService (LivePreview);
-		Services.AddService<IPaletteService> (Palette);
-		Services.AddService (Chrome);
-		Services.AddService (Effects);
+		Services = new PintaCoreServices (
+			Resources,
+			Settings,
+			Actions,
+			Workspace,
+			Layers,
+			PaintBrushes,
+			Tools,
+			ImageFormats,
+			PaletteFormats,
+			System,
+			RecentFiles,
+			LivePreview,
+			Palette,
+			Chrome,
+			Effects
+		);
 	}
 
 	public static void Initialize ()

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -41,9 +41,9 @@ public abstract class BaseBrushTool : BaseTool
 
 	private string BRUSH_WIDTH_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-brush-width";
 
-	protected BaseBrushTool (IServiceManager services) : base (services)
+	protected BaseBrushTool (PintaCoreServices services) : base (services)
 	{
-		Palette = services.GetService<IPaletteService> ();
+		Palette = services.Palette;
 	}
 
 	protected override bool ShowAntialiasingButton => true;

--- a/Pinta.Tools/Tools/BaseTransformTool.cs
+++ b/Pinta.Tools/Tools/BaseTransformTool.cs
@@ -44,7 +44,7 @@ public abstract class BaseTransformTool : BaseTool
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Pinta.Tools.BaseTransformTool"/> class.
 	/// </summary>
-	public BaseTransformTool (IServiceManager services) : base (services)
+	public BaseTransformTool (PintaCoreServices services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -36,7 +36,7 @@ public sealed class CloneStampTool : BaseBrushTool
 	private PointI? offset = null;
 	private PointI? last_point = null;
 
-	public CloneStampTool (IServiceManager services) : base (services)
+	public CloneStampTool (PintaCoreServices services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -42,10 +42,10 @@ public sealed class ColorPickerTool : BaseTool
 	private const string SAMPLE_SIZE_SETTING = "color-picker-sample-size";
 	private const string SAMPLE_TYPE_SETTING = "color-picker-sample-type";
 
-	public ColorPickerTool (IServiceManager services) : base (services)
+	public ColorPickerTool (PintaCoreServices services) : base (services)
 	{
-		palette = services.GetService<IPaletteService> ();
-		tools = services.GetService<IToolService> ();
+		palette = services.Palette;
+		tools = services.Tools;
 	}
 
 	public override string Name => Translations.GetString ("Color Picker");

--- a/Pinta.Tools/Tools/EllipseSelectTool.cs
+++ b/Pinta.Tools/Tools/EllipseSelectTool.cs
@@ -30,7 +30,7 @@ namespace Pinta.Tools;
 
 public sealed class EllipseSelectTool : SelectTool
 {
-	public EllipseSelectTool (IServiceManager services) : base (services) { }
+	public EllipseSelectTool (PintaCoreServices services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Ellipse Select");
 	public override string Icon => Pinta.Resources.Icons.ToolSelectEllipse;

--- a/Pinta.Tools/Tools/EllipseTool.cs
+++ b/Pinta.Tools/Tools/EllipseTool.cs
@@ -30,7 +30,7 @@ namespace Pinta.Tools;
 
 public sealed class EllipseTool : ShapeTool
 {
-	public EllipseTool (IServiceManager services) : base (services)
+	public EllipseTool (PintaCoreServices services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -47,7 +47,7 @@ public sealed class EraserTool : BaseBrushTool
 
 	private const string ERASER_TYPE_SETTING = "eraser-erase-type";
 
-	public EraserTool (IServiceManager services) : base (services)
+	public EraserTool (PintaCoreServices services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/FloodTool.cs
+++ b/Pinta.Tools/Tools/FloodTool.cs
@@ -48,7 +48,7 @@ public abstract class FloodTool : BaseTool
 	protected Label? tolerance_label;
 	protected Scale? tolerance_slider;
 
-	public FloodTool (IServiceManager services) : base (services)
+	public FloodTool (PintaCoreServices services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -45,7 +45,7 @@ public sealed class FreeformShapeTool : BaseBrushTool
 	private const string FILL_TYPE_SETTING = "freeform-shape-fill-type";
 	private const string DASH_PATTERN_SETTING = "freeform-shape-dash_pattern";
 
-	public FreeformShapeTool (IServiceManager services) : base (services)
+	public FreeformShapeTool (PintaCoreServices services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -41,9 +41,9 @@ public sealed class GradientTool : BaseTool
 	private const string GRADIENT_TYPE_SETTING = "gradient-type";
 	private const string GRADIENT_COLOR_MODE_SETTING = "gradient-color-mode";
 
-	public GradientTool (IServiceManager services) : base (services)
+	public GradientTool (PintaCoreServices services) : base (services)
 	{
-		palette = services.GetService<IPaletteService> ();
+		palette = services.Palette;
 	}
 
 	public override string Name => Translations.GetString ("Gradient");

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -34,7 +34,7 @@ using Pinta.Core;
 
 namespace Pinta.Tools;
 
-public class LassoSelectTool : BaseTool
+public sealed class LassoSelectTool : BaseTool
 {
 	private readonly IWorkspaceService workspace;
 
@@ -45,9 +45,9 @@ public class LassoSelectTool : BaseTool
 	private Path? path;
 	private readonly List<IntPoint> lasso_polygon = new ();
 
-	public LassoSelectTool (IServiceManager services) : base (services)
+	public LassoSelectTool (PintaCoreServices services) : base (services)
 	{
-		workspace = services.GetService<IWorkspaceService> ();
+		workspace = services.Workspace;
 	}
 
 	public override string Name => Translations.GetString ("Lasso Select");

--- a/Pinta.Tools/Tools/LineCurveTool.cs
+++ b/Pinta.Tools/Tools/LineCurveTool.cs
@@ -30,7 +30,7 @@ namespace Pinta.Tools;
 
 public sealed class LineCurveTool : ShapeTool
 {
-	public LineCurveTool (IServiceManager services) : base (services)
+	public LineCurveTool (PintaCoreServices services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/MagicWandTool.cs
+++ b/Pinta.Tools/Tools/MagicWandTool.cs
@@ -36,9 +36,9 @@ public sealed class MagicWandTool : FloodTool
 
 	private CombineMode combine_mode;
 
-	public MagicWandTool (IServiceManager services) : base (services)
+	public MagicWandTool (PintaCoreServices services) : base (services)
 	{
-		workspace = services.GetService<IWorkspaceService> ();
+		workspace = services.Workspace;
 
 		LimitToSelection = false;
 	}

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -35,7 +35,7 @@ public sealed class MoveSelectedTool : BaseTransformTool
 	private DocumentSelection? original_selection;
 	private readonly Matrix original_transform = CairoExtensions.CreateIdentityMatrix ();
 
-	public MoveSelectedTool (IServiceManager services) : base (services)
+	public MoveSelectedTool (PintaCoreServices services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -34,7 +34,7 @@ public sealed class MoveSelectionTool : BaseTransformTool
 	private SelectionHistoryItem? hist;
 	private DocumentSelection? original_selection;
 
-	public MoveSelectionTool (IServiceManager service) : base (service)
+	public MoveSelectionTool (PintaCoreServices service) : base (service)
 	{
 	}
 

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -42,9 +42,9 @@ public sealed class PaintBrushTool : BaseBrushTool
 
 	private const string BRUSH_SETTING = "paint-brush-brush";
 
-	public PaintBrushTool (IServiceManager services) : base (services)
+	public PaintBrushTool (PintaCoreServices services) : base (services)
 	{
-		brushes = services.GetService<IPaintBrushService> ();
+		brushes = services.PaintBrushes;
 
 		default_brush = brushes.FirstOrDefault ();
 		active_brush = default_brush;

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -35,9 +35,9 @@ public sealed class PaintBucketTool : FloodTool
 	private readonly IPaletteService palette;
 	private Color fill_color;
 
-	public PaintBucketTool (IServiceManager services) : base (services)
+	public PaintBucketTool (PintaCoreServices services) : base (services)
 	{
-		palette = services.GetService<IPaletteService> ();
+		palette = services.Palette;
 	}
 
 	public override string Name => Translations.GetString ("Paint Bucket");

--- a/Pinta.Tools/Tools/PanTool.cs
+++ b/Pinta.Tools/Tools/PanTool.cs
@@ -33,7 +33,7 @@ public sealed class PanTool : BaseTool
 	private bool active;
 	private PointD last_point;
 
-	public PanTool (IServiceManager services) : base (services) { }
+	public PanTool (PintaCoreServices services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Pan");
 	public override string Icon => Pinta.Resources.Icons.ToolPan;

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -39,9 +39,9 @@ public sealed class PencilTool : BaseTool
 	private bool surface_modified;
 	private MouseButton mouse_button;
 
-	public PencilTool (IServiceManager services) : base (services)
+	public PencilTool (PintaCoreServices services) : base (services)
 	{
-		palette = services.GetService<IPaletteService> ();
+		palette = services.Palette;
 	}
 
 	public override string Name => Translations.GetString ("Pencil");

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -39,7 +39,7 @@ using Pinta.Core;
 
 namespace Pinta.Tools;
 
-public class RecolorTool : BaseBrushTool
+public sealed class RecolorTool : BaseBrushTool
 {
 	private readonly IWorkspaceService workspace;
 
@@ -48,9 +48,9 @@ public class RecolorTool : BaseBrushTool
 
 	private const string TOLERANCE_SETTING = "recolor-tolerance";
 
-	public RecolorTool (IServiceManager services) : base (services)
+	public RecolorTool (PintaCoreServices services) : base (services)
 	{
-		workspace = services.GetService<IWorkspaceService> ();
+		workspace = services.Workspace;
 	}
 
 	public override string Name => Translations.GetString ("Recolor");
@@ -60,7 +60,7 @@ public class RecolorTool : BaseBrushTool
 		"\nRight click to reverse.");
 	public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Recolor.png"), 9, 18, null);
 	public override Gdk.Key ShortcutKey => Gdk.Key.R;
-	protected float Tolerance => (float) (ToleranceSlider.GetValue () / 100);
+	private float Tolerance => (float) (ToleranceSlider.GetValue () / 100);
 	public override int Priority => 49;
 
 	protected override void OnBuildToolBar (Box tb)

--- a/Pinta.Tools/Tools/RectangleSelectTool.cs
+++ b/Pinta.Tools/Tools/RectangleSelectTool.cs
@@ -30,7 +30,7 @@ namespace Pinta.Tools;
 
 public sealed class RectangleSelectTool : SelectTool
 {
-	public RectangleSelectTool (IServiceManager services) : base (services) { }
+	public RectangleSelectTool (PintaCoreServices services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Rectangle Select");
 	public override string Icon => Pinta.Resources.Icons.ToolSelectRectangle;

--- a/Pinta.Tools/Tools/RectangleTool.cs
+++ b/Pinta.Tools/Tools/RectangleTool.cs
@@ -30,7 +30,7 @@ namespace Pinta.Tools;
 
 public sealed class RectangleTool : ShapeTool
 {
-	public RectangleTool (IServiceManager services) : base (services)
+	public RectangleTool (PintaCoreServices services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/RoundedRectangleTool.cs
+++ b/Pinta.Tools/Tools/RoundedRectangleTool.cs
@@ -30,7 +30,7 @@ namespace Pinta.Tools;
 
 public sealed class RoundedRectangleTool : ShapeTool
 {
-	public RoundedRectangleTool (IServiceManager services) : base (services)
+	public RoundedRectangleTool (PintaCoreServices services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -54,10 +54,10 @@ public abstract class SelectTool : BaseTool
 	protected override bool ShowAntialiasingButton => false;
 	public override IEnumerable<MoveHandle> Handles => handles;
 
-	public SelectTool (IServiceManager services) : base (services)
+	public SelectTool (PintaCoreServices services) : base (services)
 	{
-		tools = services.GetService<IToolService> ();
-		workspace = services.GetService<IWorkspaceService> ();
+		tools = services.Tools;
+		workspace = services.Workspace;
 
 		handles[0] = new MoveHandle { CursorName = Pinta.Resources.StandardCursors.ResizeNW };
 		handles[1] = new MoveHandle { CursorName = Pinta.Resources.StandardCursors.ResizeSW };

--- a/Pinta.Tools/Tools/ShapeTool.cs
+++ b/Pinta.Tools/Tools/ShapeTool.cs
@@ -33,7 +33,7 @@ public abstract class ShapeTool : BaseTool
 {
 	public BaseEditEngine EditEngine { get; }
 
-	public ShapeTool (IServiceManager services) : base (services)
+	public ShapeTool (PintaCoreServices services) : base (services)
 	{
 		EditEngine = CreateEditEngine ();
 	}

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -91,7 +91,7 @@ public sealed class TextTool : BaseTool
 	public Gdk.Cursor InvalidEditCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon (Pinta.Resources.Icons.EditSelectionErase), 0, 0, null);
 
 	#region Constructor
-	public TextTool (IServiceManager services) : base (services)
+	public TextTool (PintaCoreServices services) : base (services)
 	{
 		cursor_hand = Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Pan.png"), 8, 8, null);
 

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -42,7 +42,7 @@ public sealed class ZoomTool : BaseTool
 	private RectangleD last_dirty;
 	private static readonly int tolerance = 10;
 
-	public ZoomTool (IServiceManager services) : base (services)
+	public ZoomTool (PintaCoreServices services) : base (services)
 	{
 		mouse_down = MouseButton.None;
 


### PR DESCRIPTION
There are certain services without which Pinta wouldn't work, but they are currently being put in a dictionary-like structure (the `IServiceManager`), and incurring the runtime cost of lookup instead of ensuring their correct initialization from the beginning and make them readily accessible in constant time.

I am thinking of replacing `IServiceManager` with `PintaCoreServices`, which for now is a `record`; this is done intentionally, so that it is easy to swap one service with another if it's needed (for example, if you need a different palette manager).

Also, I think it would be good to get rid of the global `PintaCore` in the slightly longer term, and inject `PintaCoreServices` instead, allowing us to swap anything at any time (which at the beginning wouldn't probably be of much use, but over time it could allow us to accomplish things that aren't currently possible).

As for allowing custom services, I think that with this new approach it could be accomplished easily, for example by creating another service called `CustomServiceRepository`.