### PR TITLE
Removed `BaseTool.point_empty`

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -43,10 +43,12 @@ public abstract class BaseTool
 	protected ISettingsService Settings { get; }
 
 	public const int DEFAULT_BRUSH_WIDTH = 2;
-	private string ANTIALIAS_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-antialias";
-	private string ALPHABLEND_SETTING => $"{GetType ().Name.ToLowerInvariant ()}-alpha-blend";
 
-	protected static readonly PointI point_empty = new (-500, -500);
+	private string ANTIALIAS_SETTING
+		=> $"{GetType ().Name.ToLowerInvariant ()}-antialias";
+
+	private string ALPHABLEND_SETTING
+		=> $"{GetType ().Name.ToLowerInvariant ()}-alpha-blend";
 
 	protected BaseTool (IServiceProvider services)
 	{
@@ -82,12 +84,14 @@ public abstract class BaseTool
 	/// <summary>
 	/// Localized help text shown to the user on how to use the tool.
 	/// </summary>
-	public virtual string StatusBarText => string.Empty;
+	public virtual string StatusBarText
+		=> string.Empty;
 
 	/// <summary>
 	/// The default cursor used by the tool. Return 'null' for the default pointer.
 	/// </summary>
-	public virtual Cursor? DefaultCursor => null;
+	public virtual Cursor? DefaultCursor
+		=> null;
 
 	/// <summary>
 	/// The current cursor for this tool. Return 'null' for the default pointer.
@@ -98,37 +102,44 @@ public abstract class BaseTool
 	/// Specifies whether this application needs to update this tool's
 	/// cursor after a zoom operation.
 	/// </summary>
-	public virtual bool CursorChangesOnZoom => false;
+	public virtual bool CursorChangesOnZoom
+		=> false;
 
 	/// <summary>
 	/// Whether or not the tool is an editable ShapeTool.
 	/// </summary>
-	public virtual bool IsEditableShapeTool => false;
+	public virtual bool IsEditableShapeTool
+		=> false;
 
 	/// <summary>
 	/// A list of handles that should be drawn on the canvas window.
 	/// </summary>
-	public virtual IEnumerable<IToolHandle> Handles => Enumerable.Empty<IToolHandle> ();
+	public virtual IEnumerable<IToolHandle> Handles
+		=> Enumerable.Empty<IToolHandle> ();
 
 	/// <summary>
 	/// The shortcut key used to activate this tool in the toolbox. Return 0 for no shortcut key.
 	/// </summary>
-	public virtual Gdk.Key ShortcutKey => 0;
+	public virtual Gdk.Key ShortcutKey
+		=> 0;
 
 	/// <summary>
 	/// Affects the order of the tool in the toolbox. Lower numbers will appear first.
 	/// </summary>
-	public virtual int Priority => 75;
+	public virtual int Priority
+		=> 75;
 
 	/// <summary>
 	/// Specifies if the Antialiasing toolbar button should be shown for this tool.
 	/// </summary>
-	protected virtual bool ShowAntialiasingButton => false;
+	protected virtual bool ShowAntialiasingButton
+		=> false;
 
 	/// <summary>
 	/// Specifies if the Alpha Blending toolbar button should be shown for this tool.
 	/// </summary>
-	protected virtual bool ShowAlphaBlendingButton => false;
+	protected virtual bool ShowAlphaBlendingButton
+		=> false;
 
 	/// <summary>
 	/// Specifies if the tool should use anti-aliasing.
@@ -344,7 +355,9 @@ public abstract class BaseTool
 		}
 	}
 
-	private ToolBoxButton CreateToolButton () => new (this);
+	private ToolBoxButton CreateToolButton ()
+		=> new (this);
+
 	#endregion
 
 	#region Event Invokers

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -39,7 +39,7 @@ public sealed class EraserTool : BaseBrushTool
 		Smooth = 1,
 	}
 
