### PR TITLE
Added new methods to gradients, and customization options to fractals that use them

### DIFF
--- a/Pinta.Core/Effects/HsvColor.cs
+++ b/Pinta.Core/Effects/HsvColor.cs
@@ -16,49 +16,32 @@ namespace Pinta.Core;
 /// </summary>
 public readonly struct HsvColor
 {
-	public readonly int Hue { get; init; } // 0-360
-	public readonly int Saturation { get; init; } // 0-100
-	public readonly int Value { get; init; } // 0-100
+	public readonly int Hue { get; } // 0-360
+	public readonly int Saturation { get; } // 0-100
+	public readonly int Value { get; } // 0-100
 
 	public static bool operator == (HsvColor lhs, HsvColor rhs)
-	{
-		if ((lhs.Hue == rhs.Hue) &&
-		    (lhs.Saturation == rhs.Saturation) &&
-		    (lhs.Value == rhs.Value)) {
-			return true;
-		} else {
-			return false;
-		}
-	}
+		=> lhs.Hue == rhs.Hue && lhs.Saturation == rhs.Saturation && lhs.Value == rhs.Value;
 
 	public static bool operator != (HsvColor lhs, HsvColor rhs)
-	{
-		return !(lhs == rhs);
-	}
+		=> !(lhs == rhs);
 
 	public override readonly bool Equals (object? obj)
-	{
-		return obj is HsvColor hsv && this == hsv;
-	}
+		=> obj is HsvColor hsv && this == hsv;
 
 	public override readonly int GetHashCode ()
-	{
-		return (Hue + (Saturation << 8) + (Value << 16)).GetHashCode (); ;
-	}
+		=> (Hue + (Saturation << 8) + (Value << 16)).GetHashCode ();
 
 	public HsvColor (int hue, int saturation, int value)
 	{
-		if (hue < 0 || hue > 360) {
+		if (hue < 0 || hue > 360)
 			throw new ArgumentOutOfRangeException (nameof (hue), "must be in the range [0, 360]");
-		}
 
-		if (saturation < 0 || saturation > 100) {
+		if (saturation < 0 || saturation > 100)
 			throw new ArgumentOutOfRangeException (nameof (saturation), "must be in the range [0, 100]");
-		}
 
-		if (value < 0 || value > 100) {
+		if (value < 0 || value > 100)
 			throw new ArgumentOutOfRangeException (nameof (value), "must be in the range [0, 100]");
-		}
 
 		Hue = hue;
 		Saturation = saturation;
@@ -159,7 +142,5 @@ public readonly struct HsvColor
 	}
 
 	public override readonly string ToString ()
-	{
-		return $"({Hue}, {Saturation}, {Value})";
-	}
+		=> $"({Hue}, {Saturation}, {Value})";
 }

