### PR TITLE
Some variables of array types were converted to `Span<T>` , `ReadOnlySpan<T>`, or `IReadOnlyList<T>`

### DIFF
--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -355,7 +355,7 @@ public sealed class TextEngine
 		if (HasSelection ())
 			DeleteSelection ();
 
-		string[] ins_lines = txt.Split (Environment.NewLine.ToCharArray (), StringSplitOptions.RemoveEmptyEntries);
+		IReadOnlyList<string> ins_lines = txt.Split (Environment.NewLine.ToCharArray (), StringSplitOptions.RemoveEmptyEntries);
 		string endline = lines[current_pos.Line][current_pos.Offset..];
 		lines[current_pos.Line] = lines[current_pos.Line][..current_pos.Offset];
 		bool first = true;

--- a/Pinta.Core/Effects/Histogram.cs
+++ b/Pinta.Core/Effects/Histogram.cs
@@ -100,7 +100,7 @@ public abstract class Histogram
 		var ret = ImmutableArray.CreateBuilder<float> (Channels);
 		ret.Count = Channels;
 		for (int channel = 0; channel < Channels; ++channel) {
-			long[] channelHistogram = histogram[channel];
+			ReadOnlySpan<long> channelHistogram = histogram[channel];
 			long avg = 0;
 			long sum = 0;
 
@@ -123,7 +123,7 @@ public abstract class Histogram
 		var ret = ImmutableArray.CreateBuilder<int> (Channels);
 		ret.Count = Channels;
 		for (int channel = 0; channel < Channels; ++channel) {
-			long[] channelHistogram = histogram[channel];
+			ReadOnlySpan<long> channelHistogram = histogram[channel];
 			long integral = 0;
 			long sum = 0;
 			for (int j = 0; j < channelHistogram.Length; j++) {

--- a/Pinta.Core/Effects/HistogramRGB.cs
+++ b/Pinta.Core/Effects/HistogramRGB.cs
@@ -76,8 +76,8 @@ public sealed class HistogramRgb : Histogram
 		Span<float> slopes = stackalloc float[3];
 
 		for (int c = 0; c < 3; c++) {
-			long[] channelHistogramOutput = histogram[c];
-			long[] channelHistogramInput = inputHistogram.histogram[c];
+			Span<long> channelHistogramOutput = histogram[c];
+			Span<long> channelHistogramInput = inputHistogram.histogram[c];
 
 			for (int v = 0; v <= 255; v++) {
 				ColorBgra after = ColorBgra.FromBgr ((byte) v, (byte) v, (byte) v);

--- a/Pinta.Core/PaletteFormats/GimpPalette.cs
+++ b/Pinta.Core/PaletteFormats/GimpPalette.cs
@@ -54,7 +54,7 @@ public sealed class GimpPalette : IPaletteLoader, IPaletteSaver
 			if (line.IndexOf ('#') == 0)
 				continue;
 
-			string[] split = line.Split ((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+			IReadOnlyList<string> split = line.Split ((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
 			double r = int.Parse (split[0]) / 255f;
 			double g = int.Parse (split[1]) / 255f;
 			double b = int.Parse (split[2]) / 255f;

--- a/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
@@ -53,7 +53,7 @@ public sealed class PaintShopProPalette : IPaletteLoader, IPaletteSaver
 			if (line is null)
 				break;
 
-			string[] split = line.Split (' ');
+			IReadOnlyList<string> split = line.Split (' ');
 			double r = int.Parse (split[0]) / 255f;
 			double g = int.Parse (split[1]) / 255f;
 			double b = int.Parse (split[2]) / 255f;

--- a/Pinta.Gui.Addins/AddinManagerDialog.cs
+++ b/Pinta.Gui.Addins/AddinManagerDialog.cs
@@ -116,7 +116,7 @@ public sealed class AddinManagerDialog : Adw.Window
 	{
 		gallery_list.Clear ();
 
-		AddinRepositoryEntry[] reps = service.Repositories.GetAvailableAddins (RepositorySearchFlags.None);
+		IReadOnlyList<AddinRepositoryEntry> reps = service.Repositories.GetAvailableAddins (RepositorySearchFlags.None);
 		reps = FilterToLatestCompatibleVersion (reps);
 
 		foreach (var arep in reps) {
@@ -144,7 +144,7 @@ public sealed class AddinManagerDialog : Adw.Window
 	{
 		updates_list.Clear ();
 
-		AddinRepositoryEntry[] reps = service.Repositories.GetAvailableAddins (RepositorySearchFlags.None);
+		IReadOnlyList<AddinRepositoryEntry> reps = service.Repositories.GetAvailableAddins (RepositorySearchFlags.None);
 		reps = FilterToLatestCompatibleVersion (reps);
 
 		foreach (var arep in reps) {
@@ -166,7 +166,7 @@ public sealed class AddinManagerDialog : Adw.Window
 
 	// Similar to RepositoryRegistry.FilterOldVersions(), but also filters out newer versions that require an
 	// updated version of the application.
-	private static AddinRepositoryEntry[] FilterToLatestCompatibleVersion (AddinRepositoryEntry[] addins)
+	private static AddinRepositoryEntry[] FilterToLatestCompatibleVersion (IReadOnlyList<AddinRepositoryEntry> addins)
 	{
 		Dictionary<string, string> latest_versions = new ();
 		foreach (var a in addins) {
@@ -213,7 +213,7 @@ public sealed class AddinManagerDialog : Adw.Window
 			if (e.ResponseId != (int) Gtk.ResponseType.Accept)
 				return;
 
-			string[] files = dialog.GetFileList ()
+			IReadOnlyList<string> files = dialog.GetFileList ()
 				.Select (f => f.GetPath () ?? string.Empty)
 				.Where (f => !string.IsNullOrEmpty (f))
 				.ToArray ();

--- a/Pinta.Gui.Addins/InstallDialog.cs
+++ b/Pinta.Gui.Addins/InstallDialog.cs
@@ -138,7 +138,7 @@ internal sealed class InstallDialog : Adw.Window
 		DisplayInstallInfo ();
 	}
 
-	public bool InitForInstall (string[] files_to_install)
+	public bool InitForInstall (IEnumerable<string> files_to_install)
 	{
 		try {
 			foreach (string file in files_to_install)

--- a/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Cairo;
 using Gtk;
@@ -227,7 +228,7 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 		if (engine is LineCurveSeriesEngine lCSEngine && engine.ControlPoints.Count > 0) {
 
 			// Draw the arrows for the currently active shape.
-			GeneratedPoint[] genPoints = engine.GeneratedPoints;
+			ReadOnlySpan<GeneratedPoint> genPoints = engine.GeneratedPoints;
 
 			if (lCSEngine.Arrow1.Show && genPoints.Length > 1) {
 				var rect = lCSEngine.Arrow1.Draw (


### PR DESCRIPTION
In general, the rule is:
- `IReadOnlyList<T>` for arrays that are being created by the method called
- `ReadOnlySpan<T>` for arrays that are merely being referenced _and_ only being read
- `Span<T>` for arrays that are merely being referenced _and_ being written