### PR TITLE
Several effects refactored to use `Utility.GeneratePixelOffsets`

### DIFF
--- a/Pinta.Core/Classes/PixelOffset.cs
+++ b/Pinta.Core/Classes/PixelOffset.cs
@@ -1,0 +1,3 @@
+namespace Pinta.Core;
+
+public readonly record struct PixelOffset (PointI coordinates, int memoryOffset);

--- a/Pinta.Core/Effects/ColorDifferenceEffect.cs
+++ b/Pinta.Core/Effects/ColorDifferenceEffect.cs
@@ -39,13 +39,23 @@ public abstract class ColorDifferenceEffect : BaseEffect
 
 			foreach (var pixel in Utility.GeneratePixelOffsets (rect, src.GetSize ())) {
 
-				int fyStart = (pixel.coordinates.Y == src_rect.Y) ? 1 : 0;
-				int fyEnd = (pixel.coordinates.Y == src_rect.Y + src_rect.Height - 1) ? 2 : 3;
+				PointI fStart = new (
+					X: (pixel.coordinates.X == src_rect.X) ? 1 : 0,
+					Y: (pixel.coordinates.Y == src_rect.Y) ? 1 : 0
+				);
 
-				int fxStart = (pixel.coordinates.X == src_rect.X) ? 1 : 0;
-				int fxEnd = (pixel.coordinates.X == src_rect.X + src_rect.Width - 1) ? 2 : 3;
+				PointI fEnd = new (
+					X: (pixel.coordinates.X == src_rect.X + src_rect.Width - 1) ? 2 : 3,
+					Y: (pixel.coordinates.Y == src_rect.Y + src_rect.Height - 1) ? 2 : 3
+				);
 
-				dst_data[pixel.memoryOffset] = GetFinalPixelColor (weights, src_data, src_width, fxStart, fxEnd, fyStart, fyEnd, pixel.coordinates.X, pixel.coordinates.Y);
+				dst_data[pixel.memoryOffset] = GetFinalPixelColor (
+					weights,
+					src_data,
+					src_width,
+					fStart,
+					fEnd,
+					pixel.coordinates);
 			}
 		}
 	}
@@ -54,21 +64,18 @@ public abstract class ColorDifferenceEffect : BaseEffect
 		IReadOnlyList<IReadOnlyList<double>> weights,
 		ReadOnlySpan<ColorBgra> src_data,
 		int src_width,