--- a/Pinta.Core/Effects/HsvColor.cs
+++ b/Pinta.Core/Effects/HsvColor.cs
@@ -16,9 +16,9 @@ namespace Pinta.Core;
 /// </summary>
 public readonly struct HsvColor
 {
-	public readonly int Hue { get; } // 0-360
-	public readonly int Saturation { get; } // 0-100
-	public readonly int Value { get; } // 0-100
+	public readonly int Hue { get; init; } // 0-360
+	public readonly int Saturation { get; init; } // 0-100
+	public readonly int Value { get; init; } // 0-100
 
 	public static bool operator == (HsvColor lhs, HsvColor rhs)
 	{

--- a/Pinta.Effects/Effects/ColorGradient.cs
+++ b/Pinta.Effects/Effects/ColorGradient.cs
@@ -152,7 +152,11 @@ internal sealed class ColorGradient
 		if (angle.Degrees == 0) return original;
 		RgbColor originalRgb = new (original.R, original.G, original.B);
 		HsvColor originalHsv = originalRgb.ToHsv ();
-		HsvColor rotatedHsv = originalHsv with { Hue = (int) new DegreesAngle (originalHsv.Hue + angle.Degrees).Degrees };
+		HsvColor rotatedHsv = new HsvColor (
+			hue: (int) new DegreesAngle (originalHsv.Hue + angle.Degrees).Degrees,
+			saturation: originalHsv.Saturation,
+			value: originalHsv.Value
+		);
 		RgbColor rotatedRgb = rotatedHsv.ToRgb ();
 		return ColorBgra.FromBgra (
 			b: Utility.ClampToByte (rotatedRgb.Blue),

--- a/Pinta.Effects/Effects/ColorGradient.cs
+++ b/Pinta.Effects/Effects/ColorGradient.cs
@@ -110,8 +110,8 @@ internal sealed class ColorGradient
 	/// <returns>
 	/// New gradient where the start color is now the end color,
 	/// and vice versa. Also, the color stops are in reversed positions
-	/// (in the new gradient, the first color is at the same distance
-	/// from the end color as it was from the start color in the original)
+	/// (in the new gradient, the colors are at the same distance
+	/// from the end color as they were from the start color in the original)
 	/// </returns>
 	public ColorGradient Reversed ()
 	{

--- a/Pinta.Effects/Effects/ColorGradient.cs
+++ b/Pinta.Effects/Effects/ColorGradient.cs
@@ -131,6 +131,38 @@ internal sealed class ColorGradient
 	}
 
 	/// <returns>
+	/// Gradient with the hues of all colors (including the start
+	/// and end colors, and color stops) rotated on the color wheel
+	/// </returns>
+	public ColorGradient HueRotated (DegreesAngle angle)
+	{
+		var rotatedColors = sorted_colors.Select (c => HueRotate (c, angle));
+		var newStops = sorted_positions.Zip (rotatedColors, KeyValuePair.Create);
+		return new (
+			startColor: HueRotate (StartColor, angle),
+			endColor: HueRotate (EndColor, angle),
+			startPosition: StartPosition,
+			endPosition: EndPosition,
+			gradientStops: newStops
+		);
+	}
+
+	private static ColorBgra HueRotate (ColorBgra original, DegreesAngle angle)
+	{
+		if (angle.Degrees == 0) return original;
+		RgbColor originalRgb = new (original.R, original.G, original.B);
+		HsvColor originalHsv = originalRgb.ToHsv ();
+		HsvColor rotatedHsv = originalHsv with { Hue = (int) new DegreesAngle (originalHsv.Hue + angle.Degrees).Degrees };
+		RgbColor rotatedRgb = rotatedHsv.ToRgb ();
+		return ColorBgra.FromBgra (
+			b: Utility.ClampToByte (rotatedRgb.Blue),
+			g: Utility.ClampToByte (rotatedRgb.Green),
+			r: Utility.ClampToByte (rotatedRgb.Red),
+			a: original.A
+		);
+	}
+
+	/// <returns>
 	/// Intermediate color, according to start and end colors,
 	/// and gradient stops.
 	/// No overflow occurs as such;

--- a/Pinta.Effects/Effects/ColorGradient.cs
+++ b/Pinta.Effects/Effects/ColorGradient.cs
@@ -131,42 +131,6 @@ internal sealed class ColorGradient
 	}
 
 	/// <returns>
-	/// Gradient with the hues of all colors (including the start
-	/// and end colors, and color stops) rotated on the color wheel
-	/// </returns>
-	public ColorGradient HueRotated (DegreesAngle angle)
-	{
-		var rotatedColors = sorted_colors.Select (c => HueRotate (c, angle));
-		var newStops = sorted_positions.Zip (rotatedColors, KeyValuePair.Create);
-		return new (
-			startColor: HueRotate (StartColor, angle),
-			endColor: HueRotate (EndColor, angle),
-			startPosition: StartPosition,
-			endPosition: EndPosition,
-			gradientStops: newStops
-		);
-	}
-
-	private static ColorBgra HueRotate (ColorBgra original, DegreesAngle angle)
-	{
-		if (angle.Degrees == 0) return original;
-		RgbColor originalRgb = new (original.R, original.G, original.B);
-		HsvColor originalHsv = originalRgb.ToHsv ();
-		HsvColor rotatedHsv = new HsvColor (
-			hue: (int) new DegreesAngle (originalHsv.Hue + angle.Degrees).Degrees,
-			saturation: originalHsv.Saturation,
-			value: originalHsv.Value
-		);
-		RgbColor rotatedRgb = rotatedHsv.ToRgb ();
-		return ColorBgra.FromBgra (
-			b: Utility.ClampToByte (rotatedRgb.Blue),
-			g: Utility.ClampToByte (rotatedRgb.Green),
-			r: Utility.ClampToByte (rotatedRgb.Red),
-			a: original.A
-		);
-	}
-
-	/// <returns>
 	/// Intermediate color, according to start and end colors,
 	/// and gradient stops.
 	/// No overflow occurs as such;

--- a/Pinta.Effects/Effects/ColorGradient.cs
+++ b/Pinta.Effects/Effects/ColorGradient.cs
@@ -38,31 +38,31 @@ internal sealed class ColorGradient
 	internal ColorGradient (
 		ColorBgra startColor,
 		ColorBgra endColor,
-		double minPosition,
-		double maxPosition,
+		double startPosition,
+		double endPosition,
 		IEnumerable<KeyValuePair<double, ColorBgra>> gradientStops)
 	{
-		CheckBoundsConsistency (minPosition, maxPosition);
+		CheckBoundsConsistency (startPosition, endPosition);
 
 		var sortedStops = gradientStops.OrderBy (stop => stop.Key).ToArray ();
 		var sortedPositions = sortedStops.Select (stop => stop.Key).ToImmutableArray ();
 		var sortedColors = sortedStops.Select (stop => stop.Value).ToImmutableArray ();
-		CheckStopsBounds (sortedPositions, minPosition, maxPosition);
+		CheckStopsBounds (sortedPositions, startPosition, endPosition);
 		CheckUniqueness (sortedPositions);
 
 		StartColor = startColor;
 		EndColor = endColor;
-		StartPosition = minPosition;
-		EndPosition = maxPosition;
+		StartPosition = startPosition;
+		EndPosition = endPosition;
 		sorted_positions = sortedPositions;
 		sorted_colors = sortedColors;
 	}
 
-	private static void CheckStopsBounds (ImmutableArray<double> sortedPositions, double minPosition, double maxPosition)
+	private static void CheckStopsBounds (ImmutableArray<double> sortedPositions, double startPosition, double endPosition)
 	{
 		if (sortedPositions.Length == 0) return;
-		if (sortedPositions[0] <= minPosition) throw new ArgumentException ($"Lowest key in gradient stops has to be greater than {nameof (minPosition)}");
-		if (sortedPositions[^1] >= maxPosition) throw new ArgumentException ($"Greatest key in gradient stops has to be lower than {nameof (maxPosition)}");
+		if (sortedPositions[0] <= startPosition) throw new ArgumentException ($"Lowest key in gradient stops has to be greater than {nameof (startPosition)}");
+		if (sortedPositions[^1] >= endPosition) throw new ArgumentException ($"Greatest key in gradient stops has to be lower than {nameof (endPosition)}");
 	}
 
 	private static void CheckUniqueness (ImmutableArray<double> sortedPositions)
@@ -71,9 +71,9 @@ internal sealed class ColorGradient
 		if (distinctPositions != sortedPositions.Length) throw new ArgumentException ("Cannot have more than one stop in the same position");
 	}
 
-	private static void CheckBoundsConsistency (double minPosition, double maxPosition)
+	private static void CheckBoundsConsistency (double startPosition, double endPosition)
 	{
-		if (minPosition >= maxPosition) throw new ArgumentException ($"{nameof (minPosition)} has to be lower than {nameof (maxPosition)}");
+		if (startPosition >= endPosition) throw new ArgumentException ($"{nameof (startPosition)} has to be lower than {nameof (endPosition)}");
 	}
 
 	/// <summary>
@@ -81,29 +81,52 @@ internal sealed class ColorGradient
 	/// (along with all of its stops) adjusted, proportionally,
 	/// to the provided lower and upper bounds.
 	/// </summary>
-	public ColorGradient Resized (double minPosition, double maxPosition)
+	public ColorGradient Resized (double startPosition, double endPosition)
 	{
-		CheckBoundsConsistency (minPosition, maxPosition);
+		CheckBoundsConsistency (startPosition, endPosition);
 
-		double newSpan = maxPosition - minPosition;
+		double newSpan = endPosition - startPosition;
 		double currentSpan = EndPosition - StartPosition;
 		double newProportion = newSpan / currentSpan;
-		double newMinRelativeOffset = minPosition - StartPosition;
+		double newMinRelativeOffset = startPosition - StartPosition;
 
 		KeyValuePair<double, ColorBgra> ToNewStop (KeyValuePair<double, ColorBgra> stop)
 		{
 			double stopToMinOffset = stop.Key - StartPosition;
 			double adjustedOffset = stopToMinOffset * newProportion;
-			double newPosition = minPosition + adjustedOffset;
+			double newPosition = startPosition + adjustedOffset;
 			return KeyValuePair.Create (newPosition, stop.Value);
 		}
 
 		return new (
 			StartColor,
 			EndColor,
-			minPosition,
-			maxPosition,
+			startPosition,
+			endPosition,
 			sorted_positions.Zip (sorted_colors, KeyValuePair.Create).Select (ToNewStop)
+		);
+	}
+
+	/// <returns>
+	/// New gradient where the start color is now the end color,
+	/// and vice versa. Also, the color stops are in reversed positions
+	/// (in the new gradient, the first color is at the same distance
+	/// from the end color as it was from the start color in the original)
+	/// </returns>
+	public ColorGradient Reversed ()
+	{
+		var reversedPosition = sorted_positions.Select (p => EndPosition - p);
+
+		var reversedStops =
+			reversedPosition
+			.Zip (sorted_colors, KeyValuePair.Create);
+
+		return new ColorGradient (
+			startColor: EndColor,
+			endColor: StartColor,
+			startPosition: StartPosition,
+			endPosition: EndPosition,
+			gradientStops: reversedStops
 		);
 	}
 
@@ -177,12 +200,12 @@ internal sealed class ColorGradient
 	/// Creates gradient mapping based on start and end color,
 	/// and the provided lower and upper bounds
 	/// </summary>
-	public static ColorGradient Create (ColorBgra start, ColorBgra end, double minimum, double maximum)
+	public static ColorGradient Create (ColorBgra startColor, ColorBgra endColor, double startPosition, double endPosition)
 		=> new (
-			start,
-			end,
-			minimum,
-			maximum,
+			startColor,
+			endColor,
+			startPosition,
+			endPosition,
 			EmptyStops ()
 		);
 
@@ -190,12 +213,12 @@ internal sealed class ColorGradient
 	/// Creates gradient mapping based on start and end color,
 	/// and the provided lower and upper bounds, and color stops
 	/// </summary>
-	public static ColorGradient Create (ColorBgra start, ColorBgra end, double minimum, double maximum, IEnumerable<KeyValuePair<double, ColorBgra>> stops)
+	public static ColorGradient Create (ColorBgra startColor, ColorBgra endColor, double startPosition, double endPosition, IEnumerable<KeyValuePair<double, ColorBgra>> stops)
 		=> new (
-			start,
-			end,
-			minimum,
-			maximum,
+			startColor,
+			endColor,
+			startPosition,
+			endPosition,
 			stops
 		);
 }

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -86,7 +86,10 @@ public sealed class JuliaFractalEffect : BaseEffect
 		var w = dst.Width;
 		var h = dst.Height;
 		var count = Data.Quality * Data.Quality + 1;
