### PR TITLE
Bug fix: Eraser tool does not initialize to last-used mode

### DIFF
--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -261,11 +261,11 @@ public sealed class EraserTool : BaseBrushTool
 			if (type_combobox is null) {
 				type_combobox = new ToolBarComboBox (100, 0, false, Translations.GetString ("Normal"), Translations.GetString ("Smooth"));
 
-				type_combobox.ComboBox.Active = Settings.GetSetting (ERASER_TYPE_SETTING, 0);
-
 				type_combobox.ComboBox.OnChanged += (o, e) => {
 					eraser_type = (EraserType) type_combobox.ComboBox.Active;
 				};
+
+				type_combobox.ComboBox.Active = Settings.GetSetting (ERASER_TYPE_SETTING, 0);
 			}
 
 			return type_combobox;


### PR DESCRIPTION
There is a combobox which _does_ initialize to the last-used mode, but the value doesn't actually get stashed into the tool's state, so until you interact with it, it's still in the default state. In practice, this means that if you use the eraser tool and set it to `Smooth` mode, then you restart Pinta, the combo box remembers that it should be in `Smooth` mode, but the tool initially operates in `Normal` mode.

This PR sets the tool's state to match the value loaded into the combo box.