### PR TITLE
`StaticListAttribute` is being read closer to where it's needed in `SimpleEffectDialog`

### DIFF
--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -126,8 +126,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 		MemberReflector reflector,
 		string caption,
 		string? hint,
-		bool skip,
-		bool isComboBox);
+		bool skip);
 
 	private static MemberSettings CreateSettings (MemberInfo memberInfo)
 	{
@@ -143,8 +142,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 			reflector: reflector,
 			caption: caption ?? MakeCaption (memberInfo.Name),
 			hint: reflector.Attributes.OfType<HintAttribute> ().Select (h => h.Hint).FirstOrDefault (),
-			skip: reflector.Attributes.OfType<SkipAttribute> ().Any (),
-			isComboBox: reflector.Attributes.OfType<StaticListAttribute> ().Any ()
+			skip: reflector.Attributes.OfType<SkipAttribute> ().Any ()
 		);
 	}
 
@@ -200,7 +198,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 			return CreateAnglePicker;
 		else if (memberType == typeof (double))
 			return CreateDoubleSlider;
-		else if (settings.isComboBox && memberType == typeof (string))
+		else if (memberType == typeof (string) && settings.reflector.Attributes.OfType<StaticListAttribute> ().Any ())
 			return CreateComboBox;
 		else if (memberType == typeof (bool))
 			return CreateCheckBox;


### PR DESCRIPTION
`MemberSettings` used to have an `isComboBox` property, but it doesn't apply to every type of property, only to `string`-typed properties (for which. there is no suitable control if `StaticListAttribute` is not present, by the way`).

It could be hard to get the structure right, but hopefully these refactorings are helping.