### PR TITLE
Additional operations for `BitMask`

### DIFF
--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -193,10 +193,7 @@ public sealed class BitMask : ICloneable
 				this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
 	}
 
-	/// <summary>
-	/// Creates new bitmask from selected area. It does NOT create a view
-	/// </summary>
-	public BitMask NewSubmask (RectangleI bounds)
+	public BitMask CloneArea (RectangleI bounds)
 	{
 		if (bounds.X < 0 || bounds.Y < 0 || bounds.Right >= Width || bounds.Bottom >= Height)
 			throw new ArgumentOutOfRangeException (nameof (bounds), "Chosen area out of bounds");

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -24,11 +24,11 @@ public sealed class BitMask : ICloneable
 		array = new BitArray (width * height);
 	}
 
-	private BitMask (BitMask source)
+	private BitMask (BitMask other)
 	{
-		Width = source.Width;
-		Height = source.Height;
-		array = (BitArray) source.array.Clone ();
+		Width = other.Width;
+		Height = other.Height;
+		array = (BitArray) other.array.Clone ();
 	}
 
 	object ICloneable.Clone () => Clone ();

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -86,6 +86,11 @@ public sealed class BitMask
 		return (y * Width) + x;
 	}
 
+	/// <summary>
+	/// Mirrors the bits in the BitMask along the X axis,
+	/// such that the bits that used to be on the left side
+	/// are now on the right side and vice versa.
+	/// </summary>
 	public void FlipHorizontal ()
 	{
 		int flippableWidth = Width / 2;
@@ -100,6 +105,11 @@ public sealed class BitMask
 		}
 	}
 
+	/// <summary>
+	/// Mirrors the bits in the BitMask along the Y axis,
+	/// such that the bits that used to be on the top side
+	/// are now on the bottom side and vice versa.
+	/// </summary>
 	public void FlipVertical ()
 	{
 		int flippableHeight = Height / 2;
@@ -126,6 +136,9 @@ public sealed class BitMask
 		return true;
 	}
 
+	/// <summary>
+	/// Inverts all bits in the bitmask
+	/// </summary>
 	public void Not () => array.Not ();
 
 	/// <summary>
@@ -194,11 +207,20 @@ public sealed class BitMask
 				this[x, y] = this[x, y] ^ other[x, y];
 	}
 
+	/// <param name="bounds"></param>
+	/// <returns>
+	/// A new bitmask with the width and height specified in
+	/// <paramref name="bounds"/>, and the bits set to the values
+	/// in the area demarcated by it
+	/// </returns>
+	/// <exception cref="ArgumentOutOfRangeException"></exception>
 	public BitMask CloneArea (RectangleI bounds)
 	{
 		if (bounds.X < 0 || bounds.Y < 0 || bounds.Right >= Width || bounds.Bottom >= Height)
 			throw new ArgumentOutOfRangeException (nameof (bounds), "Chosen area out of bounds");
+
 		BitMask submask = new (bounds.Width, bounds.Height);
+
 		int right = bounds.Right;
 		int bottom = bounds.Bottom;
 		for (int y = bounds.Top; y <= bottom; y++) {
@@ -206,22 +228,26 @@ public sealed class BitMask
 				submask[x - bounds.Left, y - bounds.Top] = this[x, y];
 			}
 		}
+
 		return submask;
 	}
 
 	private RectangleI GetOverlap (BitMask other, PointI offset)
 	{
 		if (Width == 0 || Height == 0) return RectangleI.Zero;
+
 		RectangleI thisRect = new (
 			point: PointI.Zero,
 			width: Width,
 			height: Height
 		);
+
 		RectangleI otherRect = new (
 			point: offset,
 			width: other.Width,
 			height: other.Height
 		);
+
 		return thisRect.Intersect (otherRect);
 	}
 

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -71,12 +71,6 @@ public sealed class BitMask : ICloneable
 		}
 	}
 
-	public void InvertAll ()
-	{
-		for (int i = 0; i < array.Length; i++)
-			array[i] = !array[i];
-	}
-
 	public void Set (int x, int y, bool newValue) => array[GetIndex (x, y)] = newValue;
 
 	public void Set (RectangleI rect, bool newValue)
@@ -134,6 +128,8 @@ public sealed class BitMask : ICloneable
 		}
 		return true;
 	}
+
+	public void Not () => array.Not ();
 
 	public void And (BitMask other)
 	{

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -7,7 +7,7 @@ namespace Pinta.Core;
 /// Represents a two-dimensional matrix of bits used to store a
 /// true/false value for each pixel in an image.
 /// </summary>
-public sealed class BitMask : ICloneable
+public sealed class BitMask
 {
 	private readonly BitArray array;
 
@@ -30,8 +30,6 @@ public sealed class BitMask : ICloneable
 		Height = other.Height;
 		array = (BitArray) other.array.Clone ();
 	}
-
-	object ICloneable.Clone () => Clone ();
 
 	public BitMask Clone () => new (this);
 

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -193,6 +193,9 @@ public sealed class BitMask : ICloneable
 				this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
 	}
 
+	/// <summary>
+	/// Creates new bitmask from selected area. It does NOT create a view
+	/// </summary>
 	public BitMask NewSubmask (RectangleI bounds)
 	{
 		if (bounds.X < 0 || bounds.Y < 0 || bounds.Right >= Width || bounds.Bottom >= Height)

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -193,7 +193,7 @@ public sealed class BitMask : ICloneable
 				this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
 	}
 
