### PR TITLE
Changed data type of zoom for Mandelbrot and Julia fractals, from `int` to `double`

### DIFF
--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -175,7 +175,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 		public int Quality { get; set; } = 2;
 
 		[Caption ("Zoom"), MinimumValue (0), MaximumValue (50)]
-		public int Zoom { get; set; } = 1;
+		public double Zoom { get; set; } = 1;
 
 		[Caption ("Color Scheme Source")]
 		public ColorSchemeSource ColorSchemeSource { get; set; } = ColorSchemeSource.PresetGradient;

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -16,20 +16,25 @@ namespace Pinta.Effects;
 
 public sealed class JuliaFractalEffect : BaseEffect
 {
-	public override string Icon => Pinta.Resources.Icons.EffectsRenderJuliaFractal;
+	public override string Icon
+		=> Pinta.Resources.Icons.EffectsRenderJuliaFractal;
 
-	public sealed override bool IsTileable => true;
+	public sealed override bool IsTileable
+		=> true;
 
-	public override string Name => Translations.GetString ("Julia Fractal");
+	public override string Name
+		=> Translations.GetString ("Julia Fractal");
 
-	public override bool IsConfigurable => true;
+	public override bool IsConfigurable
+		=> true;
 
-	public override string EffectMenuCategory => Translations.GetString ("Render");
+	public override string EffectMenuCategory
+		=> Translations.GetString ("Render");
 
-	public JuliaFractalData Data => (JuliaFractalData) EffectData!;  // NRT - Set in constructor
+	public JuliaFractalData Data
+		=> (JuliaFractalData) EffectData!;  // NRT - Set in constructor
 
 	private readonly IPaletteService palette;
-
 	private readonly IChromeService chrome;
 
 	public JuliaFractalEffect (IServiceProvider services)
@@ -114,6 +119,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 	const double Jr = 0.3125;
 	const double Ji = 0.03;
+
 	private static ColorBgra GetPixelColor (JuliaSettings settings, PointI target)
 	{
 		int r = 0;
@@ -126,12 +132,11 @@ public sealed class JuliaFractalEffect : BaseEffect
 			double v = (2.0 * target.Y - settings.canvasSize.Height + ((i * settings.invQuality) % 1)) * settings.invH;
 
 			double radius = Math.Sqrt ((u * u) + (v * v));
-			double radiusP = radius;
 			double theta = Math.Atan2 (v, u);
 			double thetaP = theta + settings.angleTheta;
 
-			double uP = radiusP * Math.Cos (thetaP);
-			double vP = radiusP * Math.Sin (thetaP);
+			double uP = radius * Math.Cos (thetaP);
+			double vP = radius * Math.Sin (thetaP);
 
 			PointD jLoc = new (
 				X: (uP - vP * settings.aspect) * settings.invZoom,

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -16,20 +16,25 @@ namespace Pinta.Effects;
 
 public sealed class MandelbrotFractalEffect : BaseEffect
 {
-	public override string Icon => Pinta.Resources.Icons.EffectsRenderMandelbrotFractal;
+	public override string Icon
+		=> Pinta.Resources.Icons.EffectsRenderMandelbrotFractal;
 
-	public sealed override bool IsTileable => true;
+	public sealed override bool IsTileable
+		=> true;
 
-	public override string Name => Translations.GetString ("Mandelbrot Fractal");
+	public override string Name
+		=> Translations.GetString ("Mandelbrot Fractal");
 
-	public override bool IsConfigurable => true;
+	public override bool IsConfigurable
+		=> true;
 
-	public override string EffectMenuCategory => Translations.GetString ("Render");
+	public override string EffectMenuCategory
+		=> Translations.GetString ("Render");
 
-	public MandelbrotFractalData Data => (MandelbrotFractalData) EffectData!;  // NRT - Set in constructor
+	public MandelbrotFractalData Data
+		=> (MandelbrotFractalData) EffectData!;  // NRT - Set in constructor
 
 	private readonly IPaletteService palette;
-
 	private readonly IChromeService chrome;
 
 	public MandelbrotFractalEffect (IServiceProvider services)
@@ -138,18 +143,18 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int g = 0;
 		int b = 0;
 		int a = 0;
+
 		for (double i = 0; i < settings.count; i++) {
 
 			double u = (2.0 * target.X - settings.canvasSize.Width + (i * settings.invCount)) * settings.invH;
 			double v = (2.0 * target.Y - settings.canvasSize.Height + (i * settings.invQuality % 1)) * settings.invH;
 
 			double radius = Utility.Magnitude (u, v);
-			double radiusP = radius;
 			double theta = Math.Atan2 (v, u);
 			double thetaP = theta + settings.angleTheta.Radians;
 
-			double uP = radiusP * Math.Cos (thetaP);
-			double vP = radiusP * Math.Sin (thetaP);
+			double uP = radius * Math.Cos (thetaP);
+			double vP = radius * Math.Sin (thetaP);
 
 			double m = Mandelbrot (
 				r: (uP * settings.invZoom) + offset_basis.X,
@@ -185,9 +190,8 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		[Caption ("Quality"), MinimumValue (1), MaximumValue (5)]
 		public int Quality { get; set; } = 2;
 
-		//TODO double
 		[Caption ("Zoom"), MinimumValue (0), MaximumValue (100)]
-		public int Zoom { get; set; } = 10;
+		public double Zoom { get; set; } = 10;
 
 		[Caption ("Angle")]
 		public DegreesAngle Angle { get; set; } = new (0);


### PR DESCRIPTION
We can see that there was a  very old (dating back to 2010) comment that read `//TODO: double` in the Mandelbrot's `EffectData`.

Also, there was a time when `SimpleEffectDialog` had no support for `double`.

Presumably, the comment (and the `int`-typed zoom) comes from that time?