### PR TITLE
Removed `ref readonly` for array accesses

### DIFF
--- a/Pinta.Core/Effects/ColorDifferenceEffect.cs
+++ b/Pinta.Core/Effects/ColorDifferenceEffect.cs
@@ -62,11 +62,11 @@ public abstract class ColorDifferenceEffect : BaseEffect
 					for (int fy = fyStart; fy < fyEnd; ++fy) {
 						for (int fx = fxStart; fx < fxEnd; ++fx) {
 							double weight = weights[fy][fx];
-							ref readonly ColorBgra c = ref src_data[(y - 1 + fy) * src_width + (x - 1 + fx)];
+							ColorBgra c = src_data[(y - 1 + fy) * src_width + (x - 1 + fx)];
 
-							rSum += weight * (double) c.R;
-							gSum += weight * (double) c.G;
-							bSum += weight * (double) c.B;
+							rSum += weight * c.R;
+							gSum += weight * c.G;
+							bSum += weight * c.B;
 						}
 					}
 

--- a/Pinta.Core/Effects/HistogramRGB.cs
+++ b/Pinta.Core/Effects/HistogramRGB.cs
@@ -56,7 +56,7 @@ public sealed class HistogramRgb : Histogram
 		for (int y = rect.Y; y <= rect.Bottom; ++y) {
 			var row = data[(y * width)..];
 			for (int x = rect.X; x <= rect_right; ++x) {
-				ref readonly ColorBgra c = ref row[x];
+				ColorBgra c = row[x];
 				++histogramB[c.B];
 				++histogramG[c.G];
 				++histogramR[c.R];

--- a/Pinta.Core/Effects/UnaryPixelOps.cs
+++ b/Pinta.Core/Effects/UnaryPixelOps.cs
@@ -382,7 +382,7 @@ public static class UnaryPixelOps
 		{
 			for (int i = 0; i < src.Length; ++i) {
 				ref ColorBgra d = ref dst[i];
-				ref readonly ColorBgra s = ref src[i];
+				ColorBgra s = src[i];
 				d = ColorBgra.FromBgra (
 					b: CurveB[s.B],
 					g: CurveG[s.G],
@@ -795,7 +795,7 @@ public static class UnaryPixelOps
 		{
 			for (int i = 0; i < src.Length; ++i) {
 				ref ColorBgra d = ref dst[i];
-				ref readonly ColorBgra s = ref src[i];
+				ColorBgra s = src[i];
 				d.B = blue_levels[s.B];
 				d.G = green_levels[s.G];
 				d.R = red_levels[s.R];

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -68,7 +68,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 
 				if (divide == 0) {
 					for (int i = 0; i < src_row.Length; ++i) {
-						ref readonly ColorBgra col = ref src_row[i];
+						ColorBgra col = src_row[i];
 						uint c = rgb_table![col.GetIntensityByte ()]; // NRT - Set in Calculate
 						dst_row[i].Bgra = (col.Bgra & 0xff000000) | c | (c << 8) | (c << 16);
 					}

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -145,7 +145,7 @@ public sealed class AddNoiseEffect : BaseEffect
 						g = i + (((g - i) * sat) >> 12);
 						b = i + (((b - i) * sat) >> 12);
 
-						ref readonly ColorBgra src_pixel = ref src_row[x];
+						ColorBgra src_pixel = src_row[x];
 						ref ColorBgra dst_pixel = ref dst_row[x];
 
 						dst_pixel.R = Utility.ClampToByte (src_pixel.R + ((r * dev + 32768) >> 16));

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -118,7 +118,7 @@ public sealed class InkSketchEffect : BaseEffect
 							int i1 = u - x + radius;
 							int w = conv[j][i1];
 
-							ref readonly ColorBgra src_pixel = ref src_row[u];
+							ColorBgra src_pixel = src_row[u];
 
 							r += src_pixel.R * w;
 							g += src_pixel.G * w;

--- a/Pinta.Effects/Effects/LocalHistogramEffect.cs
+++ b/Pinta.Effects/Effects/LocalHistogramEffect.cs
@@ -158,7 +158,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 				ReadOnlySpan<ColorBgra> psamples = src_data[((y + v) * width + rect.Left + left)..];
 
 				for (int u = left, i = 0; u <= right; ++u, ++i) {
-					ref readonly ColorBgra psamp = ref psamples[i];
+					ColorBgra psamp = psamples[i];
 					if ((u * u + v * v) <= cutoff) {
 						++area;
 						++hb[psamp.B];
@@ -196,7 +196,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v >= top) {
 					int u = leadingEdgeX[-v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) - u];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) - u];
 
 					--hb[p.B];
 					--hg[p.G];
@@ -221,7 +221,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v >= top) {
 					int u = leadingEdgeX[-v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) + u + 1];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) + u + 1];
 					++hb[p.B];
 					++hg[p.G];
 					++hr[p.R];
@@ -246,7 +246,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v <= bottom) {
 					int u = leadingEdgeX[v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) - u];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) - u];
 					--hb[p.B];
 					--hg[p.G];
 					--hr[p.R];
@@ -271,7 +271,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v <= bottom) {
 					int u = leadingEdgeX[v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) + u + 1];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) + u + 1];
 					++hb[p.B];
 					++hg[p.G];
 					++hr[p.R];