-		var gradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
+		var hueRotation = Data.HueRotation;
+		var baseGradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
+		var reversedGradient = Data.ReverseColorScheme ? baseGradient.Reversed () : baseGradient;
+		var colorRotatedGradient = hueRotation.Degrees == 0 ? reversedGradient : reversedGradient.HueRotated (hueRotation);
 		return new (
 			w: w,
 			h: h,
@@ -98,7 +101,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 			invCount: 1.0 / count,
 			angleTheta: (Data.Angle.Degrees * Math.PI * 2) / 360.0,
 			factor: Data.Factor,
-			colorGradient: Data.ReverseColorScheme ? gradient.Reversed () : gradient
+			colorGradient: colorRotatedGradient
 		);
 	}
 
@@ -162,6 +165,9 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 		[Caption ("Color Scheme")]
 		public PredefinedGradients ColorScheme { get; set; } = PredefinedGradients.Bonfire;
+
+		[Caption ("Hue Rotation")]
+		public DegreesAngle HueRotation { get; set; } = new (0);
 
 		[Caption ("Reverse Color Scheme")]
 		public bool ReverseColorScheme { get; set; } = false;

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -86,6 +86,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 		var w = dst.Width;
 		var h = dst.Height;
 		var count = Data.Quality * Data.Quality + 1;
