### PR TITLE
Re-enable the Windows installer for GTK4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,21 +126,15 @@ jobs:
         update: true
         install: mingw-w64-x86_64-libadwaita
     - name: Build
-      env:
-        MinGWFolder: ${{env.MINGW_PREFIX}}
-      run: dotnet build Pinta.sln -c Release
+      run: dotnet build Pinta.sln -c Release -p:MinGWFolder=${MINGW_PREFIX} 
     - name: Test
-      env:
-        MinGWFolder: ${{env.MINGW_PREFIX}}
-      run: dotnet test Pinta.sln -c Release
+      run: dotnet test Pinta.sln -c Release -p:MinGWFolder=${MINGW_PREFIX} 
 
     # Note that msgfmt is already available from the Git for Windows installation!
     - name: Build Installer
-      env:
-        MinGWFolder: ${{env.MINGW_PREFIX}}
       run: |
         choco install innosetup -y -v
-        dotnet publish Pinta.sln -p:BuildTranslations=true -c Release -r win-x64 --self-contained true -o release/bin
+        dotnet publish Pinta.sln -p:BuildTranslations=true -p:MinGWFolder=${MINGW_PREFIX} -c Release -r win-x64 --self-contained true -o release/bin
         mv release/bin/icons release/share/icons
         iscc installer/windows/installer.iss
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
       run: |
         choco install innosetup -y -v
         dotnet publish Pinta.sln -p:BuildTranslations=true -p:MinGWFolder=${MINGW_PREFIX} -c Release -r win-x64 --self-contained true -p:PublishDir=../release/bin
-        mv release/bin/icons release/share/icons
-        mv release/bin/locale release/share/locale
+        cp -r release/bin/icons release/bin/locale release/share/
+        rm -rf release/bin/icons release/bin/locale
         iscc installer/windows/installer.iss
 
     - name: Upload Installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,8 +134,9 @@ jobs:
     - name: Build Installer
       run: |
         choco install innosetup -y -v
-        dotnet publish Pinta.sln -p:BuildTranslations=true -p:MinGWFolder=${MINGW_PREFIX} -c Release -r win-x64 --self-contained true -o release/bin
+        dotnet publish Pinta.sln -p:BuildTranslations=true -p:MinGWFolder=${MINGW_PREFIX} -c Release -r win-x64 --self-contained true -p:PublishDir=../release/bin
         mv release/bin/icons release/share/icons
+        mv release/bin/locale release/share/locale
         iscc installer/windows/installer.iss
 
     - name: Upload Installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,21 +126,26 @@ jobs:
         update: true
         install: mingw-w64-x86_64-libadwaita
     - name: Build
+      env:
+        MinGWFolder: ${{env.MINGW_PREFIX}}
       run: dotnet build Pinta.sln -c Release
     - name: Test
+      env:
+        MinGWFolder: ${{env.MINGW_PREFIX}}
       run: dotnet test Pinta.sln -c Release
 
     # Note that msgfmt is already available from the Git for Windows installation!
     - name: Build Installer
-      if: ${{ false }} # Disable until the installer supports GTK4
+      env:
+        MinGWFolder: ${{env.MINGW_PREFIX}}
       run: |
         choco install innosetup -y -v
-        dotnet publish Pinta.sln -p:BuildTranslations=true -c Release -r win-x64 --self-contained true
+        dotnet publish Pinta.sln -p:BuildTranslations=true -c Release -r win-x64 --self-contained true -o release/bin
+        mv release/bin/icons release/share/icons
         iscc installer/windows/installer.iss
 
     - name: Upload Installer
       uses: actions/upload-artifact@v4
-      if: ${{ false }} # Disable until the installer supports GTK4
       with:
         name: "Pinta.exe"
         path: installer/windows/Pinta.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,7 @@ jobs:
         dotnet publish Pinta.sln -p:BuildTranslations=true -p:MinGWFolder=${MINGW_PREFIX} -c Release -r win-x64 --self-contained true -p:PublishDir=../release/bin
         cp -r release/bin/icons release/bin/locale release/share/
         rm -rf release/bin/icons release/bin/locale
+        cp installer/macos/hicolor.index.theme release/share/icons/hicolor/index.theme
         iscc installer/windows/installer.iss
 
     - name: Upload Installer

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 aclocal.m4
 autom4te.cache
 bin