@@ -340,7 +340,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 				ReadOnlySpan<ColorBgra> psamples = src_data[((y + v) * width + rect.Left + left)..];
 
 				for (int u = left, i = 0; u <= right; ++u, ++i) {
-					ref readonly ColorBgra psamp = ref psamples[i];
+					ColorBgra psamp = psamples[i];
 					if ((u * u + v * v) <= cutoff) {
 						++area;
 						byte w = psamp.A;
@@ -379,7 +379,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v >= top) {
 					int u = leadingEdgeX[-v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) - u];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) - u];
 					byte w = p.A;
 
 					hb[p.B] -= w;
@@ -405,7 +405,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v >= top) {
 					int u = leadingEdgeX[-v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) + u + 1];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) + u + 1];
 					byte w = p.A;
 
 					hb[p.B] += w;
@@ -432,7 +432,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v <= bottom) {
 					int u = leadingEdgeX[v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) - u];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) - u];
 					byte w = p.A;
 
 					hb[p.B] -= w;
@@ -459,7 +459,7 @@ public abstract class LocalHistogramEffect : BaseEffect
 
 				while (v <= bottom) {
 					int u = leadingEdgeX[v];
-					ref readonly ColorBgra p = ref src_data[(y * width + x) + (v * stride) + u + 1];
+					ColorBgra p = src_data[(y * width + x) + (v * stride) + u + 1];
 					byte w = p.A;
 
 					hb[p.B] += w;

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -113,7 +113,7 @@ public sealed class OilPaintingEffect : BaseEffect
 		for (int j = top; j < bottom; ++j) {
 			var src_row = src_data.Slice (j * settings.width, settings.width);
 			for (int i = left; i < right; ++i) {
-				ref readonly ColorBgra src_pixel = ref src_row[i];
+				ColorBgra src_pixel = src_row[i];
 				byte intensity = Utility.FastScaleByteByByte (src_pixel.GetIntensityByte (), settings.maxIntensity);
 
 				++intensityCount[intensity];

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -77,7 +77,7 @@ public sealed class RadialBlurEffect : BaseEffect
 
 				for (int x = rect.Left; x <= rect.Right; ++x) {
 					ref ColorBgra dst_pixel = ref dst_row[x];
-					ref readonly ColorBgra src_pixel = ref src_row[x];
+					ColorBgra src_pixel = src_row[x];
 
 					int fx = (x << 16) - fcx;
 					int fy = (y << 16) - fcy;
@@ -103,7 +103,7 @@ public sealed class RadialBlurEffect : BaseEffect
 						int v1 = oy1 + fcy + 32768 >> 16;
 
 						if (u1 > 0 && v1 > 0 && u1 < w && v1 < h) {
-							ref readonly ColorBgra sample = ref src_data[v1 * src_w + u1];
+							ColorBgra sample = src_data[v1 * src_w + u1];
 
 							sr += sample.R * sample.A;
 							sg += sample.G * sample.A;
@@ -116,7 +116,7 @@ public sealed class RadialBlurEffect : BaseEffect
 						int v2 = oy2 + fcy + 32768 >> 16;
 
 						if (u2 > 0 && v2 > 0 && u2 < w && v2 < h) {
-							ref readonly ColorBgra sample = ref src_data[v2 * src_w + u2];
+							ColorBgra sample = src_data[v2 * src_w + u2];
 
 							sr += sample.R * sample.A;
 							sg += sample.G * sample.A;

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -77,7 +77,7 @@ public sealed class ZoomBlurEffect : BaseEffect
 					int sa = 0;
 					int sc = 0;
 
-					ref readonly ColorBgra src_pixel = ref src_row[x];
+					ColorBgra src_pixel = src_row[x];
 					sr += src_pixel.R * src_pixel.A;
 					sg += src_pixel.G * src_pixel.A;
 					sb += src_pixel.B * src_pixel.A;

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -133,7 +133,7 @@ public class RecolorTool : BaseBrushTool
 				if (stencil[i, j])
 					continue;
 
-				ref readonly ColorBgra surf_color = ref surf_data[j * surf_width + i];
+				ColorBgra surf_color = surf_data[j * surf_width + i];
 				if (ColorBgra.ColorsWithinTolerance (new_color, surf_color, myTolerance))
 					tmp_data[j * tmp_width + i] = AdjustColorDifference (new_color, old_color, surf_color);
 


### PR DESCRIPTION
It could get confusing in situations where we just need to read a value (so a copy of the value on the stack is ok).

When the `ref readonly`s were returned by a method as such (specifically `CairoExtensions.GetColorBgra`) they were not removed.

I presume that the original intention of the code was to have an actual reference to the current color of the pixel in question, as opposed to a snapshot of it, such that the code always reads the updated pixel. In practice, though, the code seems to be single-threaded at that level, but even if it weren't, the pixel isn't terribly likely to change while its individual components are being read (the length of the time where this happens is just very short).

A possible use case for `readonly ref` is using the data of the pixel to update that same pixel (so one operation would affect the next read of the pixel) but I didn't find such a thing.