-	public BitMask CreateSubmask (RectangleI bounds)
+	public BitMask NewSubmask (RectangleI bounds)
 	{
 		if (bounds.X < 0 || bounds.Y < 0 || bounds.Right >= Width || bounds.Bottom >= Height)
 			throw new ArgumentOutOfRangeException (nameof (bounds), "Chosen area out of bounds");

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -135,5 +135,42 @@ public sealed class BitMask : ICloneable
 		return true;
 	}
 
+	public void And (BitMask other)
+	{
+		if (Width == 0 || Height == 0) return;
+		if (Width == other.Width && Height == other.Height) {
+			array.And (other.array);
+		} else {
+			And (other, PointI.Zero);
+		}
+	}
+
+	public void And (BitMask other, PointI offset)
+	{
+		RectangleI overlap = GetOverlap (other, offset);
+		if (overlap.IsEmpty) return;
+		int right = overlap.Right;
+		int bottom = overlap.Bottom;
+		for (int x = overlap.Left; x <= right; x++)
+			for (int y = overlap.Top; y <= bottom; y++)
+				this[x, y] = this[x, y] && other[x - offset.X, y - offset.Y];
+	}
+
+	private RectangleI GetOverlap (BitMask other, PointI offset)
+	{
+		if (Width == 0 || Height == 0) return RectangleI.Zero;
+		RectangleI thisRect = new (
+			point: PointI.Zero,
+			width: Width,
+			height: Height
+		);
+		RectangleI otherRect = new (
+			point: offset,
+			width: other.Width,
+			height: other.Height
+		);
+		return thisRect.Intersect (otherRect);
+	}
+
 	public override int GetHashCode () => Width.GetHashCode () ^ Height.GetHashCode ();
 }

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -193,6 +193,21 @@ public sealed class BitMask : ICloneable
 				this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
 	}
 
+	public BitMask CreateSubmask (RectangleI bounds)
+	{
+		if (bounds.X < 0 || bounds.Y < 0 || bounds.Right >= Width || bounds.Bottom >= Height)
+			throw new ArgumentOutOfRangeException (nameof (bounds), "Chosen area out of bounds");
+		BitMask submask = new (bounds.Width, bounds.Height);
+		int right = bounds.Right;
+		int bottom = bounds.Bottom;
+		for (int y = bounds.Top; y <= bottom; y++) {
+			for (int x = bounds.Left; x <= right; x++) {
+				submask[x - bounds.Left, y - bounds.Top] = this[x, y];
+			}
+		}
+		return submask;
+	}
+
 	private RectangleI GetOverlap (BitMask other, PointI offset)
 	{
 		if (Width == 0 || Height == 0) return RectangleI.Zero;

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -128,67 +128,70 @@ public sealed class BitMask
 
 	public void Not () => array.Not ();
 
+	/// <summary>
+	/// Performs bit-by-bit AND in the area where
+	/// this and <paramref name="other"/> overlap
+	/// </summary>
 	public void And (BitMask other)
 	{
 		if (Width == 0 || Height == 0) return;
+
 		if (Width == other.Width && Height == other.Height) {
 			array.And (other.array);
-		} else {
-			And (other, PointI.Zero);
+			return;
 		}
-	}
 
-	public void And (BitMask other, PointI offset)
-	{
-		RectangleI overlap = GetOverlap (other, offset);
+		RectangleI overlap = GetOverlap (other, PointI.Zero);
 		if (overlap.IsEmpty) return;
 		int right = overlap.Right;
 		int bottom = overlap.Bottom;
 		for (int x = overlap.Left; x <= right; x++)
 			for (int y = overlap.Top; y <= bottom; y++)
-				this[x, y] = this[x, y] && other[x - offset.X, y - offset.Y];
+				this[x, y] = this[x, y] && other[x, y];
 	}
 
+	/// <summary>
+	/// Performs bit-by-bit OR in the area where
+	/// this and <paramref name="other"/> overlap
+	/// </summary>
 	public void Or (BitMask other)
 	{
 		if (Width == 0 || Height == 0) return;
+
 		if (Width == other.Width && Height == other.Height) {
 			array.Or (other.array);
-		} else {
-			Or (other, PointI.Zero);
+			return;
 		}
-	}
 
-	public void Or (BitMask other, PointI offset)
-	{
-		RectangleI overlap = GetOverlap (other, offset);
+		RectangleI overlap = GetOverlap (other, PointI.Zero);
 		if (overlap.IsEmpty) return;
 		int right = overlap.Right;
 		int bottom = overlap.Bottom;
 		for (int x = overlap.Left; x <= right; x++)
 			for (int y = overlap.Top; y <= bottom; y++)
-				this[x, y] = this[x, y] || other[x - offset.X, y - offset.Y];
+				this[x, y] = this[x, y] || other[x, y];
 	}
 
+	/// <summary>
+	/// Performs bit-by-bit XOR in the area where
+	/// this and <paramref name="other"/> overlap
+	/// </summary>
 	public void Xor (BitMask other)
 	{
 		if (Width == 0 || Height == 0) return;
+
 		if (Width == other.Width && Height == other.Height) {
 			array.Xor (other.array);
-		} else {
-			Xor (other, PointI.Zero);
+			return;
 		}
-	}
 
-	public void Xor (BitMask other, PointI offset)
-	{
-		RectangleI overlap = GetOverlap (other, offset);
+		RectangleI overlap = GetOverlap (other, PointI.Zero);
 		if (overlap.IsEmpty) return;
 		int right = overlap.Right;
 		int bottom = overlap.Bottom;
 		for (int x = overlap.Left; x <= right; x++)
 			for (int y = overlap.Top; y <= bottom; y++)
-				this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
+				this[x, y] = this[x, y] ^ other[x, y];
 	}
 
 	public BitMask CloneArea (RectangleI bounds)

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -173,26 +173,26 @@ public sealed class BitMask : ICloneable
 				this[x, y] = this[x, y] || other[x - offset.X, y - offset.Y];
 	}
 
