### PR TITLE
Update to gir.core 0.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0-preview.4" />
-    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0-preview.4" />
-    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0-preview.4" />
+    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0" />
+    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0" />
+    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0" />
     <!-- Note: at least 1.4.2-alpha3 is required for fixes to uninstalling addins, from https://github.com/mono/mono-addins/pull/198 -->
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1431,18 +1431,16 @@ namespace Pinta.Core
 			gradient.AddColorStopRgba (offset, color.R, color.G, color.B, color.A);
 		}
 
-		// TODO-GTK4 (bindings) - requires improvements to struct generation (https://github.com/gircore/gir.core/issues/622)
 		public static Matrix CreateIdentityMatrix ()
 		{
-			var matrix = new Matrix (Cairo.Internal.MatrixManagedHandle.Create ());
+			var matrix = new Matrix ();
 			matrix.InitIdentity ();
 			return matrix;
 		}
 
-		// TODO-GTK4 (bindings) - requires improvements to struct generation (https://github.com/gircore/gir.core/issues/622)
 		public static Matrix CreateMatrix (double xx, double xy, double yx, double yy, double x0, double y0)
 		{
-			var matrix = new Matrix (Cairo.Internal.MatrixManagedHandle.Create ());
+			var matrix = new Matrix ();
 			matrix.Init (xx, xy, yx, yy, x0, y0);
 			return matrix;
 		}

--- a/Pinta.Core/Extensions/GdkPixbufExtensions.cs
+++ b/Pinta.Core/Extensions/GdkPixbufExtensions.cs
@@ -60,12 +60,11 @@ public static partial class GdkPixbufExtensions
 	// TODO-GTK4 (bindings) - record methods are not generated (https://github.com/gircore/gir.core/issues/743)
 	public static PixbufFormat[] GetFormats ()
 	{
-		// FIXME - using an unowned handle here because SListOwnedHandle is not correctly implemented in gir.core
-		var slist_handle = GetFormatsNative ();
-		uint n = GLib.Internal.SList.Length (slist_handle);
+		var slist = new GLib.SList (GetFormatsNative ());
+		uint n = GLib.SList.Length (slist);
 		var result = new PixbufFormat[n];
 		for (uint i = 0; i < n; ++i) {
-			var format = new GdkPixbuf.Internal.PixbufFormatUnownedHandle (GLib.Internal.SList.NthData (slist_handle, i));
+			var format = new GdkPixbuf.Internal.PixbufFormatUnownedHandle (GLib.SList.NthData (slist, i));
 			result[i] = new PixbufFormat (GdkPixbuf.Internal.PixbufFormat.Copy (format));
 		}
 
@@ -73,7 +72,7 @@ public static partial class GdkPixbufExtensions
 	}
 
 	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_get_formats")]
-	private static extern GLib.Internal.SListUnownedHandle GetFormatsNative ();
+	private static extern GLib.Internal.SListOwnedHandle GetFormatsNative ();
 
 	[DllImport (PixbufLibraryName, EntryPoint = "gdk_pixbuf_save_to_bufferv")]
 	private static extern bool SaveToBufferv (IntPtr pixbuf, out IntPtr buffer, out uint buffer_size, [MarshalAs (UnmanagedType.LPUTF8Str)] string type, IntPtr option_keys, IntPtr option_values, out GLib.Internal.ErrorOwnedHandle error);


### PR DESCRIPTION
- This contains a fix for the random crashes encountered on Windows

- The Cairo.Matrix class now has a more convenient constructor

- Gdk.FileList.GetFiles() is not being generated and requires a manual binding for now, but GLib.SList methods are now generated

Fixes: #674