### PR TITLE
Miscellaneous refactorings in `LayersListViewItemWidget.cs` and `CanvasRenderer`

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -120,10 +120,11 @@ public sealed class CanvasRenderer
 	{
 		Span<ColorBgra> dst_data = dst.GetPixelData ();
 
-		// Draw horizontal lines
-
 		int dstHeight = dst.Height;
 		int dstWidth = dst.Width;
+
+		// Draw horizontal lines
+
 		int sTop = D2SLookupY[offset.Y];
 		int sBottom = D2SLookupY[offset.Y + dstHeight];
 

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -57,23 +57,27 @@ public sealed class CanvasRenderer
 		s_2_d_lookup_y = null;
 	}
 
-	public void Render (List<Layer> layers, Cairo.ImageSurface dst, PointI offset)
+	public void Render (
+		IReadOnlyList<Layer> layers,
+		Cairo.ImageSurface dst,
+		PointI offset)
 	{
 		dst.Flush ();
 
 		// Our rectangle of interest
 		var r = new RectangleI (offset, dst.GetBounds ().Size).ToDouble ();
-		var is_one_to_one = scale_factor.Ratio == 1;
+		bool is_one_to_one = scale_factor.Ratio == 1;
 
-		var g = new Cairo.Context (dst);
+		Cairo.Context g = new (dst);
 
 		// Create the transparent checkerboard background
 		g.Translate (-offset.X, -offset.Y);
 		g.FillRectangle (r, tranparent_pattern, new PointD (offset.X, offset.Y));
 
-		for (var i = 0; i < layers.Count; i++) {
-			var layer = layers[i];
-			var surf = layer.Surface;
+		for (int i = 0; i < layers.Count; i++) {
+
+			Layer layer = layers[i];
+			Cairo.ImageSurface surf = layer.Surface;
 
 			// If we're in LivePreview, substitute current layer with the preview layer
 			if (enable_live_preview && layer == PintaCore.Workspace.ActiveDocument.Layers.CurrentUserLayer && PintaCore.LivePreview.IsEnabled)
@@ -111,47 +115,59 @@ public sealed class CanvasRenderer
 	private ImmutableArray<int> S2DLookupY => s_2_d_lookup_y ??= CreateS2DLookupY (source_size.Height, destination_size.Height, scale_factor);
 
 	#region Algorithms ported from PDN
+
 	private void RenderPixelGrid (Cairo.ImageSurface dst, PointI offset)
 	{
+		Span<ColorBgra> dst_data = dst.GetPixelData ();
+
 		// Draw horizontal lines
-		var dst_data = dst.GetPixelData ();
-		var dstHeight = dst.Height;
-		var dstWidth = dst.Width;
-		var sTop = D2SLookupY[offset.Y];
-		var sBottom = D2SLookupY[offset.Y + dstHeight];
+
+		int dstHeight = dst.Height;
+		int dstWidth = dst.Width;
+		int sTop = D2SLookupY[offset.Y];
+		int sBottom = D2SLookupY[offset.Y + dstHeight];
+
 		var lookup_y = S2DLookupY;
 
-		for (var srcY = sTop; srcY <= sBottom; ++srcY) {
-			var dstY = lookup_y[srcY];
-			var dstRow = dstY - offset.Y;
+		for (int srcY = sTop; srcY <= sBottom; ++srcY) {
 
-			if (dstRow >= 0 && dstRow < dstHeight) {
-				var dst_row = dst_data.Slice (dstRow * dstWidth, dstWidth);
+			int dstY = lookup_y[srcY];
+			int dstRow = dstY - offset.Y;
 
-				for (int x = offset.X & 1; x < dst_row.Length; x += 2)
-					dst_row[x] = ColorBgra.Black;
-			}
+			if (dstRow < 0 || dstRow >= dstHeight)
+				continue;
+
+			var dst_row = dst_data.Slice (dstRow * dstWidth, dstWidth);
+			for (int x = offset.X & 1; x < dst_row.Length; x += 2)
+				dst_row[x] = ColorBgra.Black;
 		}
 
 		// Draw vertical lines
-		var sLeft = D2SLookupX[offset.X];
-		var sRight = D2SLookupX[offset.X + dstWidth];
+
+		int sLeft = D2SLookupX[offset.X];
+		int sRight = D2SLookupX[offset.X + dstWidth];
+
 		var lookup_x = S2DLookupX;
 
-		for (var srcX = sLeft; srcX <= sRight; ++srcX) {
-			var dstX = lookup_x[srcX];
-			var dstCol = dstX - offset.X;
+		for (int srcX = sLeft; srcX <= sRight; ++srcX) {
 
-			if (dstCol >= 0 && dstCol < dstWidth) {
-				for (int idx = dstCol + (offset.Y & 1) * dstWidth; idx < dst_data.Length; idx += 2 * dstWidth)
-					dst_data[idx] = ColorBgra.Black;
-			}
+			int dstX = lookup_x[srcX];
+			int dstCol = dstX - offset.X;
+
+			if (dstCol < 0 || dstCol >= dstWidth)
+				continue;
+
+			for (int idx = dstCol + (offset.Y & 1) * dstWidth; idx < dst_data.Length; idx += 2 * dstWidth)
+				dst_data[idx] = ColorBgra.Black;
 		}
 	}
 
-	private static ImmutableArray<int> CreateLookupX (int srcWidth, int dstWidth, ScaleFactor scaleFactor)
+	private static ImmutableArray<int> CreateLookupX (
+		int srcWidth,
+		int dstWidth,
+		ScaleFactor scaleFactor)
 	{
-		var length = dstWidth + 1;
+		int length = dstWidth + 1;
 		var lookup = ImmutableArray.CreateBuilder<int> (length);
 		lookup.Count = length;
 
@@ -164,49 +180,59 @@ public sealed class CanvasRenderer
 		return lookup.MoveToImmutable ();
 	}
 
-	private static ImmutableArray<int> CreateLookupY (int srcHeight, int dstHeight, ScaleFactor scaleFactor)
+	private static ImmutableArray<int> CreateLookupY (
+		int srcHeight,
+		int dstHeight,
+		ScaleFactor scaleFactor)
 	{
-		var length = dstHeight + 1;
+		int length = dstHeight + 1;
 		var lookup = ImmutableArray.CreateBuilder<int> (length);
 		lookup.Count = length;
 
 		// Sometimes the scale factor is slightly different on one axis than
 		// on another, simply due to accuracy. So we have to clamp this value to
 		// be within bounds.
-		for (var y = 0; y < lookup.Count; ++y)
+		for (int y = 0; y < lookup.Count; ++y)
 			lookup[y] = Math.Clamp (scaleFactor.ScaleScalar (y), 0, srcHeight - 1);
 
 		return lookup.MoveToImmutable ();
 	}
 
-	private static ImmutableArray<int> CreateS2DLookupX (int srcWidth, int dstWidth, ScaleFactor scaleFactor)
+	private static ImmutableArray<int> CreateS2DLookupX (
+		int srcWidth,
+		int dstWidth,
+		ScaleFactor scaleFactor)
 	{
-		var length = srcWidth + 1;
+		int length = srcWidth + 1;
 		var lookup = ImmutableArray.CreateBuilder<int> (length);
 		lookup.Count = length;
 
 		// Sometimes the scale factor is slightly different on one axis than
 		// on another, simply due to accuracy. So we have to clamp this value to
 		// be within bounds.
-		for (var x = 0; x < lookup.Count; ++x)
+		for (int x = 0; x < lookup.Count; ++x)
 			lookup[x] = Math.Clamp (scaleFactor.UnscaleScalar (x), 0, dstWidth - 1);
 
 		return lookup.MoveToImmutable ();
 	}
 
-	private static ImmutableArray<int> CreateS2DLookupY (int srcHeight, int dstHeight, ScaleFactor scaleFactor)
+	private static ImmutableArray<int> CreateS2DLookupY (
+		int srcHeight,
+		int dstHeight,
+		ScaleFactor scaleFactor)
 	{
-		var length = srcHeight + 1;
+		int length = srcHeight + 1;
 		var lookup = ImmutableArray.CreateBuilder<int> (length);
 		lookup.Count = length;
 
 		// Sometimes the scale factor is slightly different on one axis than
 		// on another, simply due to accuracy. So we have to clamp this value to
 		// be within bounds.
-		for (var y = 0; y < lookup.Count; ++y)
+		for (int y = 0; y < lookup.Count; ++y)
 			lookup[y] = Math.Clamp (scaleFactor.UnscaleScalar (y), 0, dstHeight - 1);
 
 		return lookup.MoveToImmutable ();
 	}
+
 	#endregion
 }


### PR DESCRIPTION
In `LayersListViewItemWidget`, control creation was moved to its own methods.

In `CanvasRenderer`, certain syntax was modernized, a method signature (`Render()`) was modified, and variable declaration was done with specific types whenever it resulted in clearer code.