+		var gradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
 		return new (
 			w: w,
 			h: h,
@@ -97,7 +98,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 			invCount: 1.0 / count,
 			angleTheta: (Data.Angle.Degrees * Math.PI * 2) / 360.0,
 			factor: Data.Factor,
-			colorGradient: GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023)
+			colorGradient: Data.ReverseColorScheme ? gradient.Reversed () : gradient
 		);
 	}
 
@@ -161,6 +162,9 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 		[Caption ("Color Scheme")]
 		public PredefinedGradients ColorScheme { get; set; } = PredefinedGradients.Bonfire;
+
+		[Caption ("Reverse Color Scheme")]
+		public bool ReverseColorScheme { get; set; } = false;
 
 		[Caption ("Angle")]
 		public DegreesAngle Angle { get; set; } = new (0);

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -86,10 +86,9 @@ public sealed class JuliaFractalEffect : BaseEffect
 		var w = dst.Width;
 		var h = dst.Height;
 		var count = Data.Quality * Data.Quality + 1;
-		var hueRotation = Data.HueRotation;
+
 		var baseGradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
-		var reversedGradient = Data.ReverseColorScheme ? baseGradient.Reversed () : baseGradient;
-		var colorRotatedGradient = hueRotation.Degrees == 0 ? reversedGradient : reversedGradient.HueRotated (hueRotation);
+
 		return new (
 			w: w,
 			h: h,
@@ -101,7 +100,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 			invCount: 1.0 / count,
 			angleTheta: (Data.Angle.Degrees * Math.PI * 2) / 360.0,
 			factor: Data.Factor,
-			colorGradient: colorRotatedGradient
+			colorGradient: Data.ReverseColorScheme ? baseGradient.Reversed () : baseGradient
 		);
 	}
 
