### PR TITLE
Extracted some mathematical functions into `Utility`

### DIFF
--- a/Pinta.Core/Classes/Point.cs
+++ b/Pinta.Core/Classes/Point.cs
@@ -33,12 +33,6 @@ public readonly record struct PointI (int X, int Y)
 {
 	public static PointI Zero { get; } = new (0, 0);
 	public override readonly string ToString () => $"{X}, {Y}";
-	public readonly double Magnitude ()
-	{
-		double x = X;
-		double y = Y;
-		return Math.Sqrt (x * x + y * y);
-	}
 
 	public PointI Rotated90CCW () // Counterclockwise
 		=> new (-Y, X);
@@ -63,10 +57,6 @@ public readonly record struct PointD (double X, double Y)
 	public override readonly string ToString () => $"{X}, {Y}";
 
 	public readonly PointI ToInt () => new ((int) X, (int) Y);
-
-	public readonly double Distance (in PointD e) => new PointD (X - e.X, Y - e.Y).Magnitude ();
-
-	public readonly double Magnitude () => Math.Sqrt (X * X + Y * Y);
 
 	/// <summary>
 	/// Returns a new point, rounded to the nearest integer coordinates.

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -50,12 +50,15 @@ public static class Utility
 	/// <exception cref="ArgumentException">
 	/// Difference between upper and lower bounds is zero
 	/// </exception>
-	public static double InvLerp (double from, double to, double value)
+	public static TNumber InvLerp<TNumber> (
+		TNumber from,
+		TNumber to,
+		TNumber value) where TNumber : INumber<TNumber>
 	{
-		double valueSpan = to - from;
-		if (valueSpan == 0)
+		TNumber valueSpan = to - from;
+		if (valueSpan == TNumber.Zero)
 			throw new ArgumentException ("Difference between upper and lower bounds cannot be zero", $"{nameof (from)}, {nameof (to)}");
-		double offset = value - from;
+		TNumber offset = value - from;
 		return offset / valueSpan;
 	}
 

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -6,6 +6,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Numerics;
 using System.Reflection;
 
 namespace Pinta.Core;
@@ -24,10 +25,11 @@ public static class Utility
 	public static byte ClampToByte (int x)
 		=> (byte) Math.Clamp (x, byte.MinValue, byte.MaxValue);
 
-	public static float Lerp (float from, float to, float frac)
-		=> from + frac * (to - from);
-
-	public static double Lerp (double from, double to, double frac)
+	public static TNumber Lerp<TNumber> (
+		TNumber from,
+		TNumber to,
+		TNumber frac
+	) where TNumber : INumber<TNumber>
 		=> from + frac * (to - from);
 
 	public static double MagnitudeSquared (double x, double y)

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -6,7 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Numerics;
 using System.Reflection;
 
 namespace Pinta.Core;
@@ -30,6 +29,21 @@ public static class Utility
 
 	public static double Lerp (double from, double to, double frac)
 		=> from + frac * (to - from);
+
+	public static double MagnitudeSquared (double x, double y)
+		=> x * x + y * y;
+
+	public static double Magnitude (double x, double y)
+		=> Math.Sqrt (x * x + y * y);
+
+	public static double Magnitude (this PointD point)
+		=> Magnitude (point.X, point.Y);
+
+	public static double Magnitude (this PointI point)
+		=> Magnitude (point.X, point.Y);
+
+	public static double Distance (this PointD origin, in PointD dest)
+		=> Magnitude (origin - dest);
 
 	/// <exception cref="ArgumentException">
 	/// Difference between upper and lower bounds is zero

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -90,29 +90,12 @@ public static class Utility
 		if (rects.Length == 0)
 			return RectangleI.Zero;
 
-		int left = rects[startIndex].Left;
-		int top = rects[startIndex].Top;
-		int right = rects[startIndex].Right;
-		int bottom = rects[startIndex].Bottom;
+		RectangleI unionsAggregate = rects[startIndex];
 
-		for (int i = startIndex + 1; i < startIndex + length; ++i) {
+		for (int i = startIndex + 1; i < startIndex + length; ++i)
+			unionsAggregate = unionsAggregate.Union (rects[i]);
 
-			RectangleI rect = rects[i];
-
-			if (rect.Left < left)
-				left = rect.Left;
-
-			if (rect.Top < top)
-				top = rect.Top;
-
-			if (rect.Right > right)
-				right = rect.Right;
-
-			if (rect.Bottom > bottom)
-				bottom = rect.Bottom;
-		}
-
-		return RectangleI.FromLTRB (left, top, right, bottom);
+		return unionsAggregate;
 	}
 
 	public static int ColorDifferenceSquared (ColorBgra a, ColorBgra b)

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -45,13 +45,13 @@ public sealed class JuliaFractalEffect : BaseEffect
 	private static double Julia (double x, double y, double r, double i)
 	{
 		double c = 0;
-		while (c < 256 && ((x * x) + (y * y) < 10000)) {
+		while (c < 256 && Utility.MagnitudeSquared (x, y) < 10000) {
 			double t = x;
 			x = (x * x) - (y * y) + r;
 			y = (2 * t * y) + i;
 			++c;
 		}
-		return c - (2 - 2 * log2_10000 / Math.Log ((x * x) + (y * y)));
+		return c - (2 - 2 * log2_10000 / Math.Log (Utility.MagnitudeSquared (x, y)));
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -55,13 +55,13 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int c = 0;
 		double x = 0;
 		double y = 0;
-		while ((c * factor) < 1024 && ((x * x) + (y * y)) < Max) {
+		while ((c * factor) < 1024 && Utility.MagnitudeSquared (x, y) < Max) {
 			double t = x;
 			x = (x * x) - (y * y) + r;
 			y = (2 * t * y) + i;
 			++c;
 		}
-		return c - Math.Log ((y * y) + (x * x)) * inv_log_max;
+		return c - Math.Log (Utility.MagnitudeSquared (x, y)) * inv_log_max;
 	}
 
 	private sealed record MandelbrotSettings (

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -38,7 +38,7 @@ public sealed class PolarInversionEffect : WarpEffect
 		double y = transData.Y;
 
 		// NOTE: when x and y are zero, this will divide by zero and return NaN
-		double invertDistance = Utility.Lerp (1.0, DefaultRadius2 / ((x * x) + (y * y)), Data.Amount);
+		double invertDistance = Utility.Lerp (1.0, DefaultRadius2 / Utility.MagnitudeSquared (x, y), Data.Amount);
 
 		return new (
 			X: x * invertDistance,


### PR DESCRIPTION
In first commit:
- Methods in `PointI` and `PointD` that calculate magnitude and distance were moved to `Utility` as extension methods
- Created `Utility.MagnitudeSquared` and got some effects to use it

In second commit:
- Made `Utility.Lerp` generic, made possible thanks to `INumber<TSelf>` and [static virtual members](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/static-virtual-interface-members)

In third commit:
- Made `InvLerp` generic, similar to how it was done for `Lerp`

In fourth commit:
- Made `GetRegionBounds` more concise