-	//public void Xor (BitMask other)
-	//{
-	//	if (Width == 0 || Height == 0) return;
-	//	if (Width == other.Width && Height == other.Height) {
-	//		array.Xor (other.array);
-	//	} else {
-	//		Xor (other, PointI.Zero);
-	//	}
-	//}
+	public void Xor (BitMask other)
+	{
+		if (Width == 0 || Height == 0) return;
+		if (Width == other.Width && Height == other.Height) {
+			array.Xor (other.array);
+		} else {
+			Xor (other, PointI.Zero);
+		}
+	}
 
-	//public void Xor (BitMask other, PointI offset)
-	//{
-	//	RectangleI overlap = GetOverlap (other, offset);
-	//	if (overlap.IsEmpty) return;
-	//	int right = overlap.Right;
-	//	int bottom = overlap.Bottom;
-	//	for (int x = overlap.Left; x <= right; x++)
-	//		for (int y = overlap.Top; y <= bottom; y++)
-	//			this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
-	//}
+	public void Xor (BitMask other, PointI offset)
+	{
+		RectangleI overlap = GetOverlap (other, offset);
+		if (overlap.IsEmpty) return;
+		int right = overlap.Right;
+		int bottom = overlap.Bottom;
+		for (int x = overlap.Left; x <= right; x++)
+			for (int y = overlap.Top; y <= bottom; y++)
+				this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
+	}
 
 	private RectangleI GetOverlap (BitMask other, PointI offset)
 	{

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -58,7 +58,6 @@ public sealed class BitMask : ICloneable
 	public void Invert (int x, int y)
 	{
 		var index = GetIndex (x, y);
-
 		array[index] = !array[index];
 	}
 

--- a/Pinta.Core/Effects/BitMask.cs
+++ b/Pinta.Core/Effects/BitMask.cs
@@ -156,6 +156,48 @@ public sealed class BitMask : ICloneable
 				this[x, y] = this[x, y] && other[x - offset.X, y - offset.Y];
 	}
 
+	public void Or (BitMask other)
+	{
+		if (Width == 0 || Height == 0) return;
+		if (Width == other.Width && Height == other.Height) {
+			array.Or (other.array);
+		} else {
+			Or (other, PointI.Zero);
+		}
+	}
+
+	public void Or (BitMask other, PointI offset)
+	{
+		RectangleI overlap = GetOverlap (other, offset);
+		if (overlap.IsEmpty) return;
+		int right = overlap.Right;
+		int bottom = overlap.Bottom;
+		for (int x = overlap.Left; x <= right; x++)
+			for (int y = overlap.Top; y <= bottom; y++)
+				this[x, y] = this[x, y] || other[x - offset.X, y - offset.Y];
+	}
+
+	//public void Xor (BitMask other)
+	//{
+	//	if (Width == 0 || Height == 0) return;
+	//	if (Width == other.Width && Height == other.Height) {
+	//		array.Xor (other.array);
+	//	} else {
+	//		Xor (other, PointI.Zero);
+	//	}
+	//}
+
+	//public void Xor (BitMask other, PointI offset)
+	//{
+	//	RectangleI overlap = GetOverlap (other, offset);
+	//	if (overlap.IsEmpty) return;
+	//	int right = overlap.Right;
+	//	int bottom = overlap.Bottom;
+	//	for (int x = overlap.Left; x <= right; x++)
+	//		for (int y = overlap.Top; y <= bottom; y++)
+	//			this[x, y] = this[x, y] ^ other[x - offset.X, y - offset.Y];
+	//}
+
 	private RectangleI GetOverlap (BitMask other, PointI offset)
 	{
 		if (Width == 0 || Height == 0) return RectangleI.Zero;

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -158,6 +158,52 @@ internal sealed class BitMaskTest
 		}
 	}
 
+	[TestCaseSource (nameof (vertical_flip_cases))]
+	public void VerticalFlip (BitMask mask, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var clone = mask.Clone ();
+		clone.FlipVertical ();
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (clone[kvp.Key], kvp.Value);
+	}
+
+	[TestCaseSource (nameof(horizontal_flip_cases))]
+	public void HorizontalFlip (BitMask mask, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var clone = mask.Clone ();
+		clone.FlipHorizontal ();
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (clone[kvp.Key], kvp.Value);
+	}
+
+	static readonly IReadOnlyList<TestCaseData> vertical_flip_cases = CreateVerticalFlipCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateVerticalFlipCases ()
+	{
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[0, 0] = true;
+		yield return new TestCaseData (
+			topLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[new (0, 0)] = false,
+				[new (0, 1)] = true,
+			}
+		);
+	}
+
+	static readonly IReadOnlyList<TestCaseData> horizontal_flip_cases = CreateHorizontalFlipCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateHorizontalFlipCases ()
+	{
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[0, 0] = true;
+		yield return new TestCaseData (
+			topLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[new (0, 0)] = false,
+				[new (1, 0)] = true,
+			}
+		);
+	}
+
 	static readonly IReadOnlyList<TestCaseData> scanline_invert_test_cases = CreateScanlineInvertTestCases ().ToArray ();
 	static IEnumerable<TestCaseData> CreateScanlineInvertTestCases ()
 	{

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -186,15 +186,6 @@ internal sealed class BitMaskTest
 			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
 	}
 
