### PR TITLE
Add support for rotation by fractional degrees

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
@@ -44,8 +44,8 @@ public sealed class AnglePickerWidget : Box
 		hbox2.Append (anglepickergraphic1);
 
 		spin = SpinButton.NewWithRange (0, 360, 1);
+		spin.Configure (spin.GetAdjustment (), 1, 2);
 		spin.CanFocus = true;
-		spin.ClimbRate = 1;
 		spin.Numeric = true;
 		spin.Adjustment!.PageIncrement = 10;
 		spin.Valign = Align.Start;


### PR DESCRIPTION
It seems that under the hood, everything is using `double` to represent angles, so the limitation of rotation to integers is entirely a UI issue. This PR updates the UI to use a standard Gtk SpinButton feature to permit two decimal places in the angle input when rotating a layer. This doesn't affect the step size for the + / - buttons. Tested, seems to be working. :-)