### PR TITLE
Removing `Random` from `BasePaintBrush`

### DIFF
--- a/Pinta.Core/Classes/BasePaintBrush.cs
+++ b/Pinta.Core/Classes/BasePaintBrush.cs
@@ -35,8 +35,6 @@ namespace Pinta.Core;
 [Mono.Addins.TypeExtensionPoint]
 public abstract class BasePaintBrush
 {
-	private static readonly Random random = new ();
-
 	/// <summary>
 	/// The name of the brush.
 	/// </summary>
@@ -47,12 +45,6 @@ public abstract class BasePaintBrush
 	/// alphabetical ordering is used.
 	/// </summary>
 	public virtual int Priority => 0;
-
-	/// <summary>
-	/// Random number generator. This can be used to implement brushes with
-	/// random effects.
-	/// </summary>
-	public Random Random => random;
 
 	/// <summary>
 	/// Used to multiply the alpha value of the stroke color by a

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -46,7 +46,7 @@ public abstract class BaseTool
 	private string ANTIALIAS_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-antialias";
 	private string ALPHABLEND_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-alpha-blend";
 
-	protected static PointI point_empty = new (-500, -500);
+	protected static readonly PointI point_empty = new (-500, -500);
 
 	protected BaseTool (IServiceProvider services)
 	{

--- a/Pinta.Tools/Brushes/CircleBrush.cs
+++ b/Pinta.Tools/Brushes/CircleBrush.cs
@@ -37,6 +37,8 @@ public sealed class CircleBrush : BasePaintBrush
 
 	public override double StrokeAlphaMultiplier => 0.05;
 
+	private readonly Random random = new ();
+
 	protected override RectangleI OnMouseMove (
 		Context g,
 		ImageSurface surface,
@@ -50,7 +52,7 @@ public sealed class CircleBrush : BasePaintBrush
 		);
 
 		double d = mouseDelta.Magnitude () * 2.0;
-		int steps = Random.Next (1, 10);
+		int steps = random.Next (1, 10);
 		double step_delta = d / steps;
 
 		for (int i = 0; i < steps; i++) {

--- a/Pinta.Tools/Brushes/GridBrush.cs
+++ b/Pinta.Tools/Brushes/GridBrush.cs
@@ -37,6 +37,8 @@ public sealed class GridBrush : BasePaintBrush
 
 	public override double StrokeAlphaMultiplier => 0.05;
 
+	private readonly Random random = new ();
+
 	protected override RectangleI OnMouseMove (
 		Context g,
 		ImageSurface surface,
@@ -55,8 +57,8 @@ public sealed class GridBrush : BasePaintBrush
 		for (int i = 0; i < 50; i++) {
 			g.MoveTo (c.X, c.Y);
 			g.QuadraticCurveTo (
-				strokeArgs.CurrentPosition.X + Random.NextDouble () * d.X,
-				strokeArgs.CurrentPosition.Y + Random.NextDouble () * d.Y,
+				strokeArgs.CurrentPosition.X + random.NextDouble () * d.X,
+				strokeArgs.CurrentPosition.Y + random.NextDouble () * d.Y,
 				c.X,
 				c.Y);
 			g.Stroke ();

--- a/Pinta.Tools/Brushes/SplatterBrush.cs
+++ b/Pinta.Tools/Brushes/SplatterBrush.cs
@@ -37,6 +37,8 @@ public sealed class SplatterBrush : BasePaintBrush
 
 	public override double StrokeAlphaMultiplier => 0.5;
 
+	private readonly Random random = new ();
+
 	protected override RectangleI OnMouseMove (
 		Context g,
 		ImageSurface surface,
@@ -45,13 +47,13 @@ public sealed class SplatterBrush : BasePaintBrush
 		int line_width = (int) g.LineWidth;
 
 		// we want a minimum size of 2 for the splatter (except for when the brush width is 1), since a splatter of size 1 is very small
-		int size = (line_width == 1) ? 1 : Random.Next (2, line_width);
+		int size = (line_width == 1) ? 1 : random.Next (2, line_width);
 
 		PointI current = strokeArgs.CurrentPosition;
 
 		RectangleD rect = new (
-			x: current.X - Random.Next (-15, 15),
-			y: current.Y - Random.Next (-15, 15),
+			x: current.X - random.Next (-15, 15),
+			y: current.Y - random.Next (-15, 15),
 			width: size,
 			height: size
 		);


### PR DESCRIPTION
Perhaps I'm missing something, but is there a reason why all brushes share the same instance of `Random`?

If we make `Random` instance-specific, it would even be possible to test these tools with a specific seed