-	[TestCaseSource (nameof (and_offset_cases))]
-	public void And_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
-	{
-		var leftClone = left.Clone ();
-		leftClone.And (right, offset);
-		foreach (var kvp in checksAfter)
-			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
-	}
-
 	[TestCaseSource (nameof (or_cases))]
 	public void Or (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
 	{
@@ -204,29 +195,11 @@ internal sealed class BitMaskTest
 			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
 	}
 
-	[TestCaseSource (nameof (or_offset_cases))]
-	public void Or_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
-	{
-		var leftClone = left.Clone ();
-		leftClone.Or (right, offset);
-		foreach (var kvp in checksAfter)
-			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
-	}
-
 	[TestCaseSource (nameof (xor_cases))]
 	public void Xor (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
 	{
 		var leftClone = left.Clone ();
 		leftClone.Xor (right);
-		foreach (var kvp in checksAfter)
-			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
-	}
-
-	[TestCaseSource (nameof (xor_offset_cases))]
-	public void Xor_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
-	{
-		var leftClone = left.Clone ();
-		leftClone.Xor (right, offset);
 		foreach (var kvp in checksAfter)
 			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
 	}
@@ -286,82 +259,6 @@ internal sealed class BitMaskTest
 		yield return new (
 			topLeftEnabled,
 			topLeftEnabled,
-			new Dictionary<PointI, bool> {
-				[topLeft] = false,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-	}
-
-	static readonly IReadOnlyList<TestCaseData> xor_offset_cases = CreateXorOffsetCases ().ToArray ();
-	static IEnumerable<TestCaseData> CreateXorOffsetCases ()
-	{
-		PointI shift_left = new (-1, 0);
-		PointI shift_up = new (0, -1);
-		//PointI shift_left_up = new (-1, -1);
-		PointI shift_right_down = new (1, 1);
-		//PointI shift_right = new (1, 0);
-		//PointI shift_down = new (0, 1);
-		PointI no_shift = new (0, 0);
-
-		PointI topLeft = new (0, 0);
-		BitMask topLeftEnabled = new (2, 2);
-		topLeftEnabled[topLeft] = true;
-
-		PointI topRight = new (1, 0);
-		BitMask topRightEnabled = new (2, 2);
-		topRightEnabled[topRight] = true;
-
-		PointI bottomLeft = new (0, 1);
-		BitMask bottomLeftEnabled = new (2, 2);
-		bottomLeftEnabled[bottomLeft] = true;
-
-		PointI bottomRight = new (1, 1);
-		BitMask bottomRightEnabled = new (2, 2);
-		bottomRightEnabled[bottomRight] = true;
-
-		yield return new (
-			topLeftEnabled,
-			topRightEnabled,
-			no_shift,
-			new Dictionary<PointI, bool> {
-				[topLeft] = true,
-				[topRight] = true,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			topLeftEnabled,
-			topRightEnabled,
-			shift_left,
-			new Dictionary<PointI, bool> {
-				[topLeft] = false,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			topLeftEnabled,
-			bottomLeftEnabled,
-			shift_up,
-			new Dictionary<PointI, bool> {
-				[topLeft] = false,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			bottomRightEnabled,
-			topLeftEnabled,
-			shift_right_down,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
 				[topRight] = false,
@@ -431,82 +328,6 @@ internal sealed class BitMaskTest
 				[topRight] = false,
 				[bottomLeft] = false,
 				[bottomRight] = false,
-			}
-		);
-	}
-
-	static readonly IReadOnlyList<TestCaseData> or_offset_cases = CreateOrOffsetCases ().ToArray ();
-	static IEnumerable<TestCaseData> CreateOrOffsetCases ()
-	{
-		PointI shift_left = new (-1, 0);
-		PointI shift_up = new (0, -1);
-		//PointI shift_left_up = new (-1, -1);
-		PointI shift_right_down = new (1, 1);
-		//PointI shift_right = new (1, 0);
-		//PointI shift_down = new (0, 1);
-		PointI no_shift = new (0, 0);
-
-		PointI topLeft = new (0, 0);
-		BitMask topLeftEnabled = new (2, 2);
-		topLeftEnabled[topLeft] = true;
-
-		PointI topRight = new (1, 0);
-		BitMask topRightEnabled = new (2, 2);
-		topRightEnabled[topRight] = true;
-
-		PointI bottomLeft = new (0, 1);
-		BitMask bottomLeftEnabled = new (2, 2);
-		bottomLeftEnabled[bottomLeft] = true;
-
-		PointI bottomRight = new (1, 1);
-		BitMask bottomRightEnabled = new (2, 2);
-		bottomRightEnabled[bottomRight] = true;
-
-		yield return new (
-			topLeftEnabled,
-			topRightEnabled,
-			no_shift,
-			new Dictionary<PointI, bool> {
-				[topLeft] = true,
-				[topRight] = true,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			topLeftEnabled,
-			topRightEnabled,
-			shift_left,
-			new Dictionary<PointI, bool> {
-				[topLeft] = true,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			topLeftEnabled,
-			bottomLeftEnabled,
-			shift_up,
-			new Dictionary<PointI, bool> {
-				[topLeft] = true,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			bottomRightEnabled,
-			topLeftEnabled,
-			shift_right_down,
-			new Dictionary<PointI, bool> {
-				[topLeft] = false,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = true,
 			}
 		);
 	}
@@ -599,82 +420,6 @@ internal sealed class BitMaskTest
 				[topRight] = false,
 				[bottomLeft] = true,
 				[bottomRight] = false,
-			}
-		);
-	}
-
-	static readonly IReadOnlyList<TestCaseData> and_offset_cases = CreateAndOffsetCases ().ToArray ();
-	static IEnumerable<TestCaseData> CreateAndOffsetCases ()
-	{
-		PointI shift_left = new (-1, 0);
-		PointI shift_up = new (0, -1);
-		//PointI shift_left_up = new (-1, -1);
-		PointI shift_right_down = new (1, 1);
-		//PointI shift_right = new (1, 0);
-		//PointI shift_down = new (0, 1);
-		PointI no_shift = new (0, 0);
-
-		PointI topLeft = new (0, 0);
-		BitMask topLeftEnabled = new (2, 2);
-		topLeftEnabled[topLeft] = true;
-
-		PointI topRight = new (1, 0);
-		BitMask topRightEnabled = new (2, 2);
-		topRightEnabled[topRight] = true;
-
-		PointI bottomLeft = new (0, 1);
-		BitMask bottomLeftEnabled = new (2, 2);
-		bottomLeftEnabled[bottomLeft] = true;
-
-		PointI bottomRight = new (1, 1);
-		BitMask bottomRightEnabled = new (2, 2);
-		bottomRightEnabled[bottomRight] = true;
-
-		yield return new (
-			topLeftEnabled,
-			topRightEnabled,
-			no_shift,
-			new Dictionary<PointI, bool> {
-				[topLeft] = false,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			topLeftEnabled,
-			topRightEnabled,
-			shift_left,
-			new Dictionary<PointI, bool> {
-				[topLeft] = true,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			topLeftEnabled,
-			bottomLeftEnabled,
-			shift_up,
-			new Dictionary<PointI, bool> {
-				[topLeft] = true,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = false,
-			}
-		);
-
-		yield return new (
-			bottomRightEnabled,
-			topLeftEnabled,
-			shift_right_down,
-			new Dictionary<PointI, bool> {
-				[topLeft] = false,
-				[topRight] = false,
-				[bottomLeft] = false,
-				[bottomRight] = true,
 			}
 		);
 	}

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -256,6 +256,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
 				[topRight] = true,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -264,7 +266,9 @@ internal sealed class BitMaskTest
 			bottomLeftEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
 				[bottomLeft] = true,
+				[bottomRight] = false,
 			}
 		);
 
@@ -273,6 +277,8 @@ internal sealed class BitMaskTest
 			bottomRightEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
+				[bottomLeft] = false,
 				[bottomRight] = true,
 			}
 		);
@@ -323,6 +329,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
 				[topRight] = true,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -333,6 +341,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
 				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -342,7 +352,9 @@ internal sealed class BitMaskTest
 			shift_up,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
+				[topRight] = false,
 				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -352,6 +364,8 @@ internal sealed class BitMaskTest
 			shift_right_down,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = false,
 				[bottomRight] = false,
 			}
 		);
@@ -382,6 +396,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
 				[topRight] = true,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -390,7 +406,9 @@ internal sealed class BitMaskTest
 			bottomLeftEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
 				[bottomLeft] = true,
+				[bottomRight] = false,
 			}
 		);
 
