### PR TITLE
Upgrade to the latest gir.core release

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0-preview.3" />
-    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0-preview.3" />
-    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0-preview.3" />
+    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0-preview.4" />
+    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0-preview.4" />
+    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0-preview.4" />
     <!-- Note: at least 1.4.2-alpha3 is required for fixes to uninstalling addins, from https://github.com/mono/mono-addins/pull/198 -->
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -25,7 +25,7 @@ public sealed class TextEngine
 	private TextPosition current_pos;
 	private TextPosition selection_start;
 
-	public Pango.FontDescription Font { get; private set; } = PangoExtensions.CreateFontDescription ();
+	public Pango.FontDescription Font { get; private set; } = Pango.FontDescription.New ();
 	public TextAlignment Alignment { get; private set; }
 	public bool Underline { get; private set; }
 

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -175,22 +175,6 @@ public static class GdkExtensions
 	}
 
 	// TODO-GTK4 (bindings, unsubmitted) - need gir.core async bindings for Gdk.Clipboard
-	public static Task<string?> ReadTextAsync (this Gdk.Clipboard clipboard)
-	{
-		var tcs = new TaskCompletionSource<string?> ();
-
-		Gdk.Internal.Clipboard.ReadTextAsync (clipboard.Handle, IntPtr.Zero, new Gio.Internal.AsyncReadyCallbackAsyncHandler ((_, args, _) => {
-			string? result = Gdk.Internal.Clipboard.ReadTextFinish (clipboard.Handle, args.Handle, out var error).ConvertToString ();
-			if (!error.IsInvalid)
-				throw new GLib.GException (error);
-
-			tcs.SetResult (result);
-		}).NativeCallback, IntPtr.Zero);
-
-		return tcs.Task;
-	}
-
-	// TODO-GTK4 (bindings, unsubmitted) - need gir.core async bindings for Gdk.Clipboard
 	public static Task<Texture?> ReadTextureAsync (this Gdk.Clipboard clipboard)
 	{
 		var tcs = new TaskCompletionSource<Texture?> ();

--- a/Pinta.Core/Extensions/GdkPixbufExtensions.cs
+++ b/Pinta.Core/Extensions/GdkPixbufExtensions.cs
@@ -66,33 +66,11 @@ public static partial class GdkPixbufExtensions
 		var result = new PixbufFormat[n];
 		for (uint i = 0; i < n; ++i) {
 			var format = new GdkPixbuf.Internal.PixbufFormatUnownedHandle (GLib.Internal.SList.NthData (slist_handle, i));
-			result[i] = new PixbufFormat (format);
+			result[i] = new PixbufFormat (GdkPixbuf.Internal.PixbufFormat.Copy (format));
 		}
 
 		return result;
 	}
-
-	// TODO-GTK4 (bindings) - record methods are not generated (https://github.com/gircore/gir.core/issues/743)
-	public static string GetName (this PixbufFormat format)
-	{
-		return GdkPixbuf.Internal.PixbufFormat.GetName (format.Handle).ConvertToString ();
-	}
-
-	// TODO-GTK4 (bindings) - record methods are not generated (https://github.com/gircore/gir.core/issues/743)
-	public static bool IsWritable (this PixbufFormat format)
-	{
-		return GdkPixbuf.Internal.PixbufFormat.IsWritable (format.Handle);
-	}
-
-	// TODO-GTK4 (bindings) - record methods are not generated (https://github.com/gircore/gir.core/issues/743)
-	public static string[] GetMimeTypes (this PixbufFormat format)
-	{
-		var result = GetMimeTypes (format.Handle);
-		return result.ConvertToStringArray () ?? Array.Empty<string> ();
-	}
-
-	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_format_get_mime_types")]
-	private static extern GLib.Internal.Utf8StringArrayNullTerminatedOwnedHandle GetMimeTypes (GdkPixbuf.Internal.PixbufFormatHandle format);
 
 	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_get_formats")]
 	private static extern GLib.Internal.SListUnownedHandle GetFormatsNative ();

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -467,8 +467,8 @@ public static partial class GtkExtensions
 
 	public sealed class SelectionChangedSignalArgs : SignalArgs
 	{
-		public uint Position => Args[1].Extract<uint> ();
-		public uint NItems => Args[2].Extract<uint> ();
+		public uint Position => Args[1].GetUint ();
+		public uint NItems => Args[2].GetUint ();
 
 	}
 

--- a/Pinta.Core/Extensions/PangoExtensions.cs
+++ b/Pinta.Core/Extensions/PangoExtensions.cs
@@ -44,24 +44,6 @@ public static partial class PangoExtensions
 		);
 	}
 
-	public static FontDescription CreateFontDescription ()
-		=> new (Pango.Internal.FontDescription.New ());
-
-	public static FontDescription Copy (this FontDescription desc)
-		=> new (Pango.Internal.FontDescription.Copy (desc.Handle));
-
-	public static int GetSize (this FontDescription desc)
-		=> Pango.Internal.FontDescription.GetSize (desc.Handle);
-
-	public static bool GetSizeIsAbsolute (this FontDescription desc)
-		=> Pango.Internal.FontDescription.GetSizeIsAbsolute (desc.Handle);
-
-	public static void SetWeight (this FontDescription desc, Weight weight)
-		=> Pango.Internal.FontDescription.SetWeight (desc.Handle, weight);
-
-	public static void SetStyle (this FontDescription desc, Style style)
-		=> Pango.Internal.FontDescription.SetStyle (desc.Handle, style);
-
 	public static void GetCursorPos (this Layout layout, int index, out RectangleI strong_pos, out RectangleI weak_pos)
 	{
 		InternalGetCursorPos (layout.Handle, index, out var strong_pos_pango, out var weak_pos_pango);


### PR DESCRIPTION
- Remove manual bindings that are now generated correctly upstream
- The PixbufFormat constructor now requires an owned handle