+build
 BenchmarkDotNet.Artifacts
 compile
 config.log

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ po/.intltool-merge-cache
 po/Makefile.in.in
 po/POTFILES
 po/stamp-it
+release
 xdg/pinta.desktop
 xdg/pinta.appdata.xml
 .vs

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,8 @@
 SUBDIRS = xdg
 DIST_SUBDIRS = xdg
 
-BINDIR = $(srcdir)/bin
+BUILDDIR = $(srcdir)/build
+BINDIR = $(BUILDDIR)/bin
 
 PINTA_BUILD_OPTS = --configuration Release -p:BuildTranslations=true
 
@@ -31,17 +32,17 @@ all: publish
 
 # target: run - Launch the uninstalled copy
 run: build
-	$(DOTNET_CMD) bin/Pinta.dll
+	$(DOTNET_CMD) build/bin/Pinta.dll
 
 # target: help - Display callable targets.
 help:
 	egrep "^# target:" Makefile | sed 's/^# target:/make/'
 
-bin/Pinta.dll: Pinta.sln
+build/bin/Pinta.dll: Pinta.sln
 	cd $(srcdir) && $(DOTNET_CMD) build Pinta.sln $(PINTA_BUILD_OPTS)
 
 # target: build - Build Pinta.
-build: bin/Pinta.dll
+build: build/bin/Pinta.dll
 
 publish/Pinta.dll: Pinta.sln
 	cd $(srcdir) && $(DOTNET_CMD) publish Pinta.sln $(PINTA_BUILD_OPTS) --self-contained false -p:PublishDir=$(abs_srcdir)/publish
@@ -90,7 +91,7 @@ maintainer-clean-local:
 
 # target: cleanbin - Removes built files.
 cleanbin:
-	rm -rvf $(BINDIR)/*
+	rm -rvf $(BUILDDIR)/*
 
 # target: cleanobj - Removes temporary build files.
 cleanobj:

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -77,11 +77,9 @@ public sealed class SystemManager
 		string app_dir = SystemManager.GetExecutableDirectory ();
 
 		// If Pinta is located at $prefix/lib/pinta, we want to use $prefix/share.
-		// Or, on Windows, Pinta should be at $prefix/bin/Pinta.exe
-		if (GetOperatingSystem () == OS.X11 || GetOperatingSystem () == OS.Windows) {
+		if (GetOperatingSystem () == OS.X11) {
 			var lib_dir = Directory.GetParent (app_dir);
-			string expected_parent_name = (GetOperatingSystem () == OS.Windows) ? "bin" : "lib";
-			if (lib_dir?.Name == expected_parent_name) {
+			if (lib_dir?.Name == "lib") {
 				var prefix = lib_dir.Parent;
 				if (prefix is not null)
 					return Path.Combine (prefix.FullName, "share");

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -77,9 +77,11 @@ public sealed class SystemManager
 		string app_dir = SystemManager.GetExecutableDirectory ();
 
 		// If Pinta is located at $prefix/lib/pinta, we want to use $prefix/share.
-		if (GetOperatingSystem () == OS.X11) {
+		// Or, on Windows, Pinta should be at $prefix/bin/Pinta.exe
+		if (GetOperatingSystem () == OS.X11 || GetOperatingSystem () == OS.Windows) {
 			var lib_dir = Directory.GetParent (app_dir);
-			if (lib_dir?.Name == "lib") {
+			string expected_parent_name = (GetOperatingSystem () == OS.Windows) ? "bin" : "lib";
+			if (lib_dir?.Name == expected_parent_name) {
 				var prefix = lib_dir.Parent;
 				if (prefix is not null)
 					return Path.Combine (prefix.FullName, "share");

--- a/Pinta/Actions/File/OpenDocumentAction.cs
+++ b/Pinta/Actions/File/OpenDocumentAction.cs
@@ -71,8 +71,10 @@ internal sealed class OpenDocumentAction : IActionHandler
 			// Files can often also be identified by their MIME types.
 			// Windows does not understand MIME types natively.
 			// Adding a MIME filter on Windows would break the native file picker and force a GTK file picker instead.
-			foreach (var mime in format.Mimes)
-				ff.AddMimeType (mime);
+			if (SystemManager.GetOperatingSystem () != OS.Windows) {
+				foreach (var mime in format.Mimes)
+					ff.AddMimeType (mime);
+			}
 		}
 
 		fcd.AddFilter (ff);

--- a/Pinta/Pinta.csproj
+++ b/Pinta/Pinta.csproj
@@ -44,4 +44,7 @@
   <Target Name="PublishTranslations" AfterTargets="Publish" Condition="'$(BuildTranslations)' == 'true'">
     <Copy SourceFiles="$(OutputPath)/locale/%(Translation.Filename)/LC_MESSAGES/pinta.mo" DestinationFiles="$(PublishDir)/locale/%(Translation.Filename)/LC_MESSAGES/pinta.mo" />
   </Target>
+
+  <!-- For Windows, copy GTK library dependencies to the build folder. -->
+  <Import Condition="$([MSBuild]::IsOSPlatform('Windows'))" Project="../installer/windows/bundle_gtk.targets" />
 </Project>

--- a/Pinta/Pinta.csproj
+++ b/Pinta/Pinta.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>Pinta.ico</ApplicationIcon>
-    <OutputPath>..\bin</OutputPath>
+    <OutputPath>..\build\bin</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
     <!-- Disabled by default as it requires gettext to be installed. -->

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -49,7 +49,7 @@
     <GtkFile Include="$(MinGWBinFolder)\libpng16-16.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libstdc++-6.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libthai-0.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libtiff-5.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libtiff-6.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libwebp-7.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libwinpthread-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libzstd.dll" />

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -83,7 +83,7 @@
     <GtkFile Include="$(MinGWFolder)\lib\gdk-pixbuf-2.0\**" LinkBase="..\lib\gdk-pixbuf-2.0" />
     <GtkFile Include="$(MinGWFolder)\share\glib-2.0\schemas\**" LinkBase="..\share\glib-2.0\schemas" />
     <GtkFile Include="$(MinGWFolder)\share\locale\**" LinkBase="..\share\locale" />
-    <GtkFile Include="$(MinGWFolder)\share\icons\**" LinkBase="..\share\icons" />
+    <GtkFile Include="$(MinGWFolder)\share\icons\Adwaita\**" LinkBase="..\share\icons\Adwaita" />
   </ItemGroup>
 
   <ItemGroup>

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Install GTK library dependencies on Windows, from the MSYS installation. -->
   <PropertyGroup>
+    <!-- Note this can be overridden by an environment variable with the same name. -->
     <MinGWFolder>C:\msys64\mingw64</MinGWFolder>
     <MinGWBinFolder>$(MinGWFolder)\bin</MinGWBinFolder>
   </PropertyGroup>

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -1,0 +1,80 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Install GTK library dependencies on Windows, from the MSYS installation. -->
+  <PropertyGroup>
+    <MinGWFolder>C:\msys64\mingw64</MinGWFolder>
+    <MinGWBinFolder>$(MinGWFolder)\bin</MinGWBinFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Library link dependencies (run `ldd libadwaita-1-0.dll | grep '\/mingw.*\.dll' -o`) -->
+    <GtkFile Include="$(MinGWBinFolder)\libadwaita-1-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libbrotlicommon.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libbrotlidec.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libbz2-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libcairo-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libcairo-gobject-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libcairo-script-interpreter-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libdatrie-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libdeflate.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libepoxy-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libexpat-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libffi-8.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libfontconfig-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libfreetype-6.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libfribidi-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgcc_s_seh-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgdk_pixbuf-2.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgio-2.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libglib-2.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgmodule-2.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgobject-2.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgraphene-1.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgraphite2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libgtk-4-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libharfbuzz-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libiconv-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libintl-8.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libjbig-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libjpeg-8.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\liblerc.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\liblzma-5.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\liblzo2-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpango-1.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpangocairo-1.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpangoft2-1.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpangowin32-1.0-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpcre2-8-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpixman-1-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpng16-16.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libstdc++-6.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libthai-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libtiff-5.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libwebp-7.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libwinpthread-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libzstd.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\zlib1.dll" />
+
+    <!-- Additional dependencies for the SVG pixbuf loader. -->
+    <GtkFile Include="$(MinGWBinFolder)\libcharset-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\librsvg-2-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libxml2-2.dll" />
+
+    <GtkFile Include="$(MinGWBinFolder)\gdbus.exe" />
+    <GtkFile Include="$(MinGWBinFolder)\gdk-pixbuf-query-loaders.exe" />
+    <GtkFile Include="$(MinGWBinFolder)\gspawn-win64-helper.exe" />
+    <GtkFile Include="$(MinGWBinFolder)\gspawn-win64-helper-console.exe" />
+    <GtkFile Include="$(MinGWBinFolder)\gtk4-query-settings.exe" />
+    <GtkFile Include="$(MinGWBinFolder)\gtk4-update-icon-cache.exe" />
+
+    <GtkFile Include="$(MinGWFolder)\lib\gdk-pixbuf-2.0\**" LinkBase="..\lib\gdk-pixbuf-2.0" />
+    <GtkFile Include="$(MinGWFolder)\share\glib-2.0\schemas\**" LinkBase="..\share\glib-2.0\schemas" />
+    <GtkFile Include="$(MinGWFolder)\share\locale\**" LinkBase="..\share\locale" />
+    <GtkFile Include="$(MinGWFolder)\share\icons\**" LinkBase="..\share\icons" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="@(GtkFile)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -8,13 +8,17 @@
 
   <ItemGroup>
     <!-- Library link dependencies (run `ldd libadwaita-1-0.dll | grep '\/mingw.*\.dll' -o`) -->
+    <!-- TODO - This should be improved in the future to be more automated -->
     <GtkFile Include="$(MinGWBinFolder)\libadwaita-1-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libappstream-5.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libbrotlicommon.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libbrotlidec.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libbz2-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcairo-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcairo-gobject-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcairo-script-interpreter-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libcrypto-3-x64.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libcurl-4.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libdatrie-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libdeflate.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libepoxy-0.dll" />
@@ -34,12 +38,14 @@
     <GtkFile Include="$(MinGWBinFolder)\libgtk-4-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libharfbuzz-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libiconv-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libidn2-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libintl-8.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libjbig-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libjpeg-8.dll" />
     <GtkFile Include="$(MinGWBinFolder)\liblerc.dll" />
     <GtkFile Include="$(MinGWBinFolder)\liblzma-5.dll" />
     <GtkFile Include="$(MinGWBinFolder)\liblzo2-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libnghttp2-14.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpango-1.0-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpangocairo-1.0-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpangoft2-1.0-0.dll" />
@@ -47,11 +53,18 @@
     <GtkFile Include="$(MinGWBinFolder)\libpcre2-8-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpixman-1-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpng16-16.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libpsl-5.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libsharpyuv-0.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libssh2-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libssl-3-x64.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libstdc++-6.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libthai-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libtiff-6.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libunistring-5.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libwebp-7.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libwinpthread-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libxmlb-2.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libyaml-0-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libzstd.dll" />
     <GtkFile Include="$(MinGWBinFolder)\zlib1.dll" />
 

--- a/installer/windows/installer.iss
+++ b/installer/windows/installer.iss
@@ -19,17 +19,15 @@ OutputDir=installer\windows
 SetupIconFile=installer\windows\Pinta.ico
 SolidCompression=yes
 SourceDir=..\..\
-UninstallDisplayIcon={app}\{#ProductName}.exe
+UninstallDisplayIcon={app}\bin\{#ProductName}.exe
 WizardSmallImageFile=installer\windows\logo.bmp
 WizardStyle=modern
 
 [Icons]
-Name: "{group}\{#ProductName}"; Filename: "{app}\{#ProductName}.exe"
+Name: "{group}\{#ProductName}"; Filename: "{app}\bin\{#ProductName}.exe"
 
 [Files]
-Source: "bin\win-x64\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
-; Include the GTK distribution (which GtkSharp pulls in), but skip the zip file itself along with the unused gtkmm libraries.
-Source: "{#GetEnv('LOCALAPPDATA')}\Gtk\3.24.24\*"; Excludes: "gtk.zip,*mm-*.dll"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+Source: "release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Run]
-Filename: "{app}\Pinta.exe"; Flags: nowait postinstall skipifsilent; Description: "{cm:LaunchProgram,{#ProductName}}"
+Filename: "{app}\bin\Pinta.exe"; Flags: nowait postinstall skipifsilent; Description: "{cm:LaunchProgram,{#ProductName}}"


### PR DESCRIPTION
- Generate output files under a `build` folder, rather than just `bin`. This allows copying the GTK library dependencies to sibling `share` and `lib` folders.
- Copy the GTK library dependencies to the build folder. This allows running Pinta for dev workflows without MSYS in the path. Previously for GTK3, this implicitly used the GTK libraries bundled with GtkSharp
- Fix a regression in the GTK4 port which caused the non-native file picker to be used on Windows
- Update the CI builds and installer for GTK4 and the output path changes