@@ -399,6 +417,8 @@ internal sealed class BitMaskTest
 			bottomRightEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
+				[bottomLeft] = false,
 				[bottomRight] = true,
 			}
 		);
@@ -449,6 +469,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
 				[topRight] = true,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -459,6 +481,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
 				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -468,7 +492,9 @@ internal sealed class BitMaskTest
 			shift_up,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
 				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -478,6 +504,8 @@ internal sealed class BitMaskTest
 			shift_right_down,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = false,
 				[bottomRight] = true,
 			}
 		);
@@ -508,6 +536,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
 				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -516,7 +546,9 @@ internal sealed class BitMaskTest
 			bottomLeftEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
+				[topRight] = false,
 				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -525,6 +557,8 @@ internal sealed class BitMaskTest
 			bottomRightEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = false,
 				[bottomRight] = false,
 			}
 		);
@@ -534,6 +568,9 @@ internal sealed class BitMaskTest
 			topLeftEnabled,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 	}
@@ -572,6 +609,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
 				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -582,6 +621,8 @@ internal sealed class BitMaskTest
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
 				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -591,7 +632,9 @@ internal sealed class BitMaskTest
 			shift_up,
 			new Dictionary<PointI, bool> {
 				[topLeft] = true,
+				[topRight] = false,
 				[bottomLeft] = false,
+				[bottomRight] = false,
 			}
 		);
 
@@ -601,6 +644,8 @@ internal sealed class BitMaskTest
 			shift_right_down,
 			new Dictionary<PointI, bool> {
 				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = false,
 				[bottomRight] = true,
 			}
 		);

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -213,35 +213,149 @@ internal sealed class BitMaskTest
 			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
 	}
 
-	//[TestCaseSource (nameof (xor_cases))]
-	//public void Xor (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
-	//{
-	//	var leftClone = left.Clone ();
-	//	leftClone.Xor (right);
-	//	foreach (var kvp in checksAfter)
-	//		Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
-	//}
+	[TestCaseSource (nameof (xor_cases))]
+	public void Xor (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var leftClone = left.Clone ();
+		leftClone.Xor (right);
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	}
 
-	//[TestCaseSource (nameof (xor_offset_cases))]
-	//public void Xor_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
-	//{
-	//	var leftClone = left.Clone ();
-	//	leftClone.Xor (right, offset);
-	//	foreach (var kvp in checksAfter)
-	//		Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
-	//}
+	[TestCaseSource (nameof (xor_offset_cases))]
+	public void Xor_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var leftClone = left.Clone ();
+		leftClone.Xor (right, offset);
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	}
 