-	private PointI last_point = point_empty;
+	private PointI? last_point = null;
 	private EraserType eraser_type = EraserType.Normal;
 
 	private const int LUT_Resolution = 256;
@@ -85,19 +85,18 @@ public sealed class EraserTool : BaseBrushTool
 		var new_pointd = e.PointDouble;
 
 		if (mouse_button == MouseButton.None) {
-			last_point = point_empty;
+			last_point = null;
 			return;
 		}
 
-		if (last_point.Equals (point_empty))
+		if (!last_point.HasValue)
 			last_point = new_point;
 
 		if (document.Workspace.PointInCanvas (new_pointd))
 			surface_modified = true;
 
 		var g = document.CreateClippedContext ();
-		var last_pointd = new PointD (last_point.X, last_point.Y);
-
+		var last_pointd = (PointD) last_point.Value;
 		switch (eraser_type) {
 			case EraserType.Normal:
 				EraseNormal (g, last_pointd, new_pointd);
@@ -107,7 +106,7 @@ public sealed class EraserTool : BaseBrushTool
 				break;
 		}
 
-		var dirty = CairoExtensions.GetRectangleFromPoints (last_point, new_point, BrushWidth + 2);
+		var dirty = CairoExtensions.GetRectangleFromPoints (last_point.Value, new_point, BrushWidth + 2);
 
 		if (document.Workspace.IsPartiallyOffscreen (dirty))
 			document.Workspace.Invalidate ();

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -33,7 +33,7 @@ namespace Pinta.Tools;
 
 public sealed class FreeformShapeTool : BaseBrushTool
 {
-	private PointI last_point = point_empty;
+	private PointI? last_point = null;
 
 	private Path? path;
 	private Color fill_color;
@@ -70,7 +70,7 @@ public sealed class FreeformShapeTool : BaseBrushTool
 		if (dash_pattern_box != null) {
 			dash_pattern_box.GetEntry ().SetText (Settings.GetSetting (DASH_PATTERN_SETTING, "-"));
 
-			dash_pattern_box.OnChanged += (o, e) => {
+			dash_pattern_box.OnChanged += (_, _) => {
 				dash_pattern = dash_pattern_box.GetActiveText ()!;
 			};
 		}
@@ -95,14 +95,14 @@ public sealed class FreeformShapeTool : BaseBrushTool
 			outline_color = Palette.SecondaryColor;
 			fill_color = Palette.PrimaryColor;
 		} else {
-			last_point = point_empty;
+			last_point = null;
 			return;
 		}
 
 		var x = e.Point.X;
 		var y = e.Point.Y;
 
-		if (last_point.Equals (point_empty)) {
+		if (!last_point.HasValue) {
 			last_point = e.Point;
 			return;
 		}

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -38,7 +38,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 
 	private BasePaintBrush? default_brush;
 	private BasePaintBrush? active_brush;
-	private PointI last_point;
+	private PointI? last_point = PointI.Zero;
 
 	private const string BRUSH_SETTING = "paint-brush-brush";
 
@@ -93,7 +93,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 			return;
 
 		if (mouse_button is not (MouseButton.Left or MouseButton.Right)) {
-			last_point = point_empty;
+			last_point = null;
 			return;
 		}
 
@@ -113,7 +113,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 			)
 		};
 
-		if (last_point.Equals (point_empty))
+		if (!last_point.HasValue)
 			last_point = e.Point;
 
 		if (document.Workspace.PointInCanvas (e.PointDouble))
@@ -129,7 +129,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 		g.LineCap = BrushWidth == 1 ? LineCap.Butt : LineCap.Round;
 		g.SetSourceColor (strokeColor);
 
