### PR TITLE
Removed a few `ref`s to `ColorBgra` used to modify pixel colors

### DIFF
--- a/Pinta.Core/Effects/ColorBgra.cs
+++ b/Pinta.Core/Effects/ColorBgra.cs
@@ -322,14 +322,12 @@ public struct ColorBgra
 	/// </remarks>
 	public static ColorBgra Lerp (ColorBgra from, ColorBgra to, double frac)
 	{
-		ColorBgra ret = new ColorBgra {
-			B = Utility.ClampToByte (Lerp (from.B, to.B, frac)),
-			G = Utility.ClampToByte (Lerp (from.G, to.G, frac)),
-			R = Utility.ClampToByte (Lerp (from.R, to.R, frac)),
-			A = Utility.ClampToByte (Lerp (from.A, to.A, frac))
-		};
-
-		return ret;
+		return FromBgra (
+			b: Utility.ClampToByte (Lerp (from.B, to.B, frac)),
+			g: Utility.ClampToByte (Lerp (from.G, to.G, frac)),
+			r: Utility.ClampToByte (Lerp (from.R, to.R, frac)),
+			a: Utility.ClampToByte (Lerp (from.A, to.A, frac))
+		);
 	}
 
 	/// <summary>

--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -145,8 +145,8 @@ public abstract class GradientRenderer
 			for (int y = rect.Top; y <= rect.Bottom; ++y) {
 				var row = src_data.Slice (y * src_width, src_width);
 				for (int x = rect.Left; x <= rect.Right; ++x) {
-					ref ColorBgra pixel = ref row[x];
-					pixel = GetFinalSolidColor (bounds, pixel);
+					ColorBgra originalPixel = row[x];
+					row[x] = GetFinalSolidColor (bounds, originalPixel);
 				}
 			}
 		}
@@ -184,31 +184,30 @@ public abstract class GradientRenderer
 			for (var x = rect.Left; x <= right; ++x) {
 				var lerpByte = ComputeByteLerp (x, y);
 				var lerpAlpha = lerp_alphas[lerpByte];
-				ref ColorBgra pixel = ref row[x];
-				pixel = ColorBgra.FromBgra (
-					b: Utility.FastScaleByteByByte (pixel.B, lerpAlpha),
-					g: Utility.FastScaleByteByByte (pixel.G, lerpAlpha),
-					r: Utility.FastScaleByteByByte (pixel.R, lerpAlpha),
-					a: Utility.FastScaleByteByByte (pixel.A, lerpAlpha)
+				ColorBgra originalPixel = row[x];
+				row[x] = ColorBgra.FromBgra (
+					b: Utility.FastScaleByteByByte (originalPixel.B, lerpAlpha),
+					g: Utility.FastScaleByteByByte (originalPixel.G, lerpAlpha),
+					r: Utility.FastScaleByteByByte (originalPixel.R, lerpAlpha),
+					a: Utility.FastScaleByteByByte (originalPixel.A, lerpAlpha)
 				);
 			}
 		} else if (alpha_only && !alpha_blending) {
 			for (var x = rect.Left; x <= right; ++x) {
 				var lerpByte = ComputeByteLerp (x, y);
 				var lerpAlpha = lerp_alphas[lerpByte];
-				ref ColorBgra pixel = ref row[x];
-
-				var color = pixel.ToStraightAlpha ();
+				ColorBgra original = row[x];
+				var color = original.ToStraightAlpha ();
 				color.A = lerpAlpha;
-				pixel = color.ToPremultipliedAlpha ();
+				row[x] = color.ToPremultipliedAlpha ();
 			}
 		} else if (!alpha_only && (alpha_blending && (startAlpha != 255 || endAlpha != 255))) {
 			// If we're doing all color channels, and we're doing alpha blending, and if alpha blending is necessary
 			for (var x = rect.Left; x <= right; ++x) {
 				var lerpByte = ComputeByteLerp (x, y);
 				var lerpColor = lerp_colors[lerpByte];
-				ref ColorBgra pixel = ref row[x];
-				pixel = normal_blend_op.Apply (pixel, lerpColor);
+				ColorBgra originalPixel = row[x];
+				row[x] = normal_blend_op.Apply (originalPixel, lerpColor);
 			}
 			//if (!this.alphaOnly && !this.alphaBlending) // or sC.A == 255 && eC.A == 255
 		} else {

--- a/Pinta.Core/Effects/UnaryPixelOps.cs
+++ b/Pinta.Core/Effects/UnaryPixelOps.cs
@@ -311,21 +311,22 @@ public static class UnaryPixelOps
 		public override void Apply (Span<ColorBgra> dst, ReadOnlySpan<ColorBgra> src)
 		{
 			for (int i = 0; i < src.Length; ++i) {
-				ref ColorBgra result = ref dst[i];
 				byte val = src[i].GetIntensityByte ();
 				dst[i] = ColorBgra.FromBgra (val, val, val, src[i].A);
-				result.R = result.G = result.B = val;
-				result.A = src[i].A;
 			}
 		}
 
 		public override void Apply (Span<ColorBgra> dst)
 		{
 			for (int i = 0; i < dst.Length; ++i) {
-				ref ColorBgra result = ref dst[i];
-				byte val = result.GetIntensityByte ();
-				result.R = result.G = result.B = val;
-
+				ColorBgra original = dst[i];
+				byte val = original.GetIntensityByte ();
+				dst[i] = ColorBgra.FromBgra (
+					b: val,
+					g: val,
+					r: val,
+					a: original.A
+				);
 			}
 		}
 	}