-	//static readonly IReadOnlyList<TestCaseData> xor_cases = CreateXorCases ().ToArray ();
-	//static IEnumerable<TestCaseData> CreateXorCases ()
-	//{
+	static readonly IReadOnlyList<TestCaseData> xor_cases = CreateXorCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateXorCases ()
+	{
+		PointI topLeft = new (0, 0);
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[topLeft] = true;
 
-	//}
+		PointI topRight = new (1, 0);
+		BitMask topRightEnabled = new (2, 2);
+		topRightEnabled[topRight] = true;
 
-	//static readonly IReadOnlyList<TestCaseData> xor_offset_cases = CreateXorOffsetCases ().ToArray ();
-	//static IEnumerable<TestCaseData> CreateXorOffsetCases ()
-	//{
+		PointI bottomLeft = new (0, 1);
+		BitMask bottomLeftEnabled = new (2, 2);
+		bottomLeftEnabled[bottomLeft] = true;
 
-	//}
+		PointI bottomRight = new (1, 1);
+		BitMask bottomRightEnabled = new (2, 2);
+		bottomRightEnabled[bottomRight] = true;
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[bottomLeft] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomRightEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[bottomRight] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			topLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
+			}
+		);
+	}
+
+	static readonly IReadOnlyList<TestCaseData> xor_offset_cases = CreateXorOffsetCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateXorOffsetCases ()
+	{
+		PointI shift_left = new (-1, 0);
+		PointI shift_up = new (0, -1);
+		//PointI shift_left_up = new (-1, -1);
+		PointI shift_right_down = new (1, 1);
+		//PointI shift_right = new (1, 0);
+		//PointI shift_down = new (0, 1);
+		PointI no_shift = new (0, 0);
+
+		PointI topLeft = new (0, 0);
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[topLeft] = true;
+
+		PointI topRight = new (1, 0);
+		BitMask topRightEnabled = new (2, 2);
+		topRightEnabled[topRight] = true;
+
+		PointI bottomLeft = new (0, 1);
+		BitMask bottomLeftEnabled = new (2, 2);
+		bottomLeftEnabled[bottomLeft] = true;
+
+		PointI bottomRight = new (1, 1);
+		BitMask bottomRightEnabled = new (2, 2);
+		bottomRightEnabled[bottomRight] = true;
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			no_shift,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			shift_left,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topRight] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomLeftEnabled,
+			shift_up,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[bottomLeft] = false,
+			}
+		);
+
+		yield return new (
+			bottomRightEnabled,
+			topLeftEnabled,
+			shift_right_down,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[bottomRight] = false,
+			}
+		);
+	}
 
 	static readonly IReadOnlyList<TestCaseData> or_cases = CreateOrCases ().ToArray ();
 	static IEnumerable<TestCaseData> CreateOrCases ()

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -167,7 +167,7 @@ internal sealed class BitMaskTest
 			Assert.AreEqual (clone[kvp.Key], kvp.Value);
 	}
 
-	[TestCaseSource (nameof(horizontal_flip_cases))]
+	[TestCaseSource (nameof (horizontal_flip_cases))]
 	public void HorizontalFlip (BitMask mask, IReadOnlyDictionary<PointI, bool> checksAfter)
 	{
 		var clone = mask.Clone ();

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -530,6 +530,12 @@ internal sealed class BitMaskTest
 		BitMask bottomRightEnabled = new (2, 2);
 		bottomRightEnabled[bottomRight] = true;
 
+		BitMask biggerAllEnabled = new (3, 3);
+		biggerAllEnabled.Clear (true);
+
+		BitMask smallerEnabled = new (1, 1);
+		smallerEnabled.Clear (true);
+
 		yield return new (
 			topLeftEnabled,
 			topRightEnabled,
@@ -573,6 +579,28 @@ internal sealed class BitMaskTest
 				[bottomRight] = false,
 			}
 		);
+
+		yield return new (
+			bottomLeftEnabled,
+			biggerAllEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = true,
+				[bottomRight] = false,
+			}
+		);
+
+		//yield return new (
+		//	bottomLeftEnabled,
+		//	smallerEnabled,
+		//	new Dictionary<PointI, bool> {
+		//		[topLeft] = false,
+		//		[topRight] = false,
+		//		[bottomLeft] = false,
+		//		[bottomRight] = false,
+		//	}
+		//);
 	}
 
 	static readonly IReadOnlyList<TestCaseData> and_offset_cases = CreateAndOffsetCases ().ToArray ();

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -195,6 +195,180 @@ internal sealed class BitMaskTest
 			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
 	}
 
