### PR TITLE
Effects and tools are now passed an `IServiceProvider` instead of an `IServiceManager`

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -47,7 +48,7 @@ public abstract class BaseTool
 
 	protected static PointI point_empty = new (-500, -500);
 
-	protected BaseTool (IServiceManager services)
+	protected BaseTool (IServiceProvider services)
 	{
 		Resources = services.GetService<IResourceService> ();
 		Settings = services.GetService<ISettingsService> ();
@@ -211,9 +212,7 @@ public abstract class BaseTool
 	/// components to handle it.
 	/// </summary>
 	protected virtual bool OnHandleCopy (Document document, Clipboard cb)
-	{
-		return false;
-	}
+		=> false;
 
 	/// <summary>
 	/// Called to give the tool an opportunity to consume a Cut clipboard operation.
@@ -221,9 +220,7 @@ public abstract class BaseTool
 	/// components to handle it.
 	/// </summary>
 	protected virtual bool OnHandleCut (Document document, Clipboard cb)
-	{
-		return false;
-	}
+		=> false;
 
 	/// <summary>
 	/// Called to give the tool an opportunity to consume a Paste clipboard operation.
@@ -231,9 +228,7 @@ public abstract class BaseTool
 	/// components to handle it.
 	/// </summary>
 	protected virtual Task<bool> OnHandlePaste (Document document, Clipboard cb)
-	{
-		return Task.FromResult (false);
-	}
+		=> Task.FromResult (false);
 
 	/// <summary>
 	/// Called to give the tool an opportunity to consume a Redo operation.
@@ -241,9 +236,7 @@ public abstract class BaseTool
 	/// components to handle it.
 	/// </summary>
 	protected virtual bool OnHandleRedo (Document document)
-	{
-		return false;
-	}
+		=> false;
 
 	/// <summary>
 	/// Called to give the tool an opportunity to consume an Undo operation.
@@ -251,27 +244,21 @@ public abstract class BaseTool
 	/// components to handle it.
 	/// </summary>
 	protected virtual bool OnHandleUndo (Document document)
-	{
-		return false;
-	}
+		=> false;
 
 	/// <summary>
 	/// Called when a key is pressed. Return 'true' if the key is handled, or
 	/// 'false' to allow other components to handle it.
 	/// </summary>
 	protected virtual bool OnKeyDown (Document document, ToolKeyEventArgs e)
-	{
-		return false;
-	}
+		=> false;
 
 	/// <summary>
 	/// Called when a key is released. Return 'true' if the key is handled, or
 	/// 'false' to allow other components to handle it.
 	/// </summary>
 	protected virtual bool OnKeyUp (Document document, ToolKeyEventArgs e)
-	{
-		return false;
-	}
+		=> false;
 
 	/// <summary>
 	/// Called when a mouse button is pressed.

--- a/Pinta.Core/Managers/ServiceManager.cs
+++ b/Pinta.Core/Managers/ServiceManager.cs
@@ -29,11 +29,28 @@ using System.Collections.Generic;
 
 namespace Pinta.Core;
 
-public interface IServiceManager
+public static class ServiceProviderExtensions
+{
+	public static T GetService<T> (this IServiceProvider services) where T : class
+	{
+		object? implementation = services.GetService (typeof (T));
+		if (implementation is not null)
+			return (T) implementation;
+		throw new ApplicationException ($"Could not resolve service type {typeof (T)}");
+	}
+
+	public static T? GetOptionalService<T> (this IServiceProvider services) where T : class
+	{
+		object? implementation = services.GetService (typeof (T));
+		if (implementation is not null)
+			return (T) implementation;
+		return null;
+	}
+}
+
+public interface IServiceManager : IServiceProvider
 {
 	T AddService<T> (T implementation) where T : class;
-	T GetService<T> () where T : class;
-	T? GetOptionalService<T> () where T : class;
 }
 
 public sealed class ServiceManager : IServiceManager
@@ -43,23 +60,14 @@ public sealed class ServiceManager : IServiceManager
 	public T AddService<T> (T implementation) where T : class
 	{
 		services.Add (typeof (T), implementation);
-
 		return implementation;
 	}
 
-	public T GetService<T> () where T : class
+	public object? GetService (Type serviceType)
 	{
-		if (services.TryGetValue (typeof (T), out var implementation))
-			return (T) implementation;
-
-		throw new ApplicationException ($"Could not resolve service type {typeof (T)}");
-	}
-
-	public T? GetOptionalService<T> () where T : class
-	{
-		if (services.TryGetValue (typeof (T), out var implementation))
-			return (T) implementation;
-
-		return null;
+		if (services.TryGetValue (serviceType, out var implementation))
+			return implementation;
+		else
+			return null;
 	}
 }

--- a/Pinta.Effects/Adjustments/AutoLevelEffect.cs
+++ b/Pinta.Effects/Adjustments/AutoLevelEffect.cs
@@ -25,7 +25,7 @@ public sealed class AutoLevelEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "L";
 
