### PR TITLE
Fix 'uninstall' target not removing icons on linux

### DIFF
--- a/installer/linux/install.proj
+++ b/installer/linux/install.proj
@@ -53,7 +53,7 @@
     <Delete Files="$(InstallDataRootDir)/metainfo/pinta.appdata.xml" />
     <Delete Files="$(InstallDataRootDir)/applications/pinta.desktop" />
     <Delete Files="$(InstallDataRootDir)/pixmaps/pinta.xpm" />
-    <Delete Files="$(InstallDataRootDir)/icons/%(Icon.RecursiveDir)/%(Icon.Filename).%(Icon.Extension)" />
+    <Delete Files="$(InstallDataRootDir)/icons/%(Icon.RecursiveDir)/%(Icon.Filename)%(Icon.Extension)" />
     <Delete Files="$(InstallLocaleDir)/%(Translation.RecursiveDir)/pinta.mo" />
   </Target>
 </Project>


### PR DESCRIPTION
As described in documentation %(Extension) already contains a dot.

https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-well-known-item-metadata