+	[TestCaseSource (nameof (or_cases))]
+	public void Or (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var leftClone = left.Clone ();
+		leftClone.Or (right);
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	}
+
+	[TestCaseSource (nameof (or_offset_cases))]
+	public void Or_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var leftClone = left.Clone ();
+		leftClone.Or (right, offset);
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	}
+
+	//[TestCaseSource (nameof (xor_cases))]
+	//public void Xor (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
+	//{
+	//	var leftClone = left.Clone ();
+	//	leftClone.Xor (right);
+	//	foreach (var kvp in checksAfter)
+	//		Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	//}
+
+	//[TestCaseSource (nameof (xor_offset_cases))]
+	//public void Xor_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
+	//{
+	//	var leftClone = left.Clone ();
+	//	leftClone.Xor (right, offset);
+	//	foreach (var kvp in checksAfter)
+	//		Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	//}
+
+	//static readonly IReadOnlyList<TestCaseData> xor_cases = CreateXorCases ().ToArray ();
+	//static IEnumerable<TestCaseData> CreateXorCases ()
+	//{
+
+	//}
+
+	//static readonly IReadOnlyList<TestCaseData> xor_offset_cases = CreateXorOffsetCases ().ToArray ();
+	//static IEnumerable<TestCaseData> CreateXorOffsetCases ()
+	//{
+
+	//}
+
+	static readonly IReadOnlyList<TestCaseData> or_cases = CreateOrCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateOrCases ()
+	{
+		PointI topLeft = new (0, 0);
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[topLeft] = true;
+
+		PointI topRight = new (1, 0);
+		BitMask topRightEnabled = new (2, 2);
+		topRightEnabled[topRight] = true;
+
+		PointI bottomLeft = new (0, 1);
+		BitMask bottomLeftEnabled = new (2, 2);
+		bottomLeftEnabled[bottomLeft] = true;
+
+		PointI bottomRight = new (1, 1);
+		BitMask bottomRightEnabled = new (2, 2);
+		bottomRightEnabled[bottomRight] = true;
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[bottomLeft] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomRightEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[bottomRight] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			topLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = false,
+				[bottomLeft] = false,
+				[bottomRight] = false,
+			}
+		);
+	}
+
+	static readonly IReadOnlyList<TestCaseData> or_offset_cases = CreateOrOffsetCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateOrOffsetCases ()
+	{
+		PointI shift_left = new (-1, 0);
+		PointI shift_up = new (0, -1);
+		//PointI shift_left_up = new (-1, -1);
+		PointI shift_right_down = new (1, 1);
+		//PointI shift_right = new (1, 0);
+		//PointI shift_down = new (0, 1);
+		PointI no_shift = new (0, 0);
+
+		PointI topLeft = new (0, 0);
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[topLeft] = true;
+
+		PointI topRight = new (1, 0);
+		BitMask topRightEnabled = new (2, 2);
+		topRightEnabled[topRight] = true;
+
+		PointI bottomLeft = new (0, 1);
+		BitMask bottomLeftEnabled = new (2, 2);
+		bottomLeftEnabled[bottomLeft] = true;
+
+		PointI bottomRight = new (1, 1);
+		BitMask bottomRightEnabled = new (2, 2);
+		bottomRightEnabled[bottomRight] = true;
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			no_shift,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = true,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			shift_left,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomLeftEnabled,
+			shift_up,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[bottomLeft] = false,
+			}
+		);
+
+		yield return new (
+			bottomRightEnabled,
+			topLeftEnabled,
+			shift_right_down,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[bottomRight] = true,
+			}
+		);
+	}
+
 	static readonly IReadOnlyList<TestCaseData> and_cases = CreateAndCases ().ToArray ();
 	static IEnumerable<TestCaseData> CreateAndCases ()
 	{
@@ -245,7 +419,6 @@ internal sealed class BitMaskTest
 			topLeftEnabled,
 			topLeftEnabled,
 			new Dictionary<PointI, bool> {
-				[topLeft] = false,
 				[topLeft] = true,
 			}
 		);

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using NUnit.Framework;
 
 namespace Pinta.Core.Tests;
@@ -176,12 +177,154 @@ internal sealed class BitMaskTest
 			Assert.AreEqual (clone[kvp.Key], kvp.Value);
 	}
 