-	public AutoLevelEffect (IServiceManager _) { }
+	public AutoLevelEffect (IServiceProvider _) { }
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{

--- a/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
+++ b/Pinta.Effects/Adjustments/BlackAndWhiteEffect.cs
@@ -25,10 +25,8 @@ public sealed class BlackAndWhiteEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "G";
 
-	public BlackAndWhiteEffect (IServiceManager _) { }
+	public BlackAndWhiteEffect (IServiceProvider _) { }
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
-	{
-		op.Apply (dest, src, rois);
-	}
+		=> op.Apply (dest, src, rois);
 }

--- a/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
+++ b/Pinta.Effects/Adjustments/BrightnessContrastEffect.cs
@@ -35,7 +35,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public BrightnessContrastEffect (IServiceManager services)
+	public BrightnessContrastEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new BrightnessContrastData ();
@@ -51,9 +51,7 @@ public sealed class BrightnessContrastEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -33,7 +33,7 @@ public sealed class CurvesEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public CurvesEffect (IServiceManager services)
+	public CurvesEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 

--- a/Pinta.Effects/Adjustments/HueSaturationEffect.cs
+++ b/Pinta.Effects/Adjustments/HueSaturationEffect.cs
@@ -28,16 +28,14 @@ public sealed class HueSaturationEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public HueSaturationEffect (IServiceManager services)
+	public HueSaturationEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new HueSaturationData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	private UnaryPixelOp CreateOptimalOp ()
 		=>
@@ -54,7 +52,8 @@ public sealed class HueSaturationEffect : BaseEffect
 		op.Apply (dest, src, rois);
 	}
 
-	public HueSaturationData Data => (HueSaturationData) EffectData!;  // NRT - Set in constructor
+	public HueSaturationData Data
+		=> (HueSaturationData) EffectData!;  // NRT - Set in constructor
 
 	public sealed class HueSaturationData : EffectData
 	{

--- a/Pinta.Effects/Adjustments/InvertColorsEffect.cs
+++ b/Pinta.Effects/Adjustments/InvertColorsEffect.cs
@@ -25,7 +25,7 @@ public sealed class InvertColorsEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "I";
 
-	public InvertColorsEffect (IServiceManager _) { }
+	public InvertColorsEffect (IServiceProvider _) { }
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 		=> op.Apply (dest, src, rois);

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -32,7 +32,7 @@ public sealed class LevelsEffect : BaseEffect
 	private readonly IChromeService chrome;
 	private readonly IWorkspaceService workspace;
 
-	public LevelsEffect (IServiceManager services)
+	public LevelsEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		workspace = services.GetService<IWorkspaceService> ();
@@ -60,9 +60,7 @@ public sealed class LevelsEffect : BaseEffect
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
-	{
-		Data.Levels.Apply (dest, src, rois);
-	}
+		=> Data.Levels.Apply (dest, src, rois);
 }
 
 public sealed class LevelsData : EffectData

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -31,7 +31,7 @@ public sealed class PosterizeEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public PosterizeEffect (IServiceManager services)
+	public PosterizeEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 

--- a/Pinta.Effects/Adjustments/SepiaEffect.cs
+++ b/Pinta.Effects/Adjustments/SepiaEffect.cs
@@ -26,7 +26,7 @@ public sealed class SepiaEffect : BaseEffect
 
 	public override string AdjustmentMenuKey => "E";
 
