### PR TITLE
Ensured that only instance properties (and no static properties) are used in `SimpleEffectDialog`

### DIFF
--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -59,6 +59,10 @@ public sealed class CloudsEffect : BaseEffect
 	// Adapted to 2-D version in C# from 3-D version in Java from http://mrl.nyu.edu/~perlin/noise/
 	private static readonly ImmutableArray<int> permute_lookup;
 
+	public static ReadOnlyDictionary<string, object> BlendOps { get; }
+
+	private static readonly string default_blend_op;
+
 	static CloudsEffect ()
 	{
 #pragma warning disable format
@@ -90,6 +94,15 @@ public sealed class CloudsEffect : BaseEffect
 			permuteLookup[i] = permutationTable[i];
 		}
 		permute_lookup = permuteLookup.MoveToImmutable ();
+
+		BlendOps =
+			UserBlendOps.GetAllBlendModeNames ()
+			.ToDictionary (
+				o => o,
+				o => (object) UserBlendOps.GetBlendModeByName (o))
+			.AsReadOnly ();
+
+		default_blend_op = UserBlendOps.GetBlendModeName (Pinta.Core.BlendMode.Normal);
 	}
 
 	private static double Fade (double t)
@@ -218,7 +231,7 @@ public sealed class CloudsEffect : BaseEffect
 
 			g.Clear (r);
 			g.BlendSurface (src, r);
-			g.BlendSurface (temp, r.Location (), (BlendMode) CloudsData.BlendOps[Data.BlendMode]);
+			g.BlendSurface (temp, r.Location (), (BlendMode) BlendOps[Data.BlendMode]);
 		}
 	}
 	#endregion
@@ -233,24 +246,6 @@ public sealed class CloudsEffect : BaseEffect
 
 		[Caption ("Power"), MinimumValue (0), MaximumValue (100)]
 		public int Power { get; set; } = 50;
-
-		[Skip]
-		public static ReadOnlyDictionary<string, object> BlendOps { get; }
-
-		[Skip]
-		private static readonly string default_blend_op;
-
-		static CloudsData ()
-		{
-			BlendOps =
-				UserBlendOps.GetAllBlendModeNames ()
-				.ToDictionary (
-					o => o,
-					o => (object) UserBlendOps.GetBlendModeByName (o))
-				.AsReadOnly ();
-
-			default_blend_op = UserBlendOps.GetBlendModeName (Pinta.Core.BlendMode.Normal);
-		}
 
 		[StaticList ("BlendOps")]
 		public string BlendMode { get; set; } = default_blend_op;

--- a/Pinta.Gui.Widgets/Dialogs/MemberReflector.cs
+++ b/Pinta.Gui.Widgets/Dialogs/MemberReflector.cs
@@ -40,7 +40,7 @@ internal sealed class MemberReflector
 			case FieldInfo f:
 				return f.SetValue;
 			case PropertyInfo p:
-				MethodInfo setter = p.GetSetMethod () ?? throw new ArgumentException ("Property has no 'set' method", nameof (memberInfo));
+				MethodInfo setter = p.GetSetMethod () ?? throw new ArgumentException ($"Property {p.Name} has no 'set' method", nameof (memberInfo));
 				return (o, v) => setter.Invoke (o, new[] { v });
 			default:
 				throw new ArgumentException ($"Member type {memberInfo.GetType ()} not supported", nameof (memberInfo));

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -115,12 +115,26 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 			effectData
 			.GetType ()
 			.GetMembers ()
-			.Where (m => m is FieldInfo || m is PropertyInfo)
+			.Where (IsInstanceFieldOrProperty)
 			.Where (m => string.Compare (m.Name, nameof (EffectData.IsDefault), true) != 0)
 			.Select (CreateSettings)
 			.Where (settings => !settings.skip)
 			.Select (settings => GetMemberWidgets (settings, effectData, localizer))
 			.SelectMany (widgets => widgets);
+
+	private bool IsInstanceFieldOrProperty (MemberInfo memberInfo)
+	{
+		switch (memberInfo) {
+			case FieldInfo fieldInfo:
+				return !fieldInfo.IsStatic;
+			case PropertyInfo propertyInfo:
+				MethodInfo? getter = propertyInfo.GetGetMethod ();
+				if (getter is null) return false;
+				return !getter.IsStatic;
+			default:
+				return false;
+		}
+	}
 
 	private sealed record MemberSettings (
 		MemberReflector reflector,

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -116,11 +116,16 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 			.GetType ()
 			.GetMembers ()
 			.Where (IsInstanceFieldOrProperty)
-			.Where (m => string.Compare (m.Name, nameof (EffectData.IsDefault), true) != 0)
+			.Where (IsCustomProperty)
 			.Select (CreateSettings)
 			.Where (settings => !settings.skip)
 			.Select (settings => GetMemberWidgets (settings, effectData, localizer))
 			.SelectMany (widgets => widgets);
+
+	private bool IsCustomProperty (MemberInfo memberInfo)
+	{
+		return string.Compare (memberInfo.Name, nameof (EffectData.IsDefault), true) != 0;
+	}
 
 	private bool IsInstanceFieldOrProperty (MemberInfo memberInfo)
 	{


### PR DESCRIPTION
`CloudsData` has a static property `BlendOps`, which `SimpleEffectDialog` tried to use and caused an error to occur because it doesn't have a getter, but again, this property is static and isn't supposed to be used. I added some more checks in the filtering part in order to make sure that only instance properties are used.

Still, I don't think this property belongs in `CloudsData`, so I moved it to `CloudsEffect`. If this is not desired, the last commit could be discarded.