+	[TestCaseSource (nameof (and_cases))]
+	public void And (BitMask left, BitMask right, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var leftClone = left.Clone ();
+		leftClone.And (right);
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	}
+
+	[TestCaseSource (nameof (and_offset_cases))]
+	public void And_Offset (BitMask left, BitMask right, PointI offset, IReadOnlyDictionary<PointI, bool> checksAfter)
+	{
+		var leftClone = left.Clone ();
+		leftClone.And (right, offset);
+		foreach (var kvp in checksAfter)
+			Assert.AreEqual (leftClone[kvp.Key], kvp.Value);
+	}
+
+	static readonly IReadOnlyList<TestCaseData> and_cases = CreateAndCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateAndCases ()
+	{
+		PointI topLeft = new (0, 0);
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[topLeft] = true;
+
+		PointI topRight = new (1, 0);
+		BitMask topRightEnabled = new (2, 2);
+		topRightEnabled[topRight] = true;
+
+		PointI bottomLeft = new (0, 1);
+		BitMask bottomLeftEnabled = new (2, 2);
+		bottomLeftEnabled[bottomLeft] = true;
+
+		PointI bottomRight = new (1, 1);
+		BitMask bottomRightEnabled = new (2, 2);
+		bottomRightEnabled[bottomRight] = true;
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topRight] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[bottomLeft] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomRightEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[bottomRight] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			topLeftEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topLeft] = true,
+			}
+		);
+	}
+
+	static readonly IReadOnlyList<TestCaseData> and_offset_cases = CreateAndOffsetCases ().ToArray ();
+	static IEnumerable<TestCaseData> CreateAndOffsetCases ()
+	{
+		PointI shift_left = new (-1, 0);
+		PointI shift_up = new (0, -1);
+		//PointI shift_left_up = new (-1, -1);
+		PointI shift_right_down = new (1, 1);
+		//PointI shift_right = new (1, 0);
+		//PointI shift_down = new (0, 1);
+		PointI no_shift = new (0, 0);
+
+		PointI topLeft = new (0, 0);
+		BitMask topLeftEnabled = new (2, 2);
+		topLeftEnabled[topLeft] = true;
+
+		PointI topRight = new (1, 0);
+		BitMask topRightEnabled = new (2, 2);
+		topRightEnabled[topRight] = true;
+
+		PointI bottomLeft = new (0, 1);
+		BitMask bottomLeftEnabled = new (2, 2);
+		bottomLeftEnabled[bottomLeft] = true;
+
+		PointI bottomRight = new (1, 1);
+		BitMask bottomRightEnabled = new (2, 2);
+		bottomRightEnabled[bottomRight] = true;
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			no_shift,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topRight] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			topRightEnabled,
+			shift_left,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[topRight] = false,
+			}
+		);
+
+		yield return new (
+			topLeftEnabled,
+			bottomLeftEnabled,
+			shift_up,
+			new Dictionary<PointI, bool> {
+				[topLeft] = true,
+				[bottomLeft] = false,
+			}
+		);
+
+		yield return new (
+			bottomRightEnabled,
+			topLeftEnabled,
+			shift_right_down,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[bottomRight] = true,
+			}
+		);
+	}
+
 	static readonly IReadOnlyList<TestCaseData> vertical_flip_cases = CreateVerticalFlipCases ().ToArray ();
 	static IEnumerable<TestCaseData> CreateVerticalFlipCases ()
 	{
 		BitMask topLeftEnabled = new (2, 2);
 		topLeftEnabled[0, 0] = true;
-		yield return new TestCaseData (
+		yield return new (
 			topLeftEnabled,
 			new Dictionary<PointI, bool> {
 				[new (0, 0)] = false,
@@ -195,7 +338,7 @@ internal sealed class BitMaskTest
 	{
 		BitMask topLeftEnabled = new (2, 2);
 		topLeftEnabled[0, 0] = true;
-		yield return new TestCaseData (
+		yield return new (
 			topLeftEnabled,
 			new Dictionary<PointI, bool> {
 				[new (0, 0)] = false,
@@ -221,17 +364,17 @@ internal sealed class BitMaskTest
 			[new (4, 0)] = false,
 			[new (0, 1)] = false,
 		};
-		yield return new TestCaseData (WIDTH, HEIGHT, singleTopLeftSequence, singleTopLeftChangedChecks);
-		yield return new TestCaseData (WIDTH, HEIGHT, singleTopLeftSequence, singleTopLeftOutOfRangeChecks);
+		yield return new (WIDTH, HEIGHT, singleTopLeftSequence, singleTopLeftChangedChecks);
+		yield return new (WIDTH, HEIGHT, singleTopLeftSequence, singleTopLeftOutOfRangeChecks);
 
 		var doubleTopLeftSequence = Enumerable.Repeat (topLeftLine, 2);
 		var doubleTopLeftChecks = singleTopLeftChangedChecks.ToDictionary (kvp => kvp.Key, kvp => !kvp.Value);
-		yield return new TestCaseData (WIDTH, HEIGHT, doubleTopLeftSequence, doubleTopLeftChecks);
-		yield return new TestCaseData (WIDTH, HEIGHT, doubleTopLeftSequence, singleTopLeftOutOfRangeChecks);
+		yield return new (WIDTH, HEIGHT, doubleTopLeftSequence, doubleTopLeftChecks);
+		yield return new (WIDTH, HEIGHT, doubleTopLeftSequence, singleTopLeftOutOfRangeChecks);
 
 		var singlePixelSequence = new[] { new Scanline (DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX, 1) };
 		var singlePixelChecks = new Dictionary<PointI, bool> { [new (DEFAULT_WIDTH_INDEX, DEFAULT_HEIGHT_INDEX)] = true };
-		yield return new TestCaseData (DEFAULT_WIDTH, DEFAULT_HEIGHT, singlePixelSequence, singlePixelChecks);
+		yield return new (DEFAULT_WIDTH, DEFAULT_HEIGHT, singlePixelSequence, singlePixelChecks);
 	}
 
 	static readonly IReadOnlyList<TestCaseData> rectangle_set_test_cases = CreateRectangleSetTestCases ().ToArray ();
@@ -250,7 +393,7 @@ internal sealed class BitMaskTest
 			[new (1, 1)] = true,
 			[new (2, 2)] = false,
 		};
-		yield return new TestCaseData (WIDTH, HEIGHT, topLeftAreaSequence, topLeftChecks);
+		yield return new (WIDTH, HEIGHT, topLeftAreaSequence, topLeftChecks);
 
 		RectangleI bottomRightArea = new (2, 2, 2, 2);
 		var bottomRightAreaSequence = new[] { KeyValuePair.Create (bottomRightArea, true) };
@@ -262,7 +405,7 @@ internal sealed class BitMaskTest
 			[new (1, 1)] = false,
 			[new (2, 2)] = true,
 		};
-		yield return new TestCaseData (WIDTH, HEIGHT, bottomRightAreaSequence, bottomRightChecks);
+		yield return new (WIDTH, HEIGHT, bottomRightAreaSequence, bottomRightChecks);
 	}
 
 	static readonly IReadOnlyList<TestCaseData> out_of_bounds_access_cases = new TestCaseData[]

--- a/tests/Pinta.Core.Tests/BitMaskTest.cs
+++ b/tests/Pinta.Core.Tests/BitMaskTest.cs
@@ -591,16 +591,16 @@ internal sealed class BitMaskTest
 			}
 		);
 
-		//yield return new (
-		//	bottomLeftEnabled,
-		//	smallerEnabled,
-		//	new Dictionary<PointI, bool> {
-		//		[topLeft] = false,
-		//		[topRight] = false,
-		//		[bottomLeft] = false,
-		//		[bottomRight] = false,
-		//	}
-		//);
+		yield return new (
+			bottomLeftEnabled,
+			smallerEnabled,
+			new Dictionary<PointI, bool> {
+				[topLeft] = false,
+				[topRight] = false,
+				[bottomLeft] = true,
+				[bottomRight] = false,
+			}
+		);
 	}
 
 	static readonly IReadOnlyList<TestCaseData> and_offset_cases = CreateAndOffsetCases ().ToArray ();


### PR DESCRIPTION
I'm doing this because these operations will be useful for a brush I want to make, but they could be useful on their own regardless. They include:

- Flip vertically
- Flip horizontally
- AND
- OR
- XOR
- NOT
- Clone
- Creation of submask (cloning an area)

Next, I plan to create bitmask views, but that's for another pull request