-	public SepiaEffect (IServiceManager _)
+	public SepiaEffect (IServiceProvider _)
 	{
 		desat = new UnaryPixelOps.Desaturate ();
 		level = new UnaryPixelOps.Level (

--- a/Pinta.Effects/CoreEffectsExtension.cs
+++ b/Pinta.Effects/CoreEffectsExtension.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Mono.Addins;
 using Pinta.Core;
 
@@ -41,7 +42,7 @@ internal sealed class CoreEffectsExtension : IExtension
 	#region IExtension Members
 	public void Initialize ()
 	{
-		IServiceManager services = PintaCore.Services;
+		IServiceProvider services = PintaCore.Services;
 
 		// Add the adjustments
 		PintaCore.Effects.RegisterAdjustment (new AutoLevelEffect (services));

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -36,7 +36,7 @@ public sealed class AddNoiseEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public AddNoiseEffect (IServiceManager services)
+	public AddNoiseEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new NoiseData ();

--- a/Pinta.Effects/Effects/BulgeEffect.cs
+++ b/Pinta.Effects/Effects/BulgeEffect.cs
@@ -30,16 +30,14 @@ public sealed class BulgeEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public BulgeEffect (IServiceManager services)
+	public BulgeEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new BulgeData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -38,7 +38,7 @@ public sealed class CloudsEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public CloudsEffect (IServiceManager services)
+	public CloudsEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		palette = services.GetService<IPaletteService> ();

--- a/Pinta.Effects/Effects/DitheringEffect.cs
+++ b/Pinta.Effects/Effects/DitheringEffect.cs
@@ -18,7 +18,7 @@ public sealed class DitheringEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public DitheringEffect (IServiceManager services)
+	public DitheringEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new DitheringData ();

--- a/Pinta.Effects/Effects/EdgeDetectEffect.cs
+++ b/Pinta.Effects/Effects/EdgeDetectEffect.cs
@@ -30,16 +30,14 @@ public sealed class EdgeDetectEffect : ColorDifferenceEffect
 
 	private readonly IChromeService chrome;
 
-	public EdgeDetectEffect (IServiceManager services)
+	public EdgeDetectEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new EdgeDetectData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{

--- a/Pinta.Effects/Effects/EmbossEffect.cs
+++ b/Pinta.Effects/Effects/EmbossEffect.cs
@@ -30,16 +30,14 @@ public sealed class EmbossEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public EmbossEffect (IServiceManager services)
+	public EmbossEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new EmbossData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/FragmentEffect.cs
+++ b/Pinta.Effects/Effects/FragmentEffect.cs
@@ -31,16 +31,14 @@ public sealed class FragmentEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public FragmentEffect (IServiceManager services)
+	public FragmentEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new FragmentData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/FrostedGlassEffect.cs
+++ b/Pinta.Effects/Effects/FrostedGlassEffect.cs
@@ -30,16 +30,14 @@ public sealed class FrostedGlassEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public FrostedGlassEffect (IServiceManager services)
+	public FrostedGlassEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new FrostedGlassData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/GaussianBlurEffect.cs
+++ b/Pinta.Effects/Effects/GaussianBlurEffect.cs
@@ -31,16 +31,14 @@ public sealed class GaussianBlurEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public GaussianBlurEffect (IServiceManager services)
+	public GaussianBlurEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new GaussianBlurData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/GlowEffect.cs
+++ b/Pinta.Effects/Effects/GlowEffect.cs
@@ -17,7 +17,7 @@ namespace Pinta.Effects;
 public sealed class GlowEffect : BaseEffect
 {
 	private readonly UserBlendOps.ScreenBlendOp screen_blend_op;
-	private readonly IServiceManager services;
+	private readonly IServiceProvider services;
 
 	public override string Icon => Pinta.Resources.Icons.EffectsPhotoGlow;
 
@@ -33,7 +33,7 @@ public sealed class GlowEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public GlowEffect (IServiceManager services)
+	public GlowEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new GlowData ();
@@ -42,9 +42,7 @@ public sealed class GlowEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -39,7 +39,7 @@ public sealed class InkSketchEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public InkSketchEffect (IServiceManager services)
+	public InkSketchEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new InkSketchData ();
@@ -61,9 +61,7 @@ public sealed class InkSketchEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -32,7 +32,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public JuliaFractalEffect (IServiceManager services)
+	public JuliaFractalEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		palette = services.GetService<IPaletteService> ();

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -32,7 +32,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public MandelbrotFractalEffect (IServiceManager services)
+	public MandelbrotFractalEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		invert_effect = new (services);
@@ -41,9 +41,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/MedianEffect.cs
+++ b/Pinta.Effects/Effects/MedianEffect.cs
@@ -33,16 +33,14 @@ public sealed class MedianEffect : LocalHistogramEffect
 
 	private readonly IChromeService chrome;
 
-	public MedianEffect (IServiceManager services)
+	public MedianEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new MedianData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/MotionBlurEffect.cs
+++ b/Pinta.Effects/Effects/MotionBlurEffect.cs
@@ -31,7 +31,7 @@ public sealed class MotionBlurEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public MotionBlurEffect (IServiceManager services)
+	public MotionBlurEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new MotionBlurData ();

--- a/Pinta.Effects/Effects/OilPaintingEffect.cs
+++ b/Pinta.Effects/Effects/OilPaintingEffect.cs
@@ -30,16 +30,14 @@ public sealed class OilPaintingEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public OilPaintingEffect (IServiceManager services)
+	public OilPaintingEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new OilPaintingData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/OutlineEffect.cs
+++ b/Pinta.Effects/Effects/OutlineEffect.cs
@@ -33,16 +33,14 @@ public sealed class OutlineEffect : LocalHistogramEffect
 
 	private readonly IChromeService chrome;
 
-	public OutlineEffect (IServiceManager services)
+	public OutlineEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new OutlineData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override ColorBgra Apply (in ColorBgra src, int area, Span<int> hb, Span<int> hg, Span<int> hr, Span<int> ha)

--- a/Pinta.Effects/Effects/PencilSketchEffect.cs
+++ b/Pinta.Effects/Effects/PencilSketchEffect.cs
@@ -36,7 +36,7 @@ public sealed class PencilSketchEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public PencilSketchEffect (IServiceManager services)
+	public PencilSketchEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -50,9 +50,7 @@ public sealed class PencilSketchEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/PixelateEffect.cs
+++ b/Pinta.Effects/Effects/PixelateEffect.cs
@@ -30,7 +30,7 @@ public sealed class PixelateEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public PixelateEffect (IServiceManager services)
+	public PixelateEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -38,9 +38,7 @@ public sealed class PixelateEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	private static ColorBgra ComputeCellColor (int x, int y, ReadOnlySpan<ColorBgra> src_data, int cellSize, RectangleI srcBounds)

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -7,6 +7,7 @@
 // Ported to Pinta by: Olivier Dufour <olivier.duff@gmail.com>                 //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Pinta.Core;
 using Pinta.Gui.Widgets;
 
@@ -29,7 +30,7 @@ public sealed class PolarInversionEffect : WarpEffect
 	protected override IPaletteService Palette { get; }
 	protected override IChromeService Chrome { get; }
 
-	public PolarInversionEffect (IServiceManager services)
+	public PolarInversionEffect (IServiceProvider services)
 	{
 		Palette = services.GetService<IPaletteService> ();
 		Chrome = services.GetService<IChromeService> ();

--- a/Pinta.Effects/Effects/RadialBlurEffect.cs
+++ b/Pinta.Effects/Effects/RadialBlurEffect.cs
@@ -30,7 +30,7 @@ public sealed class RadialBlurEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public RadialBlurEffect (IServiceManager services)
+	public RadialBlurEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -38,9 +38,7 @@ public sealed class RadialBlurEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
+++ b/Pinta.Effects/Effects/RedEyeRemoveEffect.cs
@@ -30,7 +30,7 @@ public sealed class RedEyeRemoveEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public RedEyeRemoveEffect (IServiceManager services)
+	public RedEyeRemoveEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -38,9 +38,7 @@ public sealed class RedEyeRemoveEffect : BaseEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{

--- a/Pinta.Effects/Effects/ReduceNoiseEffect.cs
+++ b/Pinta.Effects/Effects/ReduceNoiseEffect.cs
@@ -33,7 +33,7 @@ public sealed class ReduceNoiseEffect : LocalHistogramEffect
 
 	private readonly IChromeService chrome;
 
-	public ReduceNoiseEffect (IServiceManager services)
+	public ReduceNoiseEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -41,9 +41,7 @@ public sealed class ReduceNoiseEffect : LocalHistogramEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override ColorBgra Apply (in ColorBgra color, int area, Span<int> hb, Span<int> hg, Span<int> hr, Span<int> ha)

--- a/Pinta.Effects/Effects/ReliefEffect.cs
+++ b/Pinta.Effects/Effects/ReliefEffect.cs
@@ -17,7 +17,7 @@ public sealed class ReliefEffect : ColorDifferenceEffect
 {
 	private readonly IChromeService chrome;
 
-	public ReliefEffect (IServiceManager services)
+	public ReliefEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -33,9 +33,7 @@ public sealed class ReliefEffect : ColorDifferenceEffect
 	public override string EffectMenuCategory => Translations.GetString ("Stylize");
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	public override string Icon => Pinta.Resources.Icons.EffectsStylizeRelief;
 

--- a/Pinta.Effects/Effects/SharpenEffect.cs
+++ b/Pinta.Effects/Effects/SharpenEffect.cs
@@ -30,7 +30,7 @@ public sealed class SharpenEffect : LocalHistogramEffect
 
 	private readonly IChromeService chrome;
 
-	public SharpenEffect (IServiceManager services)
+	public SharpenEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -38,9 +38,7 @@ public sealed class SharpenEffect : LocalHistogramEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
 	{

--- a/Pinta.Effects/Effects/SoftenPortraitEffect.cs
+++ b/Pinta.Effects/Effects/SoftenPortraitEffect.cs
@@ -61,7 +61,7 @@ public sealed class SoftenPortraitEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public SoftenPortraitEffect (IServiceManager services)
+	public SoftenPortraitEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 

--- a/Pinta.Effects/Effects/TileEffect.cs
+++ b/Pinta.Effects/Effects/TileEffect.cs
@@ -30,7 +30,7 @@ public sealed class TileEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public TileEffect (IServiceManager services)
+	public TileEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 

--- a/Pinta.Effects/Effects/TwistEffect.cs
+++ b/Pinta.Effects/Effects/TwistEffect.cs
@@ -31,7 +31,7 @@ public sealed class TwistEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public TwistEffect (IServiceManager services)
+	public TwistEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 

--- a/Pinta.Effects/Effects/UnfocusEffect.cs
+++ b/Pinta.Effects/Effects/UnfocusEffect.cs
@@ -32,7 +32,7 @@ public sealed class UnfocusEffect : LocalHistogramEffect
 
 	private readonly IChromeService chrome;
 
-	public UnfocusEffect (IServiceManager services)
+	public UnfocusEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 
@@ -40,9 +40,7 @@ public sealed class UnfocusEffect : LocalHistogramEffect
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/VoronoiDiagramEffect.cs
+++ b/Pinta.Effects/Effects/VoronoiDiagramEffect.cs
@@ -25,7 +25,7 @@ public sealed class VoronoiDiagramEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public VoronoiDiagramEffect (IServiceManager services)
+	public VoronoiDiagramEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new VoronoiDiagramData ();

--- a/Pinta.Effects/Effects/ZoomBlurEffect.cs
+++ b/Pinta.Effects/Effects/ZoomBlurEffect.cs
@@ -30,16 +30,14 @@ public sealed class ZoomBlurEffect : BaseEffect
 
 	private readonly IChromeService chrome;
 
-	public ZoomBlurEffect (IServiceManager services)
+	public ZoomBlurEffect (IServiceProvider services)
 	{
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new ZoomBlurData ();
 	}
 
 	public override void LaunchConfiguration ()
-	{
-		chrome.LaunchSimpleEffectDialog (this);
-	}
+		=> chrome.LaunchSimpleEffectDialog (this);
 
 	#region Algorithm Code Ported From PDN
 

--- a/Pinta.Tools/CoreToolsExtension.cs
+++ b/Pinta.Tools/CoreToolsExtension.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Mono.Addins;
 using Pinta.Core;
 
@@ -41,34 +42,36 @@ public sealed class CoreToolsExtension : IExtension
 	#region IExtension Members
 	public void Initialize ()
 	{
+		IServiceProvider services = PintaCore.Services;
+
 		PintaCore.PaintBrushes.AddPaintBrush (new Brushes.CircleBrush ());
 		PintaCore.PaintBrushes.AddPaintBrush (new Brushes.GridBrush ());
 		PintaCore.PaintBrushes.AddPaintBrush (new Brushes.PlainBrush ());
 		PintaCore.PaintBrushes.AddPaintBrush (new Brushes.SplatterBrush ());
 		PintaCore.PaintBrushes.AddPaintBrush (new Brushes.SquaresBrush ());
 
-		PintaCore.Tools.AddTool (new MoveSelectedTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new MoveSelectionTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new ZoomTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new PanTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new RectangleSelectTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new EllipseSelectTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new LassoSelectTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new MagicWandTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new PaintBrushTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new PencilTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new EraserTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new PaintBucketTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new GradientTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new ColorPickerTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new TextTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new LineCurveTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new RectangleTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new RoundedRectangleTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new EllipseTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new FreeformShapeTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new CloneStampTool (PintaCore.Services));
-		PintaCore.Tools.AddTool (new RecolorTool (PintaCore.Services));
+		PintaCore.Tools.AddTool (new MoveSelectedTool (services));
+		PintaCore.Tools.AddTool (new MoveSelectionTool (services));
+		PintaCore.Tools.AddTool (new ZoomTool (services));
+		PintaCore.Tools.AddTool (new PanTool (services));
+		PintaCore.Tools.AddTool (new RectangleSelectTool (services));
+		PintaCore.Tools.AddTool (new EllipseSelectTool (services));
+		PintaCore.Tools.AddTool (new LassoSelectTool (services));
+		PintaCore.Tools.AddTool (new MagicWandTool (services));
+		PintaCore.Tools.AddTool (new PaintBrushTool (services));
+		PintaCore.Tools.AddTool (new PencilTool (services));
+		PintaCore.Tools.AddTool (new EraserTool (services));
+		PintaCore.Tools.AddTool (new PaintBucketTool (services));
+		PintaCore.Tools.AddTool (new GradientTool (services));
+		PintaCore.Tools.AddTool (new ColorPickerTool (services));
+		PintaCore.Tools.AddTool (new TextTool (services));
+		PintaCore.Tools.AddTool (new LineCurveTool (services));
+		PintaCore.Tools.AddTool (new RectangleTool (services));
+		PintaCore.Tools.AddTool (new RoundedRectangleTool (services));
+		PintaCore.Tools.AddTool (new EllipseTool (services));
+		PintaCore.Tools.AddTool (new FreeformShapeTool (services));
+		PintaCore.Tools.AddTool (new CloneStampTool (services));
+		PintaCore.Tools.AddTool (new RecolorTool (services));
 	}
 
 	public void Uninitialize ()

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Gtk;
 using Pinta.Core;
@@ -41,7 +42,7 @@ public abstract class BaseBrushTool : BaseTool
 
 	private string BRUSH_WIDTH_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-brush-width";
 
-	protected BaseBrushTool (IServiceManager services) : base (services)
+	protected BaseBrushTool (IServiceProvider services) : base (services)
 	{
 		Palette = services.GetService<IPaletteService> ();
 	}

--- a/Pinta.Tools/Tools/BaseTransformTool.cs
+++ b/Pinta.Tools/Tools/BaseTransformTool.cs
@@ -44,7 +44,7 @@ public abstract class BaseTransformTool : BaseTool
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Pinta.Tools.BaseTransformTool"/> class.
 	/// </summary>
-	public BaseTransformTool (IServiceManager services) : base (services)
+	public BaseTransformTool (IServiceProvider services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Gdk;
 using Pinta.Core;
 
@@ -36,7 +37,7 @@ public sealed class CloneStampTool : BaseBrushTool
 	private PointI? offset = null;
 	private PointI? last_point = null;
 
-	public CloneStampTool (IServiceManager services) : base (services)
+	public CloneStampTool (IServiceProvider services) : base (services)
 	{
 	}
 

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Immutable;
 using Cairo;
 using Gtk;
@@ -42,7 +43,7 @@ public sealed class ColorPickerTool : BaseTool
 	private const string SAMPLE_SIZE_SETTING = "color-picker-sample-size";
 	private const string SAMPLE_TYPE_SETTING = "color-picker-sample-type";
 
-	public ColorPickerTool (IServiceManager services) : base (services)
+	public ColorPickerTool (IServiceProvider services) : base (services)
 	{
 		palette = services.GetService<IPaletteService> ();
 		tools = services.GetService<IToolService> ();

--- a/Pinta.Tools/Tools/EllipseSelectTool.cs
+++ b/Pinta.Tools/Tools/EllipseSelectTool.cs
@@ -24,13 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public sealed class EllipseSelectTool : SelectTool
 {
-	public EllipseSelectTool (IServiceManager services) : base (services) { }
+	public EllipseSelectTool (IServiceProvider services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Ellipse Select");
 	public override string Icon => Pinta.Resources.Icons.ToolSelectEllipse;

--- a/Pinta.Tools/Tools/EllipseTool.cs
+++ b/Pinta.Tools/Tools/EllipseTool.cs
@@ -24,13 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public sealed class EllipseTool : ShapeTool
 {
-	public EllipseTool (IServiceManager services) : base (services)
+	public EllipseTool (IServiceProvider services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -47,7 +47,7 @@ public sealed class EraserTool : BaseBrushTool
 
 	private const string ERASER_TYPE_SETTING = "eraser-erase-type";
 
-	public EraserTool (IServiceManager services) : base (services) { }
+	public EraserTool (IServiceProvider services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Eraser");
 	public override string Icon => Pinta.Resources.Icons.ToolEraser;

--- a/Pinta.Tools/Tools/FloodTool.cs
+++ b/Pinta.Tools/Tools/FloodTool.cs
@@ -34,6 +34,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Gtk;
 using Pinta.Core;
@@ -48,9 +49,7 @@ public abstract class FloodTool : BaseTool
 	protected Label? tolerance_label;
 	protected Scale? tolerance_slider;
 
-	public FloodTool (IServiceManager services) : base (services)
-	{
-	}
+	public FloodTool (IServiceProvider services) : base (services) { }
 
 	protected bool IsContinguousMode => ModeDropDown.SelectedItem.GetTagOrDefault (true);
 	protected float Tolerance => (float) (ToleranceSlider.GetValue () / 100);

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Gtk;
 using Pinta.Core;
@@ -45,9 +46,7 @@ public sealed class FreeformShapeTool : BaseBrushTool
 	private const string FILL_TYPE_SETTING = "freeform-shape-fill-type";
 	private const string DASH_PATTERN_SETTING = "freeform-shape-dash_pattern";
 
-	public FreeformShapeTool (IServiceManager services) : base (services)
-	{
-	}
+	public FreeformShapeTool (IServiceProvider services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Freeform Shape");
 	public override string Icon => Pinta.Resources.Icons.ToolFreeformShape;

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -41,7 +41,7 @@ public sealed class GradientTool : BaseTool
 	private const string GRADIENT_TYPE_SETTING = "gradient-type";
 	private const string GRADIENT_COLOR_MODE_SETTING = "gradient-color-mode";
 
-	public GradientTool (IServiceManager services) : base (services)
+	public GradientTool (IServiceProvider services) : base (services)
 	{
 		palette = services.GetService<IPaletteService> ();
 	}

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -45,7 +45,7 @@ public class LassoSelectTool : BaseTool
 	private Path? path;
 	private readonly List<IntPoint> lasso_polygon = new ();
 
-	public LassoSelectTool (IServiceManager services) : base (services)
+	public LassoSelectTool (IServiceProvider services) : base (services)
 	{
 		workspace = services.GetService<IWorkspaceService> ();
 	}

--- a/Pinta.Tools/Tools/LineCurveTool.cs
+++ b/Pinta.Tools/Tools/LineCurveTool.cs
@@ -24,13 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public sealed class LineCurveTool : ShapeTool
 {
-	public LineCurveTool (IServiceManager services) : base (services)
+	public LineCurveTool (IServiceProvider services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/MagicWandTool.cs
+++ b/Pinta.Tools/Tools/MagicWandTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Gtk;
 using Pinta.Core;
@@ -36,10 +37,9 @@ public sealed class MagicWandTool : FloodTool
 
 	private CombineMode combine_mode;
 
-	public MagicWandTool (IServiceManager services) : base (services)
+	public MagicWandTool (IServiceProvider services) : base (services)
 	{
 		workspace = services.GetService<IWorkspaceService> ();
-
 		LimitToSelection = false;
 	}
 

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -35,9 +36,7 @@ public sealed class MoveSelectedTool : BaseTransformTool
 	private DocumentSelection? original_selection;
 	private readonly Matrix original_transform = CairoExtensions.CreateIdentityMatrix ();
 
-	public MoveSelectedTool (IServiceManager services) : base (services)
-	{
-	}
+	public MoveSelectedTool (IServiceProvider services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Move Selected Pixels");
 	public override string Icon => Pinta.Resources.Icons.ToolMove;
@@ -54,9 +53,7 @@ public sealed class MoveSelectedTool : BaseTransformTool
 	public override int Priority => 5;
 
 	protected override RectangleD GetSourceRectangle (Document document)
-	{
-		return document.Selection.SelectionPath.GetBounds ().ToDouble ();
-	}
+		=> document.Selection.SelectionPath.GetBounds ().ToDouble ();
 
 	protected override void OnStartTransform (Document document)
 	{

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -34,9 +35,7 @@ public sealed class MoveSelectionTool : BaseTransformTool
 	private SelectionHistoryItem? hist;
 	private DocumentSelection? original_selection;
 
-	public MoveSelectionTool (IServiceManager service) : base (service)
-	{
-	}
+	public MoveSelectionTool (IServiceProvider service) : base (service) { }
 
 	public override string Name => Translations.GetString ("Move Selection");
 	public override string Icon => Pinta.Resources.Icons.ToolMoveSelection;
@@ -53,9 +52,7 @@ public sealed class MoveSelectionTool : BaseTransformTool
 	public override int Priority => 7;
 
 	protected override RectangleD GetSourceRectangle (Document document)
-	{
-		return document.Selection.SelectionPath.GetBounds ().ToDouble ();
-	}
+		=> document.Selection.SelectionPath.GetBounds ().ToDouble ();
 
 	protected override void OnStartTransform (Document document)
 	{

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -42,7 +42,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 
 	private const string BRUSH_SETTING = "paint-brush-brush";
 
-	public PaintBrushTool (IServiceManager services) : base (services)
+	public PaintBrushTool (IServiceProvider services) : base (services)
 	{
 		brushes = services.GetService<IPaintBrushService> ();
 

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Threading.Tasks;
 using Cairo;
 using Pinta.Core;
@@ -35,7 +36,7 @@ public sealed class PaintBucketTool : FloodTool
 	private readonly IPaletteService palette;
 	private Color fill_color;
 
-	public PaintBucketTool (IServiceManager services) : base (services)
+	public PaintBucketTool (IServiceProvider services) : base (services)
 	{
 		palette = services.GetService<IPaletteService> ();
 	}

--- a/Pinta.Tools/Tools/PanTool.cs
+++ b/Pinta.Tools/Tools/PanTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
@@ -34,7 +35,7 @@ public sealed class PanTool : BaseTool
 	private PointD last_point;
 	private readonly Gdk.Cursor grabbing_cursor = GdkExtensions.CursorFromName (Pinta.Resources.StandardCursors.Grabbing);
 
-	public PanTool (IServiceManager services) : base (services) { }
+	public PanTool (IServiceProvider services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Pan");
 	public override string Icon => Pinta.Resources.Icons.ToolPan;

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -39,7 +40,7 @@ public sealed class PencilTool : BaseTool
 	private bool surface_modified;
 	private MouseButton mouse_button;
 
-	public PencilTool (IServiceManager services) : base (services)
+	public PencilTool (IServiceProvider services) : base (services)
 	{
 		palette = services.GetService<IPaletteService> ();
 	}

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -33,6 +33,7 @@
 // See license-pdn.txt for full licensing and attribution details.             //
 /////////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Cairo;
 using Gtk;
 using Pinta.Core;
@@ -48,7 +49,7 @@ public class RecolorTool : BaseBrushTool
 
 	private const string TOLERANCE_SETTING = "recolor-tolerance";
 
-	public RecolorTool (IServiceManager services) : base (services)
+	public RecolorTool (IServiceProvider services) : base (services)
 	{
 		workspace = services.GetService<IWorkspaceService> ();
 	}

--- a/Pinta.Tools/Tools/RectangleSelectTool.cs
+++ b/Pinta.Tools/Tools/RectangleSelectTool.cs
@@ -24,13 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public sealed class RectangleSelectTool : SelectTool
 {
-	public RectangleSelectTool (IServiceManager services) : base (services) { }
+	public RectangleSelectTool (IServiceProvider services) : base (services) { }
 
 	public override string Name => Translations.GetString ("Rectangle Select");
 	public override string Icon => Pinta.Resources.Icons.ToolSelectRectangle;

--- a/Pinta.Tools/Tools/RectangleTool.cs
+++ b/Pinta.Tools/Tools/RectangleTool.cs
@@ -24,13 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public sealed class RectangleTool : ShapeTool
 {
-	public RectangleTool (IServiceManager services) : base (services)
+	public RectangleTool (IServiceProvider services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}
@@ -40,7 +41,9 @@ public sealed class RectangleTool : ShapeTool
 	public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Rectangle.png"), 9, 18, null);
 	public override int Priority => 39;
 
-	public override BaseEditEngine.ShapeTypes ShapeType => BaseEditEngine.ShapeTypes.ClosedLineCurveSeries;
+	public override BaseEditEngine.ShapeTypes ShapeType
+		=> BaseEditEngine.ShapeTypes.ClosedLineCurveSeries;
 
-	protected override BaseEditEngine CreateEditEngine () => new RectangleEditEngine (this);
+	protected override BaseEditEngine CreateEditEngine ()
+		=> new RectangleEditEngine (this);
 }

--- a/Pinta.Tools/Tools/RoundedRectangleTool.cs
+++ b/Pinta.Tools/Tools/RoundedRectangleTool.cs
@@ -24,13 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public sealed class RoundedRectangleTool : ShapeTool
 {
-	public RoundedRectangleTool (IServiceManager services) : base (services)
+	public RoundedRectangleTool (IServiceProvider services) : base (services)
 	{
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -54,7 +54,7 @@ public abstract class SelectTool : BaseTool
 	protected override bool ShowAntialiasingButton => false;
 	public override IEnumerable<MoveHandle> Handles => handles;
 
-	public SelectTool (IServiceManager services) : base (services)
+	public SelectTool (IServiceProvider services) : base (services)
 	{
 		tools = services.GetService<IToolService> ();
 		workspace = services.GetService<IWorkspaceService> ();

--- a/Pinta.Tools/Tools/ShapeTool.cs
+++ b/Pinta.Tools/Tools/ShapeTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Pinta.Core;
 
@@ -33,7 +34,7 @@ public abstract class ShapeTool : BaseTool
 {
 	public BaseEditEngine EditEngine { get; }
 
-	public ShapeTool (IServiceManager services) : base (services)
+	public ShapeTool (IServiceProvider services) : base (services)
 	{
 		EditEngine = CreateEditEngine ();
 	}

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -9,7 +9,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Text;
 using System.Threading.Tasks;
 using Gdk;
 using Gtk;
@@ -93,7 +92,7 @@ public sealed class TextTool : BaseTool
 	public override Gdk.Cursor DefaultCursor => GdkExtensions.CursorFromName (Pinta.Resources.StandardCursors.Text);
 
 	#region Constructor
-	public TextTool (IServiceManager services) : base (services)
+	public TextTool (IServiceProvider services) : base (services)
 	{
 		im_context = Gtk.IMMulticontext.New ();
 		im_context.OnCommit += OnIMCommit;

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -42,7 +43,7 @@ public sealed class ZoomTool : BaseTool
 	private RectangleD last_dirty;
 	private static readonly int tolerance = 10;
 
-	public ZoomTool (IServiceManager services) : base (services)
+	public ZoomTool (IServiceProvider services) : base (services)
 	{
 		mouse_down = MouseButton.None;
 

--- a/tests/Pinta.Effects.Tests/Utilities.cs
+++ b/tests/Pinta.Effects.Tests/Utilities.cs
@@ -1,3 +1,4 @@
+using System;
 using Cairo;
 using NUnit.Framework;
 using Pinta.Core;
@@ -14,7 +15,7 @@ internal static class Utilities
 		Gdk.Module.Initialize ();
 	}
 
-	public static IServiceManager CreateMockServices ()
+	public static IServiceProvider CreateMockServices ()
 	{
 		ServiceManager manager = new ();
 		manager.AddService<IPaletteService> (new MockPalette ());

--- a/tests/PintaBenchmarks/Utilities/Utilities.cs
+++ b/tests/PintaBenchmarks/Utilities/Utilities.cs
@@ -4,7 +4,7 @@ namespace PintaBenchmarks;
 
 internal static class Utilities
 {
-	public static IServiceManager CreateMockServices ()
+	public static IServiceProvider CreateMockServices ()
 	{
 		ServiceManager manager = new ();
 		manager.AddService<IPaletteService> (new MockPalette ());


### PR DESCRIPTION
The `IServiceManager` interface includes methods for adding new services, which is something that effects and tools shouldn't usually be able to do.

I've now changed the interface a little. The part that fetches the services only has the methods for that, and the `IServiceManager` interface has that _plus_ the addition of services.