@@ -381,9 +382,8 @@ public static class UnaryPixelOps
 		public override void Apply (Span<ColorBgra> dst, ReadOnlySpan<ColorBgra> src)
 		{
 			for (int i = 0; i < src.Length; ++i) {
-				ref ColorBgra d = ref dst[i];
 				ColorBgra s = src[i];
-				d = ColorBgra.FromBgra (
+				dst[i] = ColorBgra.FromBgra (
 					b: CurveB[s.B],
 					g: CurveG[s.G],
 					r: CurveR[s.R],
@@ -395,11 +395,13 @@ public static class UnaryPixelOps
 		public override void Apply (Span<ColorBgra> dst)
 		{
 			for (int i = 0; i < dst.Length; ++i) {
-				ref ColorBgra d = ref dst[i];
-				d.B = CurveB[d.B];
-				d.G = CurveG[d.G];
-				d.R = CurveR[d.R];
-
+				ColorBgra original = dst[i];
+				dst[i] = ColorBgra.FromBgra (
+					b: CurveB[original.B],
+					g: CurveG[original.G],
+					r: CurveR[original.R],
+					a: original.A
+				);
 			}
 		}
 
@@ -794,23 +796,27 @@ public static class UnaryPixelOps
 		public override void Apply (Span<ColorBgra> dst, ReadOnlySpan<ColorBgra> src)
 		{
 			for (int i = 0; i < src.Length; ++i) {
-				ref ColorBgra d = ref dst[i];
-				ColorBgra s = src[i];
-				d.B = blue_levels[s.B];
-				d.G = green_levels[s.G];
-				d.R = red_levels[s.R];
-				d.A = s.A;
+				ColorBgra source = src[i];
+				dst[i] = ColorBgra.FromBgra (
+					b: blue_levels[source.B],
+					g: green_levels[source.G],
+					r: red_levels[source.R],
+					a: source.A
+				);
+
 			}
 		}
 
 		public override void Apply (Span<ColorBgra> dst)
 		{
 			for (int i = 0; i < dst.Length; ++i) {
-				ref ColorBgra d = ref dst[i];
-				d.B = blue_levels[d.B];
-				d.G = green_levels[d.G];
-				d.R = red_levels[d.R];
-
+				ColorBgra original = dst[i];
+				dst[i] = ColorBgra.FromBgra (
+					b: blue_levels[original.B],
+					g: green_levels[original.G],
+					r: red_levels[original.R],
+					a: original.A
+				);
 			}
 		}
 	}

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -390,14 +390,12 @@ namespace Pinta.Core
 
 		public static ColorBgra ToColorBgra (this Cairo.Color color)
 		{
-			ColorBgra c = new ColorBgra {
-				R = (byte) (color.R * 255),
-				G = (byte) (color.G * 255),
-				B = (byte) (color.B * 255),
-				A = (byte) (color.A * 255)
-			};
-
-			return c;
+			return ColorBgra.FromBgra (
+				b: (byte) (color.B * 255),
+				g: (byte) (color.G * 255),
+				r: (byte) (color.R * 255),
+				a: (byte) (color.A * 255)
+			);
 		}
 
 		public static Cairo.Color ToCairoColor (this ColorBgra color)

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -146,12 +146,13 @@ public sealed class AddNoiseEffect : BaseEffect
 						b = i + (((b - i) * sat) >> 12);
 
 						ColorBgra src_pixel = src_row[x];
-						ref ColorBgra dst_pixel = ref dst_row[x];
 
-						dst_pixel.R = Utility.ClampToByte (src_pixel.R + ((r * dev + 32768) >> 16));
-						dst_pixel.G = Utility.ClampToByte (src_pixel.G + ((g * dev + 32768) >> 16));
-						dst_pixel.B = Utility.ClampToByte (src_pixel.B + ((b * dev + 32768) >> 16));
-						dst_pixel.A = src_pixel.A;
+						dst_row[x] = ColorBgra.FromBgra (
+							b: Utility.ClampToByte (src_pixel.B + ((b * dev + 32768) >> 16)),
+							g: Utility.ClampToByte (src_pixel.G + ((g * dev + 32768) >> 16)),
+							r: Utility.ClampToByte (src_pixel.R + ((r * dev + 32768) >> 16)),
+							a: src_pixel.A
+						);
 					}
 				}
 			}

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -142,8 +142,8 @@ public sealed class InkSketchEffect : BaseEffect
 					}
 
 					// Change Blend Mode to Darken
