### PR TITLE
Made generic constraints in `Utility.Lerp` and `Utility.InvLerp` more specific

### DIFF
--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -29,7 +29,7 @@ public static class Utility
 		TNumber from,
 		TNumber to,
 		TNumber frac
-	) where TNumber : INumber<TNumber>
+	) where TNumber : IFloatingPoint<TNumber>
 		=> from + frac * (to - from);
 
 	public static double MagnitudeSquared (double x, double y)
@@ -53,7 +53,7 @@ public static class Utility
 	public static TNumber InvLerp<TNumber> (
 		TNumber from,
 		TNumber to,
-		TNumber value) where TNumber : INumber<TNumber>
+		TNumber value) where TNumber : IFloatingPoint<TNumber>
 	{
 		TNumber valueSpan = to - from;
 		if (valueSpan == TNumber.Zero)

--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -104,13 +104,14 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 
 		var points = new PointD[entries + 2];
 
-		points[entries] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (t, b, 20));
-		points[entries + 1] = new PointD (Utility.Lerp (l, r, -1), Utility.Lerp (b, t, 20));
+		points[entries] = new PointD (X: Utility.Lerp<double> (l, r, -1), Y: Utility.Lerp<double> (t, b, 20));
+		points[entries + 1] = new PointD (X: Utility.Lerp<double> (l, r, -1), Y: Utility.Lerp<double> (b, t, 20));
 
 		for (var i = 0; i < entries; i += entries - 1) {
 			points[i] = new PointD (
-			    Utility.Lerp (l, r, hist[i] / (float) max),
-			    Utility.Lerp (t, b, i / (float) entries));
+				X: Utility.Lerp (l, r, hist[i] / (float) max),
+				Y: Utility.Lerp (t, b, i / (float) entries)
+			);
 
 			CheckPoint (rect, ref points[i]);
 		}
@@ -121,8 +122,9 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 			sum3 += hist[i + 1];
 
 			points[i] = new PointD (
-			    Utility.Lerp (l, r, sum3 / (float) (max * 3.1f)),
-			    Utility.Lerp (t, b, i / (float) entries));
+				X: Utility.Lerp (l, r, sum3 / (float) (max * 3.1f)),
+				Y: Utility.Lerp (t, b, i / (float) entries)
+			);
 
 			CheckPoint (rect, ref points[i]);
 			sum3 -= hist[i - 1];


### PR DESCRIPTION
One unintended consequence of making these methods generic on `INumber` is that when the type inference determines that the type is an integer, the result will be truncated, and when that results in an inaccurate calculation it could be hard to determine where the error is, so now it's only values of type `IFloatingPoint<TSelf>`