-		BrushStrokeArgs strokeArgs = new (strokeColor, e.Point, last_point);
+		BrushStrokeArgs strokeArgs = new (strokeColor, e.Point, last_point.Value);
 
 		var invalidate_rect = active_brush.DoMouseMove (g, surf, strokeArgs);
 

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -34,7 +34,7 @@ public sealed class PencilTool : BaseTool
 {
 	private readonly IPaletteService palette;
 
-	private PointI last_point = point_empty;
+	private PointI? last_point = null;
 
 	private ImageSurface? undo_surface;
 	private bool surface_modified;
@@ -75,7 +75,7 @@ public sealed class PencilTool : BaseTool
 				tool_color = palette.SecondaryColor;
 				break;
 			default:
-				last_point = point_empty;
+				last_point = null;
 				return;
 		}
 
@@ -94,7 +94,7 @@ public sealed class PencilTool : BaseTool
 				tool_color = palette.SecondaryColor;
 				break;
 			default:
-				last_point = point_empty;
+				last_point = null;
 				return;
 		}
 
@@ -116,7 +116,7 @@ public sealed class PencilTool : BaseTool
 		var x = e.Point.X;
 		var y = e.Point.Y;
 
-		if (last_point.Equals (point_empty)) {
+		if (!last_point.HasValue) {
 			last_point = e.Point;
 
 			if (!first_pixel)
@@ -147,12 +147,13 @@ public sealed class PencilTool : BaseTool
 		} else {
 			// Adding 0.5 forces cairo into the correct square:
 			// See https://bugs.launchpad.net/bugs/672232
-			g.MoveTo (last_point.X + 0.5, last_point.Y + 0.5);
+			PointI lastPoint = last_point.Value;
+			g.MoveTo (lastPoint.X + 0.5, lastPoint.Y + 0.5);
 			g.LineTo (x + 0.5, y + 0.5);
 			g.Stroke ();
 		}
 
-		var dirty = CairoExtensions.GetRectangleFromPoints (last_point, new PointI (x, y), 4);
+		var dirty = CairoExtensions.GetRectangleFromPoints (last_point.Value, new PointI (x, y), 4);
 
 		document.Workspace.Invalidate (document.ClampToImageSize (dirty));
 

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -44,7 +44,7 @@ public class RecolorTool : BaseBrushTool
 {
 	private readonly IWorkspaceService workspace;
 
-	private PointI last_point = point_empty;
+	private PointI? last_point = null;
 	private BitMask? stencil;
 
 	private const string TOLERANCE_SETTING = "recolor-tolerance";
@@ -98,14 +98,14 @@ public class RecolorTool : BaseBrushTool
 			old_color = Palette.SecondaryColor.ToColorBgra ();
 			new_color = Palette.PrimaryColor.ToColorBgra ();
 		} else {
-			last_point = point_empty;
+			last_point = null;
 			return;
 		}
 
 		var x = e.Point.X;
 		var y = e.Point.Y;
 
-		if (last_point.Equals (point_empty))
+		if (!last_point.HasValue)
 			last_point = new PointI (x, y);
 
 		if (document.Workspace.PointInCanvas (e.PointDouble))
@@ -114,7 +114,7 @@ public class RecolorTool : BaseBrushTool
 		var surf = document.Layers.CurrentUserLayer.Surface;
 		var tmp_layer = document.Layers.ToolLayer.Surface;
 
-		var roi = CairoExtensions.GetRectangleFromPoints (last_point, new PointI (x, y), BrushWidth + 2);
+		var roi = CairoExtensions.GetRectangleFromPoints (last_point.Value, new PointI (x, y), BrushWidth + 2);
 
 		roi = workspace.ClampToImageSize (roi);
 		var myTolerance = (int) (Tolerance * 256);
@@ -146,7 +146,7 @@ public class RecolorTool : BaseBrushTool
 		var g = document.CreateClippedContext ();
 		g.Antialias = UseAntialiasing ? Antialias.Subpixel : Antialias.None;
 
-		g.MoveTo (last_point.X, last_point.Y);
+		g.MoveTo (last_point.Value.X, last_point.Value.Y);
 		g.LineTo (x, y);
 
 		g.LineWidth = BrushWidth;


### PR DESCRIPTION
The child tools that used this value were made to have a nullable `PointI` instead