### PR TITLE
`Pinta.Core` internals visible to other assemblies

### DIFF
--- a/Pinta.Core/FriendAssemblies.cs
+++ b/Pinta.Core/FriendAssemblies.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo ("Pinta")]
+
+[assembly: InternalsVisibleTo ("Pinta.Core.Tests")]
+[assembly: InternalsVisibleTo ("Pinta.Effects.Tests")]
+[assembly: InternalsVisibleTo ("PintaBenchmarks")]
+
+[assembly: InternalsVisibleTo ("Pinta.Docking")]
+[assembly: InternalsVisibleTo ("Pinta.Effects")]
+[assembly: InternalsVisibleTo ("Pinta.Gui.Addins")]
+[assembly: InternalsVisibleTo ("Pinta.Gui.Widgets")]
+[assembly: InternalsVisibleTo ("Pinta.Resources")]
+[assembly: InternalsVisibleTo ("Pinta.Tools")]

--- a/Pinta.Core/FriendAssemblies.cs
+++ b/Pinta.Core/FriendAssemblies.cs
@@ -1,7 +1,5 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo ("Pinta")]
-
 [assembly: InternalsVisibleTo ("Pinta.Core.Tests")]
 [assembly: InternalsVisibleTo ("Pinta.Effects.Tests")]
 [assembly: InternalsVisibleTo ("PintaBenchmarks")]

--- a/Pinta.Core/FriendAssemblies.cs
+++ b/Pinta.Core/FriendAssemblies.cs
@@ -5,10 +5,3 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo ("Pinta.Core.Tests")]
 [assembly: InternalsVisibleTo ("Pinta.Effects.Tests")]
 [assembly: InternalsVisibleTo ("PintaBenchmarks")]
-
-[assembly: InternalsVisibleTo ("Pinta.Docking")]
-[assembly: InternalsVisibleTo ("Pinta.Effects")]
-[assembly: InternalsVisibleTo ("Pinta.Gui.Addins")]
-[assembly: InternalsVisibleTo ("Pinta.Gui.Widgets")]
-[assembly: InternalsVisibleTo ("Pinta.Resources")]
-[assembly: InternalsVisibleTo ("Pinta.Tools")]


### PR DESCRIPTION
I think that certain things in the codebase that should really be `internal` are `public` not because it makes sense to make them part of the public API, but because they need to be visible from other Pinta projects (for example when testing them). Adding this file would make it possible to make more things `internal`