-		int fxStart,
-		int fxEnd,
-		int fyStart,
-		int fyEnd,
-		int x,
-		int y)
+		PointI fStart,
+		PointI fEnd,
+		PointI coordinates)
 	{
 		// loop through each weight
 		double rSum = 0.0;
 		double gSum = 0.0;
 		double bSum = 0.0;
-		for (int fy = fyStart; fy < fyEnd; ++fy) {
-			for (int fx = fxStart; fx < fxEnd; ++fx) {
+		for (int fy = fStart.Y; fy < fEnd.Y; ++fy) {
+			for (int fx = fStart.X; fx < fEnd.X; ++fx) {
 				double weight = weights[fy][fx];
-				ColorBgra c = src_data[(y - 1 + fy) * src_width + (x - 1 + fx)];
+				ColorBgra c = src_data[(coordinates.Y - 1 + fy) * src_width + (coordinates.X - 1 + fx)];
 				rSum += weight * c.R;
 				gSum += weight * c.G;
 				bSum += weight * c.B;

--- a/Pinta.Core/Effects/ColorDifferenceEffect.cs
+++ b/Pinta.Core/Effects/ColorDifferenceEffect.cs
@@ -37,22 +37,15 @@ public abstract class ColorDifferenceEffect : BaseEffect
 
 		foreach (RectangleI rect in rois) {
 
-			// loop through each line of target rectangle
-			for (int y = rect.Y; y < rect.Y + rect.Height; ++y) {
+			foreach (var pixel in Utility.GeneratePixelOffsets (rect, src.GetSize ())) {
 
-				int fyStart = (y == src_rect.Y) ? 1 : 0;
-				int fyEnd = (y == src_rect.Y + src_rect.Height - 1) ? 2 : 3;
+				int fyStart = (pixel.coordinates.Y == src_rect.Y) ? 1 : 0;
+				int fyEnd = (pixel.coordinates.Y == src_rect.Y + src_rect.Height - 1) ? 2 : 3;
 
-				// loop through each point in the line
-				var dst_row = dst_data[(y * src_width)..];
+				int fxStart = (pixel.coordinates.X == src_rect.X) ? 1 : 0;
+				int fxEnd = (pixel.coordinates.X == src_rect.X + src_rect.Width - 1) ? 2 : 3;
 
-				for (int x = rect.X; x < rect.X + rect.Width; ++x) {
-
-					int fxStart = (x == src_rect.X) ? 1 : 0;
-					int fxEnd = (x == src_rect.X + src_rect.Width - 1) ? 2 : 3;
-
-					dst_row[x] = GetFinalPixelColor (weights, src_data, src_width, fxStart, fxEnd, fyStart, fyEnd, x, y);
-				}
+				dst_data[pixel.memoryOffset] = GetFinalPixelColor (weights, src_data, src_width, fxStart, fxEnd, fyStart, fyEnd, x, y);
 			}
 		}
 	}

--- a/Pinta.Core/Effects/ColorDifferenceEffect.cs
+++ b/Pinta.Core/Effects/ColorDifferenceEffect.cs
@@ -45,7 +45,7 @@ public abstract class ColorDifferenceEffect : BaseEffect
 				int fxStart = (pixel.coordinates.X == src_rect.X) ? 1 : 0;
 				int fxEnd = (pixel.coordinates.X == src_rect.X + src_rect.Width - 1) ? 2 : 3;
 
-				dst_data[pixel.memoryOffset] = GetFinalPixelColor (weights, src_data, src_width, fxStart, fxEnd, fyStart, fyEnd, x, y);
+				dst_data[pixel.memoryOffset] = GetFinalPixelColor (weights, src_data, src_width, fxStart, fxEnd, fyStart, fyEnd, pixel.coordinates.X, pixel.coordinates.Y);
 			}
 		}
 	}

--- a/Pinta.Core/Effects/Utility.cs
+++ b/Pinta.Core/Effects/Utility.cs
@@ -51,8 +51,6 @@ public static class Utility
 	public static double Distance (this PointD origin, in PointD dest)
 		=> Magnitude (origin - dest);
 
-	public readonly record struct PixelOffset (PointI coordinates, int memoryOffset);
-
 	/// <returns>
 	/// Offsets of pixels, if we consider all pixels in a canvas of
 	/// size <paramref name="canvasSize"/> to be sequential in memory

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -87,9 +87,10 @@ public sealed class BulgeEffect : BaseEffect
 			for (int y = rect.Top; y <= rect.Bottom; y++) {
 				var src_row = src_data.Slice (y * settings.src_width, settings.src_width);
 				var dst_row = dst_data.Slice (y * settings.src_width, settings.src_width);
-				float v = y - settings.hh;
+
 
 				for (int x = rect.Left; x <= rect.Right; x++) {
+					float v = y - settings.hh;
 					float u = x - settings.hw;
 					float r = (float) Math.Sqrt (u * u + v * v);
 					float rscale1 = (1f - (r / settings.maxrad));

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -84,27 +84,22 @@ public sealed class BulgeEffect : BaseEffect
 
 		foreach (RectangleI rect in rois) {
 
-			for (int y = rect.Top; y <= rect.Bottom; y++) {
-				var src_row = src_data.Slice (y * settings.src_width, settings.src_width);
-				var dst_row = dst_data.Slice (y * settings.src_width, settings.src_width);
+			foreach (var pixel in Utility.GeneratePixelOffsets (rect, new Size (settings.src_width, settings.src_height))) {
 
+				float v = pixel.coordinates.Y - settings.hh;
+				float u = pixel.coordinates.X - settings.hw;
+				float r = (float) Math.Sqrt (u * u + v * v);
+				float rscale1 = (1f - (r / settings.maxrad));
 
-				for (int x = rect.Left; x <= rect.Right; x++) {
-					float v = y - settings.hh;
-					float u = x - settings.hw;
-					float r = (float) Math.Sqrt (u * u + v * v);
-					float rscale1 = (1f - (r / settings.maxrad));
+				if (rscale1 > 0) {
+					float rscale2 = 1 - settings.amt * rscale1 * rscale1;
 
-					if (rscale1 > 0) {
-						float rscale2 = 1 - settings.amt * rscale1 * rscale1;
+					float xp = u * rscale2;
+					float yp = v * rscale2;
 
-						float xp = u * rscale2;
-						float yp = v * rscale2;
-
-						dst_row[x] = src.GetBilinearSampleClamped (src_data, settings.src_width, settings.src_height, xp + settings.hw, yp + settings.hh);
-					} else {
-						dst_row[x] = src_row[x];
-					}
+					dst_data[pixel.memoryOffset] = src.GetBilinearSampleClamped (src_data, settings.src_width, settings.src_height, xp + settings.hw, yp + settings.hh);
+				} else {
+					dst_data[pixel.memoryOffset] = src_data[pixel.memoryOffset];
 				}
 			}
 		}

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -47,31 +47,24 @@ public sealed class BulgeEffect : BaseEffect
 		float hw,
 		float hh,
 		float maxrad,
-		float amt,
+		float amount,
 		int src_width,
 		int src_height);
 	private BulgeSettings CreateSettings (ImageSurface src, ImageSurface dst)
 	{
-		float bulge = Data.Amount;
-
 		float hw = dst.Width / 2f;
 		float hh = dst.Height / 2f;
-		float maxrad = Math.Min (hw, hh);
-		float amt = bulge / 100f;
 
 		hh += (float) Data.Offset.Y * hh;
 		hw += (float) Data.Offset.X * hw;
 
-		int src_width = src.Width;
-		int src_height = src.Height;
-
 		return new BulgeSettings (
 			hw: hw,
 			hh: hh,
-			maxrad: maxrad,
-			amt: amt,
-			src_width: src_width,
-			src_height: src_height
+			maxrad: Math.Min (hw, hh),
+			amount: Data.Amount / 100f,
+			src_width: src.Width,
+			src_height: src.Height
 		);
 	}
 
@@ -88,11 +81,11 @@ public sealed class BulgeEffect : BaseEffect
 
 				float v = pixel.coordinates.Y - settings.hh;
 				float u = pixel.coordinates.X - settings.hw;
-				float r = (float) Math.Sqrt (u * u + v * v);
+				float r = (float) Utility.Magnitude (u, v);
 				float rscale1 = (1f - (r / settings.maxrad));
 
 				if (rscale1 > 0) {
-					float rscale2 = 1 - settings.amt * rscale1 * rscale1;
+					float rscale2 = 1 - settings.amount * rscale1 * rscale1;
 
 					float xp = u * rscale2;
 					float yp = v * rscale2;

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -84,26 +84,22 @@ public sealed class BulgeEffect : BaseEffect
 
 		foreach (RectangleI rect in rois) {
 
-			for (int y = rect.Top; y <= rect.Bottom; y++) {
-				var src_row = src_data.Slice (y * settings.src_width, settings.src_width);
-				var dst_row = dst_data.Slice (y * settings.src_width, settings.src_width);
-				float v = y - settings.hh;
+			foreach (var pixel in Utility.GeneratePixelOffsets (rect, new Size (settings.src_width, settings.src_height))) {
 
-				for (int x = rect.Left; x <= rect.Right; x++) {
-					float u = x - settings.hw;
-					float r = (float) Math.Sqrt (u * u + v * v);
-					float rscale1 = (1f - (r / settings.maxrad));
+				float v = pixel.coordinates.Y - settings.hh;
+				float u = pixel.coordinates.X - settings.hw;
+				float r = (float) Math.Sqrt (u * u + v * v);
+				float rscale1 = (1f - (r / settings.maxrad));
 
-					if (rscale1 > 0) {
-						float rscale2 = 1 - settings.amt * rscale1 * rscale1;
+				if (rscale1 > 0) {
+					float rscale2 = 1 - settings.amt * rscale1 * rscale1;
 
-						float xp = u * rscale2;
-						float yp = v * rscale2;
+					float xp = u * rscale2;
+					float yp = v * rscale2;
 
-						dst_row[x] = src.GetBilinearSampleClamped (src_data, settings.src_width, settings.src_height, xp + settings.hw, yp + settings.hh);
-					} else {
-						dst_row[x] = src_row[x];
-					}
+					dst_data[pixel.memoryOffset] = src.GetBilinearSampleClamped (src_data, settings.src_width, settings.src_height, xp + settings.hw, yp + settings.hh);
+				} else {
+					dst_data[pixel.memoryOffset] = src_data[pixel.memoryOffset];
 				}
 			}
 		}

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -37,9 +37,7 @@ public sealed class BulgeEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 
@@ -47,7 +45,7 @@ public sealed class BulgeEffect : BaseEffect
 		float hw,
 		float hh,
 		float maxrad,
-		float amt,
+		float amount,
 		int src_width,
 		int src_height);
 	private BulgeSettings CreateSettings (ImageSurface src, ImageSurface dst)
@@ -56,22 +54,17 @@ public sealed class BulgeEffect : BaseEffect
 
 		float hw = dst.Width / 2f;
 		float hh = dst.Height / 2f;
-		float maxrad = Math.Min (hw, hh);
-		float amt = bulge / 100f;
 
 		hh += (float) Data.Offset.Y * hh;
 		hw += (float) Data.Offset.X * hw;
 
-		int src_width = src.Width;
-		int src_height = src.Height;
-
 		return new BulgeSettings (
 			hw: hw,
 			hh: hh,
-			maxrad: maxrad,
-			amt: amt,
-			src_width: src_width,
-			src_height: src_height
+			maxrad: Math.Min (hw, hh),
+			amount: bulge / 100f,
+			src_width: src.Width,
+			src_height: src.Height
 		);
 	}
 
@@ -92,12 +85,17 @@ public sealed class BulgeEffect : BaseEffect
 				float rscale1 = (1f - (r / settings.maxrad));
 
 				if (rscale1 > 0) {
-					float rscale2 = 1 - settings.amt * rscale1 * rscale1;
+					float rscale2 = 1 - settings.amount * rscale1 * rscale1;
 
 					float xp = u * rscale2;
 					float yp = v * rscale2;
 
-					dst_data[pixel.memoryOffset] = src.GetBilinearSampleClamped (src_data, settings.src_width, settings.src_height, xp + settings.hw, yp + settings.hh);
+					dst_data[pixel.memoryOffset] = src.GetBilinearSampleClamped (
+						src_data,
+						settings.src_width,
+						settings.src_height,
+						xp + settings.hw,
+						yp + settings.hh);
 				} else {
 					dst_data[pixel.memoryOffset] = src_data[pixel.memoryOffset];
 				}

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -37,7 +37,9 @@ public sealed class BulgeEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-		=> chrome.LaunchSimpleEffectDialog (this);
+	{
+		chrome.LaunchSimpleEffectDialog (this);
+	}
 
 	#region Algorithm Code Ported From PDN
 
@@ -45,7 +47,7 @@ public sealed class BulgeEffect : BaseEffect
 		float hw,
 		float hh,
 		float maxrad,
-		float amount,
+		float amt,
 		int src_width,
 		int src_height);
 	private BulgeSettings CreateSettings (ImageSurface src, ImageSurface dst)
@@ -54,17 +56,22 @@ public sealed class BulgeEffect : BaseEffect
 
 		float hw = dst.Width / 2f;
 		float hh = dst.Height / 2f;
+		float maxrad = Math.Min (hw, hh);
+		float amt = bulge / 100f;
 
 		hh += (float) Data.Offset.Y * hh;
 		hw += (float) Data.Offset.X * hw;
 
+		int src_width = src.Width;
+		int src_height = src.Height;
+
 		return new BulgeSettings (
 			hw: hw,
 			hh: hh,
-			maxrad: Math.Min (hw, hh),
-			amount: bulge / 100f,
-			src_width: src.Width,
-			src_height: src.Height
+			maxrad: maxrad,
+			amt: amt,
+			src_width: src_width,
+			src_height: src_height
 		);
 	}
 
@@ -85,17 +92,12 @@ public sealed class BulgeEffect : BaseEffect
 				float rscale1 = (1f - (r / settings.maxrad));
 
 				if (rscale1 > 0) {
-					float rscale2 = 1 - settings.amount * rscale1 * rscale1;
+					float rscale2 = 1 - settings.amt * rscale1 * rscale1;
 
 					float xp = u * rscale2;
 					float yp = v * rscale2;
 
-					dst_data[pixel.memoryOffset] = src.GetBilinearSampleClamped (
-						src_data,
-						settings.src_width,
-						settings.src_height,
-						xp + settings.hw,
-						yp + settings.hh);
+					dst_data[pixel.memoryOffset] = src.GetBilinearSampleClamped (src_data, settings.src_width, settings.src_height, xp + settings.hw, yp + settings.hh);
 				} else {
 					dst_data[pixel.memoryOffset] = src_data[pixel.memoryOffset];
 				}

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -50,21 +50,10 @@ public sealed class OilPaintingEffect : BaseEffect
 		Span<ColorBgra> dst_data = dest.GetPixelData ();
 
 		foreach (var rect in rois) {
-
-			int rectTop = rect.Top;
-			int rectBottom = rect.Bottom;
-			int rectLeft = rect.Left;
-			int rectRight = rect.Right;
-
-			for (int y = rectTop; y <= rectBottom; ++y) {
-
-				var dst_row = dst_data.Slice (y * settings.width, settings.width);
-
-				int top = Math.Max (y - settings.brushSize, 0);
-				int bottom = Math.Min (y + settings.brushSize + 1, settings.height);
-
-				for (int x = rectLeft; x <= rectRight; ++x)
-					dst_row[x] = GetFinalColor (settings, src_data, top, bottom, x);
+			foreach (var pixel in Utility.GeneratePixelOffsets (rect, new (settings.width, settings.height))) {
+				int top = Math.Max (pixel.coordinates.Y - settings.brushSize, 0);
+				int bottom = Math.Min (pixel.coordinates.Y + settings.brushSize + 1, settings.height);
+				dst_data[pixel.memoryOffset] = GetFinalColor (settings, src_data, top, bottom, x);
 			}
 		}
 	}

--- a/Pinta.Effects/Effects/PencilSketchEffect.cs
+++ b/Pinta.Effects/Effects/PencilSketchEffect.cs
@@ -68,19 +68,14 @@ public sealed class PencilSketchEffect : BaseEffect
 		desaturate_op.Apply (dest, dest, rois);
 
 		var dst_data = dest.GetPixelData ();
-		int dst_width = dest.Width;
 		var src_data = src.GetReadOnlyPixelData ();
-		int src_width = src.Width;
+
+		Size canvasSize = src.GetSize ();
 
 		foreach (RectangleI roi in rois) {
-			for (int y = roi.Top; y <= roi.Bottom; ++y) {
-				var src_row = src_data.Slice (y * src_width, src_width);
-				var dst_row = dst_data.Slice (y * dst_width, dst_width);
-
-				for (int x = roi.Left; x <= roi.Right; ++x) {
-					ColorBgra srcGrey = desaturate_op.Apply (src_row[x]);
-					dst_row[x] = color_dodge_op.Apply (srcGrey, dst_row[x]);
-				}
+			foreach (var pixel in Utility.GeneratePixelOffsets (roi, canvasSize)) {
+				ColorBgra srcGrey = desaturate_op.Apply (src_data[pixel.memoryOffset]);
+				dst_data[pixel.memoryOffset] = color_dodge_op.Apply (srcGrey, dst_data[pixel.memoryOffset]);
 			}
 		}
 	}

--- a/Pinta.Effects/Effects/TileEffect.cs
+++ b/Pinta.Effects/Effects/TileEffect.cs
@@ -38,9 +38,7 @@ public sealed class TileEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 
@@ -108,13 +106,9 @@ public sealed class TileEffect : BaseEffect
 		Span<ColorBgra> dst_data = dst.GetPixelData ();
 
 		foreach (var rect in rois) {
-			for (int y = rect.Top; y <= rect.Bottom; y++) {
-
-				float j = y - settings.hh;
-				var dst_row = dst_data.Slice (y * settings.width, settings.width);
-
-				for (int x = rect.Left; x <= rect.Right; x++)
-					dst_row[x] = GetFinalPixelColor (src, settings, aaPoints, src_data, j, x);
+			foreach (var pixel in Utility.GeneratePixelOffsets (rect, src.GetSize ())) {
+				float j = pixel.coordinates.Y - settings.hh;
+				dst_data[pixel.memoryOffset] = GetFinalPixelColor (src, settings, aaPoints, src_data, j, pixel.coordinates.X);
 			}
 		}
 	}

--- a/Pinta.Effects/Effects/VoronoiDiagramEffect.cs
+++ b/Pinta.Effects/Effects/VoronoiDiagramEffect.cs
@@ -68,7 +68,7 @@ public sealed class VoronoiDiagramEffect : BaseEffect
 		foreach (var kvp in roi.GeneratePixelOffsets (settings.size).AsParallel ().Select (CreateColor))
 			dst_data[kvp.Key] = kvp.Value;
 
-		KeyValuePair<int, ColorBgra> CreateColor (Utility.PixelOffset pixel)
+		KeyValuePair<int, ColorBgra> CreateColor (PixelOffset pixel)
 		{
 			double shortestDistance = double.MaxValue;
 			int closestIndex = 0;

--- a/Pinta.Effects/Effects/WarpEffect.cs
+++ b/Pinta.Effects/Effects/WarpEffect.cs
@@ -49,9 +49,7 @@ public abstract class WarpEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		Chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> Chrome.LaunchSimpleEffectDialog (this);
 
 	protected double DefaultRadius { get; private set; } = 0;
 	protected double DefaultRadius2 { get; private set; } = 0;
@@ -75,13 +73,9 @@ public abstract class WarpEffect : BaseEffect
 		ReadOnlySpan<ColorBgra> src_data = src.GetReadOnlyPixelData ();
 
 		foreach (RectangleI rect in rois) {
-			for (int y = rect.Top; y <= rect.Bottom; y++) {
-				var dst_row = dst_data.Slice (y * dst.Width, dst.Width);
-				double relativeY = y - settings.y_center_offset;
-				for (int x = rect.Left; x <= rect.Right; x++) {
-					PointI target = new (x, y);
-					dst_row[x] = GetPixelColor (settings, src, src_data, aaPoints, relativeY, target);
-				}
+			foreach (var pixel in Utility.GeneratePixelOffsets (rect, src.GetSize ())) {
+				double relativeY = pixel.coordinates.Y - settings.y_center_offset;
+				dst_data[pixel.memoryOffset] = GetPixelColor (settings, src, src_data, aaPoints, relativeY, pixel.coordinates);
 			}
 		}
 	}


### PR DESCRIPTION
Some simple values are re-calculated with each pixel, but I plan to solve it with another structure that stores values for each row or column. The code of some effects is not that easy to refactor in this way yet, though.

Also, I'm noticing that `SoftenPortraitData.Softness` and `SoftenPortraitData.Lighting` aren't being used anywhere?