### PR TITLE
Bug fix: Handling of alpha pixels when committing selection

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -214,7 +214,7 @@ public sealed class Document
 
 		Context g = new (Layers.CurrentUserLayer.Surface);
 		selection.Clip (g);
-		layer.Draw (g);
+		layer.DrawWithOperator (g, Operator.Source, opacity: 1.0, transform: true);
 
 		Layers.DestroySelectionLayer ();
 		Workspace.Invalidate ();

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -146,6 +146,11 @@ public class Layer : ObservableObject
 		ctx.Restore ();
 	}
 
+	public void DrawWithOperator (Context ctx, Operator op, double opacity = 1.0, bool transform = true)
+	{
+		DrawWithOperator (ctx, Surface, op, opacity, transform);
+	}
+
 	public void DrawWithOperator (
 		Context ctx,
 		ImageSurface surface,


### PR DESCRIPTION
When you finish a selection with pixels that aren't fully-opaque (whether due to layer opacity or the pixels' alpha channel), those pixels are blended with the target layer according to the opacity, but this is not the proper semantic for a selection. If you create a selection and then use Move Selection tool to relocate it, within that layer, the pixels' opacity should simply be translated along with the colour. This PR fixes selection moves so that when the selection is "dropped" onto the underlying layer, it simply replaces all of the pixels involved. It implements this by still blending the pixels the way it did before, but by clearing the underlying pixels so that there's nothing there for them to blend with. The new blend method ignores the layer opacity as well.

There is a separate bug in how the selection layer is previewed. Prior to finishing the selection, it will appear incorrectly blended with the underlying pixels. That is outside of the scope of this PR.

Before moving selection:

![image](https://github.com/PintaProject/Pinta/assets/2349379/1a792fa8-1e9d-474e-8591-af41f9bab663)

After moving selection, before finish selection:

![image](https://github.com/PintaProject/Pinta/assets/2349379/f1a0463c-fe52-4055-9a61-f9a03c6cd021)

After finishing selection:

![image](https://github.com/PintaProject/Pinta/assets/2349379/454a885e-2fc6-49b7-a1e0-aa1cde701549)

This PR partially fixes #819.