### PR TITLE
Refactoring of all action handlers

### DIFF
--- a/Pinta/Actions/Addins/AddinManagerAction.cs
+++ b/Pinta/Actions/Addins/AddinManagerAction.cs
@@ -32,22 +32,20 @@ namespace Pinta.Actions;
 
 internal sealed class AddinManagerAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Addins.AddinManager.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Addins.AddinManager.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
-		var service = new AddinSetupService (Mono.Addins.AddinManager.Registry);
-		var dialog = new AddinManagerDialog (PintaCore.Chrome.MainWindow, service);
+		AddinSetupService service = new (Mono.Addins.AddinManager.Registry);
+		AddinManagerDialog dialog = new (PintaCore.Chrome.MainWindow, service);
 		dialog.Show ();
 	}
 }

--- a/Pinta/Actions/Edit/OffsetSelectionAction.cs
+++ b/Pinta/Actions/Edit/OffsetSelectionAction.cs
@@ -30,24 +30,24 @@ using Pinta.Core;
 namespace Pinta.Actions;
 internal sealed class OffsetSelectionAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Edit.OffsetSelection.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Edit.OffsetSelection.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
 		var dialog = new OffsetSelectionDialog ();
 
 		dialog.OnResponse += (_, args) => {
+
 			if (args.ResponseId == (int) Gtk.ResponseType.Ok) {
+
 				PintaCore.Tools.Commit ();
 
 				Document document = PintaCore.Workspace.ActiveDocument;

--- a/Pinta/Actions/Edit/PasteAction.cs
+++ b/Pinta/Actions/Edit/PasteAction.cs
@@ -27,16 +27,21 @@
 
 using System;
 using System.Threading.Tasks;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Actions;
 
 internal sealed class PasteAction : IActionHandler
 {
-	public void Initialize () => PintaCore.Actions.Edit.Paste.Activated += Activated;
+	void IActionHandler.Initialize ()
+	{
+		PintaCore.Actions.Edit.Paste.Activated += Activated;
+	}
 
-	public void Uninitialize () => PintaCore.Actions.Edit.Paste.Activated -= Activated;
+	void IActionHandler.Uninitialize ()
+	{
+		PintaCore.Actions.Edit.Paste.Activated -= Activated;
+	}
 
 	private void Activated (object sender, EventArgs e)
 	{
@@ -50,14 +55,13 @@ internal sealed class PasteAction : IActionHandler
 		var doc = PintaCore.Workspace.ActiveDocument;
 
 		// Get the scroll position in canvas coordinates
-		var view = (Viewport) doc.Workspace.Canvas.Parent!;
+		var view = (Gtk.Viewport) doc.Workspace.Canvas.Parent!;
 
 		PointD viewPoint = new (
 			X: view.Hadjustment!.Value,
-			Y: view.Vadjustment!.Value
-		);
+			Y: view.Vadjustment!.Value);
 
-		var canvasPos = doc.Workspace.ViewPointToCanvas (viewPoint);
+		PointD canvasPos = doc.Workspace.ViewPointToCanvas (viewPoint);
 
 		// Paste into the active document.
 		// The 'false' argument indicates that paste should be
@@ -114,7 +118,7 @@ internal sealed class PasteAction : IActionHandler
 
 			var response = await ShowExpandCanvasDialog ();
 
-			if (response == ResponseType.Accept) {
+			if (response == Gtk.ResponseType.Accept) {
 
 				Size newSize = new (
 					Width: Math.Max (canvas_size.Width, cb_image.Width),
@@ -124,7 +128,7 @@ internal sealed class PasteAction : IActionHandler
 				PintaCore.Workspace.ResizeCanvas (newSize, Pinta.Core.Anchor.Center, paste_action);
 				PintaCore.Actions.View.UpdateCanvasScale ();
 
-			} else if (response != ResponseType.Reject) // cancelled
+			} else if (response != Gtk.ResponseType.Reject) // cancelled
 				return;
 		}
 
@@ -175,7 +179,7 @@ internal sealed class PasteAction : IActionHandler
 		PintaCore.Chrome.ShowMessageDialog (PintaCore.Chrome.MainWindow, primary, secondary);
 	}
 
-	public static async Task<ResponseType> ShowExpandCanvasDialog ()
+	public static async Task<Gtk.ResponseType> ShowExpandCanvasDialog ()
 	{
 		var primary = Translations.GetString ("Image larger than canvas");
 		var secondary = Translations.GetString ("The image being pasted is larger than the canvas. What would you like to do to the canvas size?");
@@ -184,6 +188,7 @@ internal sealed class PasteAction : IActionHandler
 		const string cancel_response = "cancel";
 		const string reject_response = "reject";
 		const string expand_response = "expand";
+
 		dialog.AddResponse (cancel_response, Translations.GetString ("_Cancel"));
 		// Translators: This refers to preserving the current canvas size when pasting a larger image.
 		dialog.AddResponse (reject_response, Translations.GetString ("Preserve"));
@@ -195,10 +200,11 @@ internal sealed class PasteAction : IActionHandler
 		dialog.DefaultResponse = expand_response;
 
 		string response = await dialog.RunAsync ();
+
 		return response switch {
-			expand_response => ResponseType.Accept,
-			reject_response => ResponseType.Reject,
-			_ => ResponseType.Cancel
+			expand_response => Gtk.ResponseType.Accept,
+			reject_response => Gtk.ResponseType.Reject,
+			_ => Gtk.ResponseType.Cancel,
 		};
 	}
 }

--- a/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
@@ -31,9 +31,15 @@ namespace Pinta.Actions;
 
 internal sealed class PasteIntoNewImageAction : IActionHandler
 {
-	public void Initialize () => PintaCore.Actions.Edit.PasteIntoNewImage.Activated += Activated;
+	void IActionHandler.Initialize ()
+	{
+		PintaCore.Actions.Edit.PasteIntoNewImage.Activated += Activated;
+	}
 
-	public void Uninitialize () => PintaCore.Actions.Edit.PasteIntoNewImage.Activated -= Activated;
+	void IActionHandler.Uninitialize ()
+	{
+		PintaCore.Actions.Edit.PasteIntoNewImage.Activated -= Activated;
+	}
 
 	private async void Activated (object sender, EventArgs e)
 	{

--- a/Pinta/Actions/Edit/PasteIntoNewLayerAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewLayerAction.cs
@@ -25,16 +25,21 @@
 // THE SOFTWARE.
 
 using System;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Actions;
 
 internal sealed class PasteIntoNewLayerAction : IActionHandler
 {
-	public void Initialize () => PintaCore.Actions.Edit.PasteIntoNewLayer.Activated += Activated;
+	void IActionHandler.Initialize ()
+	{
+		PintaCore.Actions.Edit.PasteIntoNewLayer.Activated += Activated;
+	}
 
-	public void Uninitialize () => PintaCore.Actions.Edit.PasteIntoNewLayer.Activated -= Activated;
+	void IActionHandler.Uninitialize ()
+	{
+		PintaCore.Actions.Edit.PasteIntoNewLayer.Activated -= Activated;
+	}
 
 	private void Activated (object sender, EventArgs e)
 	{
@@ -48,14 +53,14 @@ internal sealed class PasteIntoNewLayerAction : IActionHandler
 		var doc = PintaCore.Workspace.ActiveDocument;
 
 		// Get the scroll position in canvas coordinates
-		var view = (Viewport) doc.Workspace.Canvas.Parent!;
+		var view = (Gtk.Viewport) doc.Workspace.Canvas.Parent!;
 
 		PointD viewPoint = new (
 			X: view.Hadjustment!.Value,
 			Y: view.Vadjustment!.Value
 		);
 
-		var canvasPos = doc.Workspace.ViewPointToCanvas (viewPoint);
+		PointD canvasPos = doc.Workspace.ViewPointToCanvas (viewPoint);
 
 		// Paste into the active document.
 		// The 'true' argument indicates that paste should be

--- a/Pinta/Actions/Edit/ResizePaletteAction.cs
+++ b/Pinta/Actions/Edit/ResizePaletteAction.cs
@@ -25,33 +25,35 @@
 // THE SOFTWARE.
 
 using System;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Actions;
 
 internal sealed class ResizePaletteAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Edit.ResizePalette.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Edit.ResizePalette.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
-		var dialog = new SpinButtonEntryDialog (Translations.GetString ("Resize Palette"),
-				PintaCore.Chrome.MainWindow, Translations.GetString ("New palette size:"), 1, 96,
-				PintaCore.Palette.CurrentPalette.Count);
+		SpinButtonEntryDialog dialog = new (
+			Translations.GetString ("Resize Palette"),
+			PintaCore.Chrome.MainWindow,
+			Translations.GetString ("New palette size:"),
+			1,
+			96,
+			PintaCore.Palette.CurrentPalette.Count);
 
 		dialog.OnResponse += (_, args) => {
-			if (args.ResponseId == (int) ResponseType.Ok)
+
+			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
 				PintaCore.Palette.CurrentPalette.Resize (dialog.GetValue ());
 
 			dialog.Destroy ();

--- a/Pinta/Actions/File/CloseDocumentAction.cs
+++ b/Pinta/Actions/File/CloseDocumentAction.cs
@@ -29,19 +29,17 @@ using Pinta.Core;
 
 namespace Pinta.Actions;
 
-class CloseDocumentAction : IActionHandler
+internal sealed class CloseDocumentAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.File.Close.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.File.Close.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
@@ -54,15 +52,18 @@ class CloseDocumentAction : IActionHandler
 			return;
 		}
 
-		var heading = Translations.GetString ("Save changes to image \"{0}\" before closing?",
+		string heading = Translations.GetString (
+			"Save changes to image \"{0}\" before closing?",
 			PintaCore.Workspace.ActiveDocument.DisplayName);
-		var body = Translations.GetString ("If you don't save, all changes will be permanently lost.");
 
-		var dialog = Adw.MessageDialog.New (PintaCore.Chrome.MainWindow, heading, body);
+		string body = Translations.GetString ("If you don't save, all changes will be permanently lost.");
+
+		Adw.MessageDialog dialog = Adw.MessageDialog.New (PintaCore.Chrome.MainWindow, heading, body);
 
 		const string cancel_response = "cancel";
 		const string discard_response = "discard";
 		const string save_response = "save";
+
 		dialog.AddResponse (cancel_response, Translations.GetString ("_Cancel"));
 		dialog.AddResponse (discard_response, Translations.GetString ("_Discard"));
 		dialog.AddResponse (save_response, Translations.GetString ("_Save"));

--- a/Pinta/Actions/File/ExitAction.cs
+++ b/Pinta/Actions/File/ExitAction.cs
@@ -31,17 +31,15 @@ namespace Pinta.Actions;
 
 internal sealed class ExitProgramAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.App.Exit.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.App.Exit.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{

--- a/Pinta/Actions/File/ModifyCompressionAction.cs
+++ b/Pinta/Actions/File/ModifyCompressionAction.cs
@@ -30,23 +30,22 @@ namespace Pinta.Actions;
 
 internal sealed class ModifyCompressionAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.File.ModifyCompression += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.File.ModifyCompression -= Activated;
 	}
-	#endregion
 
 	private void Activated (object? sender, ModifyCompressionEventArgs e)
 	{
-		var dlg = new JpegCompressionDialog (e.Quality, e.ParentWindow);
+		JpegCompressionDialog dlg = new (e.Quality, e.ParentWindow);
+
 		if (dlg.RunBlocking () == Gtk.ResponseType.Ok)
-			e.Quality = dlg.GetCompressionLevel ();
+			e.Quality = dlg.CompressionLevel;
 		else
 			e.Cancel = true;
 

--- a/Pinta/Actions/File/NewDocumentAction.cs
+++ b/Pinta/Actions/File/NewDocumentAction.cs
@@ -31,17 +31,15 @@ namespace Pinta.Actions;
 
 internal sealed class NewDocumentAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.File.New.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.File.New.Activated -= Activated;
 	}
-	#endregion
 
 	private async void Activated (object sender, EventArgs e)
 	{
@@ -68,10 +66,12 @@ internal sealed class NewDocumentAction : IActionHandler
 			using_clipboard = true;
 		}
 
-		var dialog = new NewImageDialog (imgWidth, imgHeight, bg_type, using_clipboard);
+		NewImageDialog dialog = new (imgWidth, imgHeight, bg_type, using_clipboard);
 
 		dialog.OnResponse += (_, e) => {
+
 			int response = e.ResponseId;
+
 			if (response == (int) Gtk.ResponseType.Ok) {
 				PintaCore.Workspace.NewDocument (new Size (dialog.NewImageWidth, dialog.NewImageHeight), dialog.NewImageBackground);
 

--- a/Pinta/Actions/File/SaveDocumentAction.cs
+++ b/Pinta/Actions/File/SaveDocumentAction.cs
@@ -31,17 +31,15 @@ namespace Pinta.Actions;
 
 internal sealed class SaveDocumentAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.File.Save.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.File.Save.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{

--- a/Pinta/Actions/File/SaveDocumentAsAction.cs
+++ b/Pinta/Actions/File/SaveDocumentAsAction.cs
@@ -31,17 +31,15 @@ namespace Pinta.Actions;
 
 internal sealed class SaveDocumentAsAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.File.SaveAs.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.File.SaveAs.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -27,24 +27,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Actions;
 
 internal sealed class SaveDocumentImplmentationAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.File.SaveDocument += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.File.SaveDocument -= Activated;
 	}
-	#endregion
 
 	private void Activated (object? sender, DocumentCancelEventArgs e)
 	{
@@ -66,10 +63,10 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 	// been saved before.  Either way, we need to prompt for a filename.
 	private static bool SaveFileAs (Document document)
 	{
-		var fcd = FileChooserNative.New (
+		var fcd = Gtk.FileChooserNative.New (
 			Translations.GetString ("Save Image File"),
 			PintaCore.Chrome.MainWindow,
-			FileChooserAction.Save,
+			Gtk.FileChooserAction.Save,
 			Translations.GetString ("Save"),
 			Translations.GetString ("Cancel"));
 
@@ -85,7 +82,7 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 		}
 
 		// Add all the formats we support to the save dialog
-		var filetypes = new Dictionary<FileFilter, FormatDescriptor> ();
+		var filetypes = new Dictionary<Gtk.FileFilter, FormatDescriptor> ();
 		foreach (var format in PintaCore.ImageFormats.Formats) {
 
 			if (format.IsReadOnly ())
@@ -111,7 +108,7 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 
 		fcd.Filter = format_desc.Filter;
 
-		while (fcd.RunBlocking () == ResponseType.Accept) {
+		while (fcd.RunBlocking () == Gtk.ResponseType.Accept) {
 			var file = fcd.GetFile ()!;
 
 			// Note that we can't use file.GetDisplayName() because the file doesn't exist.
@@ -152,7 +149,7 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 		return false;
 	}
 
-	private static bool SaveFile (Document document, Gio.File? file, FormatDescriptor? format, Window parent)
+	private static bool SaveFile (Document document, Gio.File? file, FormatDescriptor? format, Gtk.Window parent)
 	{
 		file ??= document.File;
 

--- a/Pinta/Actions/Help/AboutDialogAction.cs
+++ b/Pinta/Actions/Help/AboutDialogAction.cs
@@ -27,31 +27,30 @@
 using System;
 using System.Text;
 using Pinta.Core;
+using Pinta.Resources;
 
 namespace Pinta.Actions;
 
 internal sealed class AboutDialogAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.App.About.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.App.About.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
 		var dialog = Adw.AboutWindow.New ();
 		dialog.TransientFor = PintaCore.Chrome.MainWindow;
 		dialog.Title = Translations.GetString ("About Pinta");
-		dialog.IconName = Pinta.Resources.Icons.AboutPinta;
+		dialog.IconName = Icons.AboutPinta;
 		dialog.ApplicationName = Translations.GetString ("Pinta");
-		dialog.ApplicationIcon = Pinta.Resources.Icons.Pinta;
+		dialog.ApplicationIcon = Icons.Pinta;
 		dialog.Version = PintaCore.ApplicationVersion;
 		dialog.Website = "https://www.pinta-project.com";
 		dialog.Comments = Translations.GetString ("Easily create and edit images");
@@ -59,7 +58,6 @@ internal sealed class AboutDialogAction : IActionHandler
 		dialog.License = BuildLicenseText ();
 		dialog.Developers = authors;
 		dialog.TranslatorCredits = Translations.GetString ("translator-credits");
-
 		dialog.Present ();
 	}
 

--- a/Pinta/Actions/Image/ResizeCanvasAction.cs
+++ b/Pinta/Actions/Image/ResizeCanvasAction.cs
@@ -31,23 +31,22 @@ namespace Pinta.Actions;
 
 internal sealed class ResizeCanvasAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Image.CanvasSize.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Image.CanvasSize.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
-		var dialog = new ResizeCanvasDialog ();
+		ResizeCanvasDialog dialog = new ();
 
 		dialog.OnResponse += (_, args) => {
+
 			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
 				dialog.SaveChanges ();
 

--- a/Pinta/Actions/Image/ResizeImageAction.cs
+++ b/Pinta/Actions/Image/ResizeImageAction.cs
@@ -31,23 +31,22 @@ namespace Pinta.Actions;
 
 internal sealed class ResizeImageAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Image.Resize.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Image.Resize.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
-		var dialog = new ResizeImageDialog ();
+		ResizeImageDialog dialog = new ();
 
 		dialog.OnResponse += (_, args) => {
+
 			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
 				dialog.SaveChanges ();
 

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -25,24 +25,21 @@
 // THE SOFTWARE.
 
 using System;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Actions;
 
 internal sealed class LayerPropertiesAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Layers.Properties.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Layers.Properties.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
@@ -51,7 +48,7 @@ internal sealed class LayerPropertiesAction : IActionHandler
 		var dialog = new LayerPropertiesDialog ();
 
 		dialog.OnResponse += (_, args) => {
-			var response = (ResponseType) args.ResponseId;
+			var response = (Gtk.ResponseType) args.ResponseId;
 			if (response == Gtk.ResponseType.Ok && dialog.AreLayerPropertiesUpdated) {
 
 				var historyMessage = GetLayerPropertyUpdateMessage (
@@ -71,10 +68,11 @@ internal sealed class LayerPropertiesAction : IActionHandler
 
 			} else {
 
-				var layer = doc.Layers.CurrentUserLayer;
-				var selectionLayer = doc.Layers.SelectionLayer;
-				var initial = dialog.InitialLayerProperties;
+				Layer layer = doc.Layers.CurrentUserLayer;
+				Layer selectionLayer = doc.Layers.SelectionLayer;
+				LayerProperties initial = dialog.InitialLayerProperties;
 				initial.SetProperties (layer);
+
 				if (selectionLayer != null)
 					initial.SetProperties (selectionLayer);
 

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -33,12 +33,12 @@ namespace Pinta.Actions;
 
 public sealed class RotateZoomLayerAction : IActionHandler
 {
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Layers.RotateZoom.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Layers.RotateZoom.Activated -= Activated;
 	}
@@ -47,7 +47,7 @@ public sealed class RotateZoomLayerAction : IActionHandler
 	{
 		// TODO - allow the layer to be zoomed in or out
 
-		var data = new RotateZoomData ();
+		RotateZoomData data = new ();
 
 		var dialog = new SimpleEffectDialog (
 			Translations.GetString ("Rotate / Zoom Layer"),
@@ -88,7 +88,7 @@ public sealed class RotateZoomLayerAction : IActionHandler
 		var center_y = image_size.Height / 2.0;
 
 		xform.Translate ((1 + data.Pan.X) * center_x, (1 + data.Pan.Y) * center_y);
-		xform.Rotate ((-data.Angle.Degrees / 180d) * Math.PI);
+		xform.Rotate (-data.Angle.ToRadians ().Radians);
 		xform.Scale (data.Zoom, data.Zoom);
 		xform.Translate (-center_x, -center_y);
 
@@ -98,16 +98,28 @@ public sealed class RotateZoomLayerAction : IActionHandler
 	private static void ApplyTransform (RotateZoomData data)
 	{
 		var doc = PintaCore.Workspace.ActiveDocument;
+
 		PintaCore.Tools.Commit ();
 
 		var old_surf = doc.Layers.CurrentUserLayer.Surface.Clone ();
 
 		var xform = ComputeMatrix (data);
-		doc.Layers.CurrentUserLayer.ApplyTransform (xform, PintaCore.Workspace.ImageSize, PintaCore.Workspace.ImageSize);
+
+		doc.Layers.CurrentUserLayer.ApplyTransform (
+			xform,
+			PintaCore.Workspace.ImageSize,
+			PintaCore.Workspace.ImageSize);
+
 		doc.Workspace.Invalidate ();
 
-		doc.History.PushNewItem (new SimpleHistoryItem (Resources.Icons.LayerRotateZoom,
-		    Translations.GetString ("Rotate / Zoom Layer"), old_surf, doc.Layers.CurrentUserLayerIndex));
+		doc.History.PushNewItem (
+			new SimpleHistoryItem (
+				Resources.Icons.LayerRotateZoom,
+				Translations.GetString ("Rotate / Zoom Layer"),
+				old_surf,
+				doc.Layers.CurrentUserLayerIndex
+			)
+		);
 	}
 
 	private sealed class RotateZoomData : EffectData

--- a/Pinta/Actions/View/ColorSchemeChangedAction.cs
+++ b/Pinta/Actions/View/ColorSchemeChangedAction.cs
@@ -5,17 +5,15 @@ namespace Pinta.Actions;
 
 internal sealed class ColorSchemeChangedAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.View.ColorScheme.OnActivate += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.View.ColorScheme.OnActivate -= Activated;
 	}
-	#endregion
 
 	private void Activated (SimpleAction action, SimpleAction.ActivateSignalArgs args)
 	{
@@ -24,7 +22,7 @@ internal sealed class ColorSchemeChangedAction : IActionHandler
 		Adw.ColorScheme scheme = args.Parameter!.GetInt32 () switch {
 			1 => Adw.ColorScheme.ForceLight,
 			2 => Adw.ColorScheme.ForceDark,
-			_ => Adw.ColorScheme.Default
+			_ => Adw.ColorScheme.Default,
 		};
 
 		Adw.StyleManager.GetDefault ().SetColorScheme (scheme);

--- a/Pinta/Actions/View/ImageTabsToggledAction.cs
+++ b/Pinta/Actions/View/ImageTabsToggledAction.cs
@@ -30,17 +30,15 @@ namespace Pinta.Actions;
 
 internal sealed class ImageTabsToggledAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.View.ImageTabs.Toggled += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.View.ImageTabs.Toggled -= Activated;
 	}
-	#endregion
 
 	private void Activated (bool value)
 	{

--- a/Pinta/Actions/View/StatusBarToggledAction.cs
+++ b/Pinta/Actions/View/StatusBarToggledAction.cs
@@ -30,17 +30,15 @@ namespace Pinta.Actions;
 
 internal sealed class StatusBarToggledAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.View.StatusBar.Toggled += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.View.StatusBar.Toggled -= Activated;
 	}
-	#endregion
 
 	private void Activated (bool value)
 	{

--- a/Pinta/Actions/View/ToolBarToggledAction.cs
+++ b/Pinta/Actions/View/ToolBarToggledAction.cs
@@ -30,17 +30,15 @@ namespace Pinta.Actions;
 
 internal sealed class ToolBarToggledAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.View.ToolBar.Toggled += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.View.ToolBar.Toggled -= Activated;
 	}
-	#endregion
 
 	private void Activated (bool value)
 	{

--- a/Pinta/Actions/View/ToolBoxToggledAction.cs
+++ b/Pinta/Actions/View/ToolBoxToggledAction.cs
@@ -30,17 +30,15 @@ namespace Pinta.Actions;
 
 internal sealed class ToolBoxToggledAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.View.ToolBox.Toggled += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.View.ToolBox.Toggled -= Activated;
 	}
-	#endregion
 
 	private void Activated (bool value)
 	{

--- a/Pinta/Actions/Window/CloseAllDocumentsAction.cs
+++ b/Pinta/Actions/Window/CloseAllDocumentsAction.cs
@@ -31,21 +31,20 @@ namespace Pinta.Actions;
 
 internal sealed class CloseAllDocumentsAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Window.CloseAll.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Window.CloseAll.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
 		while (PintaCore.Workspace.HasOpenDocuments) {
+
 			int count = PintaCore.Workspace.OpenDocuments.Count;
 
 			PintaCore.Actions.File.Close.Activate ();

--- a/Pinta/Actions/Window/SaveAllDocumentsAction.cs
+++ b/Pinta/Actions/Window/SaveAllDocumentsAction.cs
@@ -31,21 +31,20 @@ namespace Pinta.Actions;
 
 internal sealed class SaveAllDocumentsAction : IActionHandler
 {
-	#region IActionHandler Members
-	public void Initialize ()
+	void IActionHandler.Initialize ()
 	{
 		PintaCore.Actions.Window.SaveAll.Activated += Activated;
 	}
 
-	public void Uninitialize ()
+	void IActionHandler.Uninitialize ()
 	{
 		PintaCore.Actions.Window.SaveAll.Activated -= Activated;
 	}
-	#endregion
 
 	private void Activated (object sender, EventArgs e)
 	{
 		foreach (Document doc in PintaCore.Workspace.OpenDocuments) {
+
 			if (!doc.IsDirty && doc.HasFile)
 				continue;
 

--- a/Pinta/Dialogs/JpegCompressionDialog.cs
+++ b/Pinta/Dialogs/JpegCompressionDialog.cs
@@ -24,39 +24,48 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta;
 
-public sealed class JpegCompressionDialog : Dialog
+public sealed class JpegCompressionDialog : Gtk.Dialog
 {
-	private readonly Scale compressionLevel;
+	private readonly Gtk.Scale compression_level;
 
 	public JpegCompressionDialog (int defaultQuality, Gtk.Window parent)
 	{
 		Title = Translations.GetString ("JPEG Quality");
 		TransientFor = parent;
 		Modal = true;
-		this.AddCancelOkButtons ();
-		this.SetDefaultResponse (ResponseType.Ok);
 
-		var content_area = this.GetContentAreaBox ();
+		this.AddCancelOkButtons ();
+		this.SetDefaultResponse (Gtk.ResponseType.Ok);
+
+		Gtk.Label label = CreateQualityLabel ();
+		compression_level = CreateCompressionScale (defaultQuality);
+
+		Gtk.Box content_area = this.GetContentAreaBox ();
 		content_area.SetAllMargins (6);
 		content_area.Spacing = 3;
-
-		var label = Label.New (Translations.GetString ("Quality: "));
-		label.Xalign = 0;
 		content_area.Append (label);
-
-		compressionLevel = Scale.NewWithRange (Orientation.Horizontal, 1, 100, 1);
-		compressionLevel.SetValue (defaultQuality);
-		compressionLevel.DrawValue = true;
-		content_area.Append (compressionLevel);
+		content_area.Append (compression_level);
 	}
 
-	public int GetCompressionLevel ()
+	private static Gtk.Label CreateQualityLabel ()
 	{
-		return (int) compressionLevel.GetValue ();
+		Gtk.Label result = Gtk.Label.New (Translations.GetString ("Quality: "));
+		result.Xalign = 0;
+		return result;
 	}
+
+	private static Gtk.Scale CreateCompressionScale (int defaultQuality)
+	{
+		Gtk.Scale result = Gtk.Scale.NewWithRange (Gtk.Orientation.Horizontal, 1, 100, 1);
+		result.SetValue (defaultQuality);
+		result.DrawValue = true;
+		return result;
+	}
+
+	public int CompressionLevel
+		=> (int) compression_level.GetValue ();
 }


### PR DESCRIPTION
Originally, the idea was to change (or even get rid of) `IActionHandler` and the constructors of the actions, so that they don't depend on global context like `PintaCore`, but I think it would require some thought.

The refactoring is mostly done in bulk in order to get rid of ugly patterns like `#region IActionHandler Members`, but there are some where special care was taken, like `OpenDocumentAction`.

On the way, `JpegCompressionDialog` was also modified