@@ -165,9 +164,6 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 		[Caption ("Color Scheme")]
 		public PredefinedGradients ColorScheme { get; set; } = PredefinedGradients.Bonfire;
-
-		[Caption ("Hue Rotation")]
-		public DegreesAngle HueRotation { get; set; } = new (0);
 
 		[Caption ("Reverse Color Scheme")]
 		public bool ReverseColorScheme { get; set; } = false;

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -84,7 +84,10 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		double zoom = 1 + zoom_factor * Data.Zoom;
 		int count = Data.Quality * Data.Quality + 1;
 
-		var gradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
+		var hueRotation = Data.HueRotation;
+		var baseGradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
+		var reversedGradient = Data.ReverseColorScheme ? baseGradient.Reversed () : baseGradient;
+		var colorRotatedGradient = hueRotation.Degrees == 0 ? reversedGradient : reversedGradient.HueRotated (hueRotation);
 
 		return new (
 
@@ -107,7 +110,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 			invertColors: Data.InvertColors,
 
-			colorGradient: Data.ReverseColorScheme ? gradient.Reversed () : gradient
+			colorGradient: colorRotatedGradient
 		);
 	}
 
@@ -187,6 +190,9 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 		[Caption ("Color Scheme")]
 		public PredefinedGradients ColorScheme { get; set; } = PredefinedGradients.Electric;
