### PR TITLE
Modified `SimpleEffectDialog` to use `RandomSeed`, and changed effects that were using that mechanism

### DIFF
--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -171,7 +171,7 @@ public sealed class CloudsEffect : BaseEffect
 
 		var temp = CairoExtensions.CreateImageSurface (Format.Argb32, roi.Width, roi.Height);
 
-		RenderClouds (temp, roi, Data.Scale, (byte) (Data.Seed ^ instance_seed), Data.Power / 100.0,
+		RenderClouds (temp, roi, Data.Scale, (byte) (Data.Seed.Value ^ instance_seed), Data.Power / 100.0,
 				PintaCore.Palette.PrimaryColor.ToColorBgra (), PintaCore.Palette.SecondaryColor.ToColorBgra ());
 
 		temp.MarkDirty ();

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -219,8 +219,8 @@ public sealed class CloudsEffect : BaseEffect
 		[StaticList ("BlendOps")]
 		public string BlendMode { get; set; } = default_blend_op;
 
-		[Caption ("Seed"), MinimumValue (0), MaximumValue (255)]
-		public int Seed { get; set; } = 0;
+		[Caption ("Seed")]
+		public RandomSeed Seed { get; set; } = new (0);
 
 	}
 }

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -154,7 +154,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 
 			caption ??= MakeCaption (mi.Name);
 
-			if (mType == typeof (int) && (caption == "Seed"))
+			if (mType == typeof (RandomSeed))
 				yield return CreateSeed (localizer.GetString (caption), effectData, mi, attrs);
 			else if (mType == typeof (int))
 				yield return CreateSlider (localizer.GetString (caption), effectData, mi, attrs);
@@ -396,7 +396,21 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 	private ReseedButtonWidget CreateSeed (string caption, object o, MemberInfo member, object[] attributes)
 	{
 		var widget = new ReseedButtonWidget ();
-		widget.Clicked += (_, _) => SetValue (member, o, random.Next ());
+
+		int min_value = 0;
+		int max_value = int.MaxValue - 1;
+		foreach (var attr in attributes) {
+			switch (attr) {
+				case MinimumValueAttribute min:
+					min_value = min.Value;
+					break;
+				case MaximumValueAttribute max:
+					max_value = max.Value;
+					break;
+			}
+		}
+
+		widget.Clicked += (_, _) => SetValue (member, o, new RandomSeed (random.Next (min_value, max_value)));
 		return widget;
 	}
 


### PR DESCRIPTION
It appears that only `CloudsEffect` is using this.

Notice, however, that the attributes `MinimumValue` and `MaximumValue` were being ignored inside the `CreateSeed` method, so I added code to handle them, but also removed these attributes from `CloudsData` itself, as the effect seems to be working fine as is.

I updated the relevant documentation:
https://github.com/PintaProject/Pinta/wiki/SimpleEffectDialog-Reference/#random-seed