-					ref ColorBgra dst_pixel = ref dst_row[x];
-					dst_pixel = darken_op.Apply (topLayer, dst_pixel);
+					ColorBgra originalPixel = dst_row[x];
+					dst_row[x] = darken_op.Apply (topLayer, originalPixel);
 				}
 			}
 		}

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -76,7 +76,7 @@ public sealed class RadialBlurEffect : BaseEffect
 				var src_row = src_data.Slice (y * src_w, src_w);
 
 				for (int x = rect.Left; x <= rect.Right; ++x) {
-					ref ColorBgra dst_pixel = ref dst_row[x];
+
 					ColorBgra src_pixel = src_row[x];
 
 					int fx = (x << 16) - fcx;
@@ -127,13 +127,13 @@ public sealed class RadialBlurEffect : BaseEffect
 					}
 
 					if (sa > 0) {
-						dst_pixel = ColorBgra.FromBgra (
+						dst_row[x] = ColorBgra.FromBgra (
 						    Utility.ClampToByte (sb / sa),
 						    Utility.ClampToByte (sg / sa),
 						    Utility.ClampToByte (sr / sa),
 						    Utility.ClampToByte (sa / sc));
 					} else {
-						dst_pixel.Bgra = 0;
+						dst_row[x].Bgra = 0;
 					}
 				}
 			}

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -102,16 +102,15 @@ public sealed class ZoomBlurEffect : BaseEffect
 						}
 					}
 