+
+		[Caption ("Hue Rotation")]
+		public DegreesAngle HueRotation { get; set; } = new (0);
 
 		[Caption ("Reverse Color Scheme")]
 		public bool ReverseColorScheme { get; set; } = false;

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -84,10 +84,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		double zoom = 1 + zoom_factor * Data.Zoom;
 		int count = Data.Quality * Data.Quality + 1;
 
-		var hueRotation = Data.HueRotation;
 		var baseGradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
-		var reversedGradient = Data.ReverseColorScheme ? baseGradient.Reversed () : baseGradient;
-		var colorRotatedGradient = hueRotation.Degrees == 0 ? reversedGradient : reversedGradient.HueRotated (hueRotation);
 
 		return new (
 
@@ -110,7 +107,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 			invertColors: Data.InvertColors,
 
-			colorGradient: colorRotatedGradient
+			colorGradient: Data.ReverseColorScheme ? baseGradient.Reversed () : baseGradient
 		);
 	}
 
@@ -190,9 +187,6 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 		[Caption ("Color Scheme")]
 		public PredefinedGradients ColorScheme { get; set; } = PredefinedGradients.Electric;
-
-		[Caption ("Hue Rotation")]
-		public DegreesAngle HueRotation { get; set; } = new (0);
 
 		[Caption ("Reverse Color Scheme")]
 		public bool ReverseColorScheme { get; set; } = false;

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -84,6 +84,8 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		double zoom = 1 + zoom_factor * Data.Zoom;
 		int count = Data.Quality * Data.Quality + 1;
 
+		var gradient = GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023);
+
 		return new (
 
 			w: dst.Width,
@@ -105,7 +107,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 			invertColors: Data.InvertColors,
 
-			colorGradient: GradientHelper.CreateColorGradient (Data.ColorScheme).Resized (0, 1023)
+			colorGradient: Data.ReverseColorScheme ? gradient.Reversed () : gradient
 		);
 	}
 
@@ -185,6 +187,9 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 		[Caption ("Color Scheme")]
 		public PredefinedGradients ColorScheme { get; set; } = PredefinedGradients.Electric;
+
+		[Caption ("Reverse Color Scheme")]
+		public bool ReverseColorScheme { get; set; } = false;
 
 		[Caption ("Invert Colors")]
 		public bool InvertColors { get; set; } = false;


### PR DESCRIPTION
I think the current selection of gradients for the fractals could be a bit dull, so what if we make it wider by adding customization options?

In the first commit, I added the option of reversing the gradient (turning the gradient upside down):

![reversed_colors_mandelbrot](https://github.com/PintaProject/Pinta/assets/17771375/19ac231e-4b8f-4481-b984-c515ea4363fb)

At some point I added the option of rotating the hue of the colors in the gradient. However, in the last commit I removed the `HueRotation` property in the `EffectData`. because the user can just use **Adjustments > Hue / Saturation**; but if you think that keeping that property is a good idea, you could drop the last commit.

![colorrotatedmandlebrot](https://github.com/PintaProject/Pinta/assets/17771375/cbe9e5a8-97e8-4ae6-9cd6-47f77922b231)
