### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,16 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  DOTNET_VERSION: 7.0.x
+  DOTNET_VERSION: 8.0.x
 
 jobs:
   build-ubuntu:
     runs-on: ubuntu-22.04
 
-    # Test building with .NET 6 and .NET 7
+    # Test building with .NET 7 and .NET 8
     strategy:
       matrix:
-        dotnet_version: [6.0.x, 7.0.x]
+        dotnet_version: [7.0.x, 8.0.x]
 
     env:
       # Skip pkg-config version checks. Ubuntu 22.04 doesn't have a recent
@@ -38,8 +38,8 @@ jobs:
       with:
         dotnet-version: ${{matrix.dotnet_version}}
     - name: Create temporary global.json
-      if: matrix.dotnet_version == '6.0.x'
-      run: mv .github/workflows/dotnet6.global.json ./global.json
+      if: matrix.dotnet_version == '7.0.x'
+      run: mv .github/workflows/dotnet7.global.json ./global.json
     - name: Install Apt Dependencies
       run: |
         sudo apt update

--- a/.github/workflows/dotnet7.global.json
+++ b/.github/workflows/dotnet7.global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Thanks to the following contributors who worked on this release:
 ### Added
 - Ported to GTK4 and libadwaita
   - Due to API changes in GTK4, the File -> New Screenshot option now invokes platform-specific tools (the XDG screenshot portal on Linux, and the screenshot tool on maCOS). This is currently unsupported on Windows
+- Upgraded to .NET 8
+  - Building against .NET 7 is still supported. When building from the tarball, .NET 7 will be used if .NET 8 is unavailable.
 - Restored support for add-ins, which had been disabled in Pinta 2.0 due to technical limitations
   - Ported the add-in manager dialog to GTK4
   - The add-in manager dialog now filters out old versions incompatible with the current version of Pinta, or new addins requiring future version of Pinta ([#1580205](https://bugs.launchpad.net/pinta/+bug/1580205))

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- The target framework can be set with an environment variable of the same name -->
-    <TargetFramework Condition=" '$(TargetFramework)' == '' ">net7.0</TargetFramework>
+    <TargetFramework Condition=" '$(TargetFramework)' == '' ">net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <!-- Versioning and assembly info -->

--- a/configure.ac
+++ b/configure.ac
@@ -22,9 +22,9 @@ AX_COMPARE_VERSION([$DOTNET_VERSION], [ge], [$DOTNET_MINIMUM_VERSION],
 )
 
 # Select target framework based on the dotnet version.
-DOTNET_TARGET_FRAMEWORK=net6.0
-AX_COMPARE_VERSION([$DOTNET_VERSION], [ge], [7.0],
-                   [DOTNET_TARGET_FRAMEWORK=net7.0], [])
+DOTNET_TARGET_FRAMEWORK=net7.0
+AX_COMPARE_VERSION([$DOTNET_VERSION], [ge], [8.0],
+                   [DOTNET_TARGET_FRAMEWORK=net8.0], [])
 AC_MSG_NOTICE([Using target framework $DOTNET_TARGET_FRAMEWORK])
 
 DOTNET_CMD="env TargetFramework=$DOTNET_TARGET_FRAMEWORK $DOTNET"

--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,10 @@ Used under [Creative Commons Attribution 3.0 License](http://creativecommons.org
 ## Building on Windows
 
 Pinta can be built by opening `Pinta.sln` in [Visual Studio](https://visualstudio.microsoft.com/).
-Ensure that .NET 7 is installed via the Visual Studio installer.
+Ensure that .NET 8 is installed via the Visual Studio installer.
 
 For building on the command line:
-- [Install the .NET 7 SDK](https://dotnet.microsoft.com/).
+- [Install the .NET 8 SDK](https://dotnet.microsoft.com/).
 - Build:
   - `dotnet build`
 - Run:
@@ -40,7 +40,7 @@ For building on the command line:
 
 ## Building on macOS
 
-- Install .NET 7 and GTK4
+- Install .NET 8 and GTK4
   - `brew install dotnet-sdk libadwaita adwaita-icon-theme gettext webp-pixbuf-loader`
 - Build:
   - `dotnet build`
@@ -51,7 +51,7 @@ Alternatively, Pinta can be built by opening `Pinta.sln` in [Visual Studio for M
 
 ## Building on Linux
 
-- Install [.NET 7](https://dotnet.microsoft.com/) following the instructions for your Linux distribution.
+- Install [.NET 8](https://dotnet.microsoft.com/) following the instructions for your Linux distribution.
 - Install other dependencies (instructions are for Ubuntu 22.10, but should be similar for other distros):
   - `sudo apt install autotools-dev autoconf-archive gettext intltool libadwaita-1-dev
   - Minimum library versions: `gtk` >= 4.8 and `libadwaita` >= 1.2


### PR DESCRIPTION
Building against .NET 7 is still supported for now