-					ref ColorBgra dst_pixel = ref dst_row[x];
-
 					if (sa != 0) {
-						dst_pixel = ColorBgra.FromBgra (
-						    Utility.ClampToByte (sb / sa),
-						    Utility.ClampToByte (sg / sa),
-						    Utility.ClampToByte (sr / sa),
-						    Utility.ClampToByte (sa / sc));
+						dst_row[x] = ColorBgra.FromBgra (
+							b: Utility.ClampToByte (sb / sa),
+							g: Utility.ClampToByte (sg / sa),
+							r: Utility.ClampToByte (sr / sa),
+							a: Utility.ClampToByte (sa / sc)
+						);
 					} else {
-						dst_pixel.Bgra = 0;
+						dst_row[x].Bgra = 0;
 					}
 				}
 			}

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -218,7 +218,7 @@ public sealed class EraserTool : BaseBrushTool
 					dy = -dy;
 
 				for (var ix = dest_rect.Left; ix < dest_rect.Right; ix++) {
-					ref ColorBgra col = ref srcRow[ix - dest_rect.Left];
+
 					var dx = ((ix - x) * LUT_Resolution) / rad;
 
 					if (dx < 0)
@@ -227,19 +227,21 @@ public sealed class EraserTool : BaseBrushTool
 					var force = lut_factor[dy, dx];
 
 					// Note: premultiplied alpha is used!
+					int idx = ix - dest_rect.Left;
+					ColorBgra original = srcRow[idx];
 					if (mouse_button == MouseButton.Right) {
-						col = ColorBgra.FromBgra (
-							b: (byte) ((col.B * force + bk_col_b * (255 - force)) / 255),
-							g: (byte) ((col.G * force + bk_col_g * (255 - force)) / 255),
-							r: (byte) ((col.R * force + bk_col_r * (255 - force)) / 255),
-							a: (byte) ((col.A * force + bk_col_a * (255 - force)) / 255)
+						srcRow[idx] = ColorBgra.FromBgra (
+							b: (byte) ((original.B * force + bk_col_b * (255 - force)) / 255),
+							g: (byte) ((original.G * force + bk_col_g * (255 - force)) / 255),
+							r: (byte) ((original.R * force + bk_col_r * (255 - force)) / 255),
+							a: (byte) ((original.A * force + bk_col_a * (255 - force)) / 255)
 						);
 					} else {
-						col = ColorBgra.FromBgra (
-							b: (byte) (col.B * force / 255),
-							g: (byte) (col.G * force / 255),
-							r: (byte) (col.R * force / 255),
-							a: (byte) (col.A * force / 255)
+						srcRow[idx] = ColorBgra.FromBgra (
+							b: (byte) (original.B * force / 255),
+							g: (byte) (original.G * force / 255),
+							r: (byte) (original.R * force / 255),
+							a: (byte) (original.A * force / 255)
 						);
 					}
 				}

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -172,16 +172,12 @@ public class RecolorTool : BaseBrushTool
 	#region Private PDN Methods
 	private static ColorBgra AdjustColorDifference (ColorBgra oldColor, ColorBgra newColor, ColorBgra basisColor)
 	{
-		ColorBgra returnColor;
-
-		// eliminate testing for the "equal to" case
-		returnColor = basisColor;
-
-		returnColor.B = AdjustColorByte (oldColor.B, newColor.B, basisColor.B);
-		returnColor.G = AdjustColorByte (oldColor.G, newColor.G, basisColor.G);
-		returnColor.R = AdjustColorByte (oldColor.R, newColor.R, basisColor.R);
-
-		return returnColor;
+		return ColorBgra.FromBgra (
+			b: AdjustColorByte (oldColor.B, newColor.B, basisColor.B),
+			g: AdjustColorByte (oldColor.G, newColor.G, basisColor.G),
+			r: AdjustColorByte (oldColor.R, newColor.R, basisColor.R),
+			a: basisColor.A
+		);
 	}
 
 	private static byte AdjustColorByte (byte oldByte, byte newByte, byte basisByte)


### PR DESCRIPTION
Also, some occurrences where its members are mutated were replaced by `ColorBgra.FromBgra()`. I don't know how feasible it is to make `ColorBgra` a `readonly` `struct`, but this may be a step in the right direction