### PR TITLE
Refactored control creation in constructor of `NewImageDialog`

### DIFF
--- a/Pinta/Actions/File/NewDocumentAction.cs
+++ b/Pinta/Actions/File/NewDocumentAction.cs
@@ -66,14 +66,15 @@ internal sealed class NewDocumentAction : IActionHandler
 			using_clipboard = true;
 		}
 
-		NewImageDialog dialog = new (imgWidth, imgHeight, bg_type, using_clipboard);
+		Size imageSize = new (imgWidth, imgHeight);
+		NewImageDialog dialog = new (imageSize, bg_type, using_clipboard);
 
 		dialog.OnResponse += (_, e) => {
 
 			int response = e.ResponseId;
 
 			if (response == (int) Gtk.ResponseType.Ok) {
-				PintaCore.Workspace.NewDocument (new Size (dialog.NewImageWidth, dialog.NewImageHeight), dialog.NewImageBackground);
+				PintaCore.Workspace.NewDocument (dialog.NewImageSize, dialog.NewImageBackground);
 
 				PintaCore.Settings.PutSetting ("new-image-width", dialog.NewImageWidth);
 				PintaCore.Settings.PutSetting ("new-image-height", dialog.NewImageHeight);

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -84,14 +84,14 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		// Some arbitrary presets
 		preset_sizes = new List<Size> {
-			new Size (640, 480),
-			new Size (800, 600),
-			new Size (1024, 768),
-			new Size (1600, 1200)
+			new (640, 480),
+			new (800, 600),
+			new (1024, 768),
+			new (1600, 1200)
 		};
 
 		// Layout table for preset, width, and height
-		Gtk.Grid layout_grid = new Gtk.Grid {
+		Gtk.Grid layout_grid = new () {
 			RowSpacing = 5,
 			ColumnSpacing = 6
 		};
@@ -101,7 +101,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		size_label.Xalign = 1f;
 		size_label.Yalign = .5f;
 
-		List<string> preset_entries = new List<string> ();
+		List<string> preset_entries = new ();
 
 		if (has_clipboard)
 			preset_entries.Add (Translations.GetString ("Clipboard"));
@@ -120,7 +120,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		width_label.Xalign = 1f;
 		width_label.Yalign = .5f;
 
-		width_entry = new Gtk.Entry {
+		width_entry = new Gtk.Entry () {
 			WidthRequest = 50,
 			ActivatesDefault = true
 		};
@@ -140,7 +140,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		height_label.Xalign = 1f;
 		height_label.Yalign = .5f;
 
-		height_entry = new Gtk.Entry {
+		height_entry = new Gtk.Entry () {
 			WidthRequest = 50,
 			ActivatesDefault = true
 		};
@@ -161,7 +161,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		orientation_label.Yalign = .5f;
 
 		portrait_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
-		Gtk.Image portrait_image = new Gtk.Image () {
+		Gtk.Image portrait_image = new () {
 			IconName = Resources.Icons.OrientationPortrait,
 			PixelSize = 16
 		};
@@ -174,7 +174,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		landscape_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
 		landscape_radio.SetGroup (portrait_radio);
-		Gtk.Image landscape_image = new Gtk.Image () {
+		Gtk.Image landscape_image = new () {
 			IconName = Resources.Icons.OrientationLandscape,
 			PixelSize = 16
 		};
@@ -248,7 +248,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		options_vbox.Append (background_vbox);
 
 		// Layout the preview + the options
-		preview = new PreviewArea {
+		preview = new PreviewArea () {
 			Vexpand = true,
 			Valign = Gtk.Align.Fill
 		};
@@ -288,9 +288,14 @@ public sealed class NewImageDialog : Gtk.Dialog
 		preview.Update (NewImageSize, NewImageBackground);
 	}
 
-	public int NewImageWidth => int.Parse (width_entry.Buffer!.Text!);
-	public int NewImageHeight => int.Parse (height_entry.Buffer!.Text!);
-	public Size NewImageSize => new (NewImageWidth, NewImageHeight);
+	public int NewImageWidth
+		=> int.Parse (width_entry.Buffer!.Text!);
+
+	public int NewImageHeight
+		=> int.Parse (height_entry.Buffer!.Text!);
+
+	public Size NewImageSize
+		=> new (NewImageWidth, NewImageHeight);
 
 	public enum BackgroundType
 	{
@@ -344,7 +349,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			int width = int.Parse (text_parts[0]);
 			int height = int.Parse (text_parts[2]);
 
-			return new Size (width, height);
+			return new (width, height);
 		}
 	}
 
@@ -455,7 +460,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			int width = int.Parse (text_parts[0].Trim ());
 			int height = int.Parse (text_parts[1].Trim ());
 
-			Size new_size = new Size (NewImageWidth < NewImageHeight ? Math.Min (width, height) : Math.Max (width, height), NewImageWidth < NewImageHeight ? Math.Max (width, height) : Math.Min (width, height));
+			Size new_size = new (NewImageWidth < NewImageHeight ? Math.Min (width, height) : Math.Max (width, height), NewImageWidth < NewImageHeight ? Math.Max (width, height) : Math.Min (width, height));
 			string new_text = $"{new_size.Width} x {new_size.Height}";
 
 			if (new_text != text)
@@ -475,9 +480,8 @@ public sealed class NewImageDialog : Gtk.Dialog
 			return;
 
 		string text = $"{NewImageWidth} x {NewImageHeight}";
-		if (preset_dropdown_model.FindString (text, out uint index) && preset_dropdown.Selected != index) {
+		if (preset_dropdown_model.FindString (text, out uint index) && preset_dropdown.Selected != index)
 			preset_dropdown.Selected = index;
-		}
 	}
 
 	private sealed class PreviewArea : Gtk.DrawingArea
@@ -528,11 +532,15 @@ public sealed class NewImageDialog : Gtk.Dialog
 			else
 				preview_size = new Size ((int) (MAX_SIZE / (size.Height / (float) size.Width)), MAX_SIZE);
 
-			RectangleD r = new RectangleD ((widget_width - preview_size.Width) / 2, (widget_height - preview_size.Height) / 2, preview_size.Width, preview_size.Height);
+			RectangleD r = new (
+				(widget_width - preview_size.Width) / 2,
+				(widget_height - preview_size.Height) / 2,
+				preview_size.Width,
+				preview_size.Height);
 
 			if (color.A == 0) {
 				// Fill with transparent checkerboard pattern
-				var pattern = CairoExtensions.CreateTransparentBackgroundPattern (16);
+				Pattern pattern = CairoExtensions.CreateTransparentBackgroundPattern (16);
 				cr.FillRectangle (r, pattern);
 			} else {
 				// Fill with selected color

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -72,18 +72,14 @@ public sealed class NewImageDialog : Gtk.Dialog
 		bool hasClipboard = isClipboardSize;
 
 		// Preset Combo
-		Gtk.Label sizeLabel = Gtk.Label.New (Translations.GetString ("Preset:"));
-		sizeLabel.Xalign = 1f;
-		sizeLabel.Yalign = .5f;
+		Gtk.Label sizeLabel = CreateSizeLabel ();
 
 		Gtk.StringList presetDropdownModel = Gtk.StringList.New (GeneratePresetEntries (hasClipboard).ToArray ());
 
 		Gtk.DropDown presetDropdown = Gtk.DropDown.New (presetDropdownModel, expression: null);
 
 		// Width Entry
-		Gtk.Label widthLabel = Gtk.Label.New (Translations.GetString ("Width:"));
-		widthLabel.Xalign = 1f;
-		widthLabel.Yalign = .5f;
+		Gtk.Label widthLabel = CreateWidthLabel ();
 
 		Gtk.Entry widthEntry = new () {
 			WidthRequest = 50,
@@ -98,9 +94,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		widthHbox.Append (widthUnits);
 
 		// Height Entry
-		Gtk.Label heightLabel = Gtk.Label.New (Translations.GetString ("Height:"));
-		heightLabel.Xalign = 1f;
-		heightLabel.Yalign = .5f;
+		Gtk.Label heightLabel = CreateHeightLabel ();
 
 		Gtk.Entry heightEntry = new () {
 			WidthRequest = 50,
@@ -115,10 +109,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		heightHbox.Append (heightUnits);
 
 		// Orientation Radio options
-		Gtk.Label orientationLabel = Gtk.Label.New (Translations.GetString ("Orientation:"));
-		orientationLabel.Xalign = 0f;
-		orientationLabel.Yalign = .5f;
-		orientationLabel.MarginBottom = 4;
+		Gtk.Label orientationLabel = CreateOrientationLabel ();
 
 		Gtk.CheckButton portraitRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
 
@@ -152,10 +143,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		orientationVbox.Append (landscapeHbox);
 
 		// Background Color options
-		Gtk.Label backgroundLabel = Gtk.Label.New (Translations.GetString ("Background:"));
-		backgroundLabel.Xalign = 0f;
-		backgroundLabel.Yalign = .5f;
-		backgroundLabel.MarginBottom = 4;
+		Gtk.Label backgroundLabel = CreateBackgroundLabel ();
 
 		Gtk.CheckButton whiteBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("White"));
 
@@ -294,6 +282,48 @@ public sealed class NewImageDialog : Gtk.Dialog
 		UpdatePresetSelection ();
 
 		previewBox.Update (NewImageSize, NewImageBackground);
+	}
+
+	private static Gtk.Label CreateBackgroundLabel ()
+	{
+		Gtk.Label result = Gtk.Label.New (Translations.GetString ("Background:"));
+		result.Xalign = 0f;
+		result.Yalign = .5f;
+		result.MarginBottom = 4;
+		return result;
+	}
+
+	private static Gtk.Label CreateOrientationLabel ()
+	{
+		Gtk.Label result = Gtk.Label.New (Translations.GetString ("Orientation:"));
+		result.Xalign = 0f;
+		result.Yalign = .5f;
+		result.MarginBottom = 4;
+		return result;
+	}
+
+	private static Gtk.Label CreateWidthLabel ()
+	{
+		Gtk.Label result = Gtk.Label.New (Translations.GetString ("Width:"));
+		result.Xalign = 1f;
+		result.Yalign = .5f;
+		return result;
+	}
+
+	private static Gtk.Label CreateHeightLabel ()
+	{
+		Gtk.Label result = Gtk.Label.New (Translations.GetString ("Height:"));
+		result.Xalign = 1f;
+		result.Yalign = .5f;
+		return result;
+	}
+
+	private static Gtk.Label CreateSizeLabel ()
+	{
+		Gtk.Label result = Gtk.Label.New (Translations.GetString ("Preset:"));
+		result.Xalign = 1f;
+		result.Yalign = .5f;
+		return result;
 	}
 
 	// Some arbitrary presets

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -79,25 +79,25 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label widthLabel = CreateWidthLabel ();
 		Gtk.Entry widthEntry = CreateLengthEntry ();
 		Gtk.Label widthUnitsLabel = CreateUnitsLabel ();
-		Gtk.Box widthHbox = CreateHorizontalBox (widthEntry, widthUnitsLabel);
+		Gtk.Box widthHbox = CreateHorizontalBox (0, widthEntry, widthUnitsLabel);
 
 		Gtk.Label heightLabel = CreateHeightLabel ();
 		Gtk.Entry heightEntry = CreateLengthEntry ();
 		Gtk.Label heightUnitsLabel = CreateUnitsLabel ();
-		Gtk.Box heightHbox = CreateHorizontalBox (heightEntry, heightUnitsLabel);
+		Gtk.Box heightHbox = CreateHorizontalBox (0, heightEntry, heightUnitsLabel);
 
 		// Orientation Radio options
 		Gtk.Label orientationLabel = CreateOrientationLabel ();
 
 		Gtk.CheckButton portraitRadio = CreatePortraitRadio ();
 		Gtk.Image portraitImage = CreateOrientationIcon (Resources.Icons.OrientationPortrait);
-		Gtk.Box portraitHbox = CreateHorizontalBox (portraitImage, portraitRadio);
+		Gtk.Box portraitHbox = CreateHorizontalBox (0, portraitImage, portraitRadio);
 
 		Gtk.CheckButton landscapeRadio = CreateLandscapeRadio (portraitRadio);
 		Gtk.Image landscapeImage = CreateOrientationIcon (Resources.Icons.OrientationLandscape);
-		Gtk.Box landscapeHbox = CreateHorizontalBox (landscapeImage, landscapeRadio);
+		Gtk.Box landscapeHbox = CreateHorizontalBox (0, landscapeImage, landscapeRadio);
 
-		Gtk.Box orientationVbox = CreateVerticalBox (orientationLabel, portraitHbox, landscapeHbox);
+		Gtk.Box orientationVbox = CreateVerticalBox (0, orientationLabel, portraitHbox, landscapeHbox);
 
 		// Background Color options
 		Gtk.Label backgroundLabel = CreateBackgroundLabel ();
@@ -107,7 +107,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageWhite = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 		imageWhite.MarginEnd = 7;
 
-		Gtk.Box hboxWhite = CreateHorizontalBox (imageWhite, whiteBackgroundRadio);
+		Gtk.Box hboxWhite = CreateHorizontalBox (0, imageWhite, whiteBackgroundRadio);
 
 		Gtk.CheckButton secondaryBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
 		secondaryBackgroundRadio.SetGroup (whiteBackgroundRadio);
@@ -115,7 +115,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
 		imageBackground.MarginEnd = 7;
 
-		Gtk.Box hboxBackground = CreateHorizontalBox (imageBackground, secondaryBackgroundRadio);
+		Gtk.Box hboxBackground = CreateHorizontalBox (0, imageBackground, secondaryBackgroundRadio);
 
 		Gtk.CheckButton transparentBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
 		transparentBackgroundRadio.SetGroup (secondaryBackgroundRadio);
@@ -123,9 +123,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageTransparent = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		imageTransparent.MarginEnd = 7;
 
-		Gtk.Box hboxTransparent = CreateHorizontalBox (imageTransparent, transparentBackgroundRadio);
+		Gtk.Box hboxTransparent = CreateHorizontalBox (0, imageTransparent, transparentBackgroundRadio);
 
-		Gtk.Box backgroundVbox = CreateVerticalBox (backgroundLabel, hboxWhite);
+		Gtk.Box backgroundVbox = CreateVerticalBox (0, backgroundLabel, hboxWhite);
 
 		if (allowBackgroundColor)
 			backgroundVbox.Append (hboxBackground);
@@ -147,11 +147,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layoutGrid.Attach (heightHbox, 1, 2, 1, 1);
 
 		// Put all the options together
-		Gtk.Box optionsVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		optionsVbox.Spacing = 10;
-		optionsVbox.Append (layoutGrid);
-		optionsVbox.Append (orientationVbox);
-		optionsVbox.Append (backgroundVbox);
+		Gtk.Box optionsVbox = CreateVerticalBox (10, layoutGrid, orientationVbox, backgroundVbox);
 
 		// Layout the preview + the options
 
@@ -164,11 +160,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 			Halign = Gtk.Align.Fill,
 		};
 
-		Gtk.Box previewVbox = CreateVerticalBox (previewLabel, previewBox);
+		Gtk.Box previewVbox = CreateVerticalBox (0, previewLabel, previewBox);
 
-		Gtk.Box mainHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
-		mainHbox.Append (optionsVbox);
-		mainHbox.Append (previewVbox);
+		Gtk.Box mainHbox = CreateHorizontalBox (10, optionsVbox, previewVbox);
 
 		Gtk.Box contentArea = this.GetContentAreaBox ();
 		contentArea.SetAllMargins (8);
@@ -231,25 +225,33 @@ public sealed class NewImageDialog : Gtk.Dialog
 		previewBox.Update (NewImageSize, NewImageBackground);
 	}
 
-	private static Gtk.Box CreateHorizontalBox (Gtk.Widget w1, Gtk.Widget w2)
+	private static Gtk.Box CreateHorizontalBox (
+		int spacing,
+		Gtk.Widget w1,
+		Gtk.Widget w2)
 	{
-		Gtk.Box hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, spacing);
 		hbox.Append (w1);
 		hbox.Append (w2);
 		return hbox;
 	}
 
-	private static Gtk.Box CreateVerticalBox (Gtk.Widget w1, Gtk.Widget w2)
+	private static Gtk.Box CreateVerticalBox (
+		int spacing,
+		Gtk.Widget w1,
+		Gtk.Widget w2)
 	{
-		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, spacing);
 		vbox.Append (w1);
 		vbox.Append (w2);
 		return vbox;
 	}
 
-	private static Gtk.Box CreateVerticalBox (params Gtk.Widget[] children)
+	private static Gtk.Box CreateVerticalBox (
+		int spacing,
+		params Gtk.Widget[] children)
 	{
-		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, spacing);
 
 		foreach (var child in children)
 			vbox.Append (child);

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -88,7 +88,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		Gtk.Entry widthEntry = new () {
 			WidthRequest = 50,
-			ActivatesDefault = true
+			ActivatesDefault = true,
 		};
 
 		Gtk.Label widthUnits = Gtk.Label.New (Translations.GetString ("pixels"));
@@ -105,7 +105,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		Gtk.Entry heightEntry = new () {
 			WidthRequest = 50,
-			ActivatesDefault = true
+			ActivatesDefault = true,
 		};
 
 		Gtk.Label heightUnits = Gtk.Label.New (Translations.GetString ("pixels"));
@@ -445,21 +445,25 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		// Handle orientation changes
 		portrait_radio.OnToggled += (o, e) => {
-			if (portrait_radio.Active && IsValidSize && NewImageWidth > NewImageHeight) {
-				int temp = NewImageWidth;
-				width_entry.Buffer!.Text = height_entry.Buffer!.Text;
-				height_entry.Buffer!.Text = temp.ToString ();
-				preview_box.Update (NewImageSize);
-			}
+
+			if (!portrait_radio.Active || !IsValidSize || NewImageWidth <= NewImageHeight)
+				return;
+
+			int temp = NewImageWidth;
+			width_entry.Buffer!.Text = height_entry.Buffer!.Text;
+			height_entry.Buffer!.Text = temp.ToString ();
+			preview_box.Update (NewImageSize);
 		};
 
 		landscape_radio.OnToggled += (o, e) => {
-			if (landscape_radio.Active && IsValidSize && NewImageWidth < NewImageHeight) {
-				int temp = NewImageWidth;
-				width_entry.Buffer!.Text = height_entry.Buffer!.Text;
-				height_entry.Buffer!.Text = temp.ToString ();
-				preview_box.Update (NewImageSize);
-			}
+
+			if (!landscape_radio.Active || !IsValidSize || NewImageWidth >= NewImageHeight)
+				return;
+
+			int temp = NewImageWidth;
+			width_entry.Buffer!.Text = height_entry.Buffer!.Text;
+			height_entry.Buffer!.Text = temp.ToString ();
+			preview_box.Update (NewImageSize);
 		};
 
 		// Handle background color changes
@@ -547,15 +551,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		private void Draw (Context cr, int widget_width, int widget_height)
 		{
-			Size preview_size;
-
-			// Figure out the dimensions of the preview to draw
-			if (size.Width <= MAX_SIZE && size.Height <= MAX_SIZE)
-				preview_size = size;
-			else if (size.Width > size.Height)
-				preview_size = new Size (MAX_SIZE, (int) (MAX_SIZE / (size.Width / (float) size.Height)));
-			else
-				preview_size = new Size ((int) (MAX_SIZE / (size.Height / (float) size.Width)), MAX_SIZE);
+			Size preview_size = GetPreviewSizeForDraw ();
 
 			RectangleD r = new (
 				(widget_width - preview_size.Width) / 2,
@@ -576,6 +572,16 @@ public sealed class NewImageDialog : Gtk.Dialog
 			cr.DrawRectangle (new RectangleD (r.X - 1, r.Y - 1, r.Width + 2, r.Height + 2), new Cairo.Color (.5, .5, .5), 1);
 			cr.DrawRectangle (new RectangleD (r.X - 2, r.Y - 2, r.Width + 4, r.Height + 4), new Cairo.Color (.8, .8, .8), 1);
 			cr.DrawRectangle (new RectangleD (r.X - 3, r.Y - 3, r.Width + 6, r.Height + 6), new Cairo.Color (.9, .9, .9), 1);
+		}
+
+		private Size GetPreviewSizeForDraw () // Figure out the dimensions of the preview to draw
+		{
+			if (size.Width <= MAX_SIZE && size.Height <= MAX_SIZE)
+				return size;
+			else if (size.Width > size.Height)
+				return new Size (MAX_SIZE, (int) (MAX_SIZE / (size.Width / (float) size.Height)));
+			else
+				return new Size ((int) (MAX_SIZE / (size.Height / (float) size.Width)), MAX_SIZE);
 		}
 	}
 }

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -71,14 +71,13 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		bool hasClipboard = isClipboardSize;
 
-		// Preset Combo
 		Gtk.Label sizeLabel = CreateSizeLabel ();
 
+		// Preset Combo
 		Gtk.StringList presetDropdownModel = Gtk.StringList.New (GeneratePresetEntries (hasClipboard).ToArray ());
 
 		Gtk.DropDown presetDropdown = Gtk.DropDown.New (presetDropdownModel, expression: null);
 
-		// Width Entry
 		Gtk.Label widthLabel = CreateWidthLabel ();
 
 		Gtk.Entry widthEntry = new () {
@@ -86,14 +85,11 @@ public sealed class NewImageDialog : Gtk.Dialog
 			ActivatesDefault = true,
 		};
 
-		Gtk.Label widthUnits = Gtk.Label.New (Translations.GetString ("pixels"));
-		widthUnits.MarginStart = 5;
+		Gtk.Label widthUnitsLabel = Gtk.Label.New (Translations.GetString ("pixels"));
+		widthUnitsLabel.MarginStart = 5;
 
-		Gtk.Box widthHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		widthHbox.Append (widthEntry);
-		widthHbox.Append (widthUnits);
+		Gtk.Box widthHbox = CreateWidthBox (widthEntry, widthUnitsLabel);
 
-		// Height Entry
 		Gtk.Label heightLabel = CreateHeightLabel ();
 
 		Gtk.Entry heightEntry = new () {
@@ -101,12 +97,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 			ActivatesDefault = true,
 		};
 
-		Gtk.Label heightUnits = Gtk.Label.New (Translations.GetString ("pixels"));
-		heightUnits.MarginStart = 5;
+		Gtk.Label heightUnitsLabel = Gtk.Label.New (Translations.GetString ("pixels"));
+		heightUnitsLabel.MarginStart = 5;
 
-		Gtk.Box heightHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		heightHbox.Append (heightEntry);
-		heightHbox.Append (heightUnits);
+		Gtk.Box heightHbox = CreateHeightBox (heightEntry, heightUnitsLabel);
 
 		// Orientation Radio options
 		Gtk.Label orientationLabel = CreateOrientationLabel ();
@@ -119,9 +113,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			MarginEnd = 7,
 		};
 
-		Gtk.Box portraitHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		portraitHbox.Append (portraitImage);
-		portraitHbox.Append (portraitRadio);
+		Gtk.Box portraitHbox = CreatePortraitBox (portraitImage, portraitRadio);
 
 		Gtk.CheckButton landscapeRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
 		landscapeRadio.SetGroup (portraitRadio);
@@ -132,9 +124,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			MarginEnd = 7,
 		};
 
-		Gtk.Box landscapeHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		landscapeHbox.Append (landscapeImage);
-		landscapeHbox.Append (landscapeRadio);
+		Gtk.Box landscapeHbox = CreateLandscapeBox (landscapeImage, landscapeRadio);
 
 		// Orientation VBox
 		Gtk.Box orientationVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
@@ -282,6 +272,46 @@ public sealed class NewImageDialog : Gtk.Dialog
 		UpdatePresetSelection ();
 
 		previewBox.Update (NewImageSize, NewImageBackground);
+	}
+
+	private static Gtk.Box CreatePortraitBox (
+		Gtk.Image portraitImage,
+		Gtk.CheckButton portraitRadio)
+	{
+		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		result.Append (portraitImage);
+		result.Append (portraitRadio);
+		return result;
+	}
+
+	private static Gtk.Box CreateLandscapeBox (
+		Gtk.Image landscapeImage,
+		Gtk.CheckButton landscapeRadio)
+	{
+		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		result.Append (landscapeImage);
+		result.Append (landscapeRadio);
+		return result;
+	}
+
+	private static Gtk.Box CreateWidthBox (
+		Gtk.Entry widthEntry,
+		Gtk.Label widthUnitsLabel)
+	{
+		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		result.Append (widthEntry);
+		result.Append (widthUnitsLabel);
+		return result;
+	}
+
+	private static Gtk.Box CreateHeightBox (
+		Gtk.Entry heightEntry,
+		Gtk.Label heightUnitsLabel)
+	{
+		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		result.Append (heightEntry);
+		result.Append (heightUnitsLabel);
+		return result;
 	}
 
 	private static Gtk.Label CreateBackgroundLabel ()

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -125,12 +125,18 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		Gtk.Box hboxTransparent = CreateHorizontalBox (0, imageTransparent, transparentBackgroundRadio);
 
-		Gtk.Box backgroundVbox = CreateVerticalBox (0, backgroundLabel, hboxWhite);
+		IEnumerable<Gtk.Widget> GenerateBackgroundBoxItems ()
+		{
+			yield return backgroundLabel;
+			yield return hboxWhite;
 
-		if (allowBackgroundColor)
-			backgroundVbox.Append (hboxBackground);
+			if (allowBackgroundColor)
+				yield return hboxBackground;
 
-		backgroundVbox.Append (hboxTransparent);
+			yield return hboxTransparent;
+		}
+
+		Gtk.Box backgroundVbox = CreateVerticalBox (0, GenerateBackgroundBoxItems ());
 		backgroundVbox.MarginTop = 4;
 
 		// Layout table for preset, width, and height
@@ -178,7 +184,6 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		if (initialBackgroundType == BackgroundType.White)
 			whiteBackgroundRadio.Active = true;
-
 
 		heightEntry.Buffer!.Text = initialSize.Height.ToString ();
 
@@ -249,7 +254,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 	private static Gtk.Box CreateVerticalBox (
 		int spacing,
-		params Gtk.Widget[] children)
+		IEnumerable<Gtk.Widget> children)
 	{
 		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, spacing);
 
@@ -258,6 +263,14 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		return vbox;
 	}
+
+	private static Gtk.Box CreateVerticalBox (
+		int spacing,
+		params Gtk.Widget[] children
+	)
+		=> CreateVerticalBox (
+			spacing,
+			(IEnumerable<Gtk.Widget>) children);
 
 	private static Gtk.Label CreateUnitsLabel ()
 	{

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -73,9 +73,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		Gtk.Label sizeLabel = CreateSizeLabel ();
 
-		// Preset Combo
 		Gtk.StringList presetDropdownModel = Gtk.StringList.New (GeneratePresetEntries (hasClipboard).ToArray ());
-
 		Gtk.DropDown presetDropdown = Gtk.DropDown.New (presetDropdownModel, expression: null);
 
 		Gtk.Label widthLabel = CreateWidthLabel ();
@@ -91,25 +89,12 @@ public sealed class NewImageDialog : Gtk.Dialog
 		// Orientation Radio options
 		Gtk.Label orientationLabel = CreateOrientationLabel ();
 
-		Gtk.CheckButton portraitRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
-
-		Gtk.Image portraitImage = new () {
-			IconName = Resources.Icons.OrientationPortrait,
-			PixelSize = 16,
-			MarginEnd = 7,
-		};
-
+		Gtk.CheckButton portraitRadio = CreatePortraitRadio ();
+		Gtk.Image portraitImage = CreateOrientationIcon (Resources.Icons.OrientationPortrait);
 		Gtk.Box portraitHbox = CreateHorizontalBox (portraitImage, portraitRadio);
 
-		Gtk.CheckButton landscapeRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
-		landscapeRadio.SetGroup (portraitRadio);
-
-		Gtk.Image landscapeImage = new () {
-			IconName = Resources.Icons.OrientationLandscape,
-			PixelSize = 16,
-			MarginEnd = 7,
-		};
-
+		Gtk.CheckButton landscapeRadio = CreateLandscapeRadio (portraitRadio);
+		Gtk.Image landscapeImage = CreateOrientationIcon (Resources.Icons.OrientationLandscape);
 		Gtk.Box landscapeHbox = CreateHorizontalBox (landscapeImage, landscapeRadio);
 
 		Gtk.Box orientationVbox = CreateVerticalBox (orientationLabel, portraitHbox, landscapeHbox);
@@ -179,9 +164,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			Halign = Gtk.Align.Fill,
 		};
 
-		Gtk.Box previewVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		previewVbox.Append (previewLabel);
-		previewVbox.Append (previewBox);
+		Gtk.Box previewVbox = CreateVerticalBox (previewLabel, previewBox);
 
 		Gtk.Box mainHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
 		mainHbox.Append (optionsVbox);
@@ -281,11 +264,28 @@ public sealed class NewImageDialog : Gtk.Dialog
 		return label;
 	}
 
+	private static Gtk.Image CreateOrientationIcon (string iconName)
+		=> new () {
+			IconName = iconName,
+			PixelSize = 16,
+			MarginEnd = 7,
+		};
+
 	private static Gtk.Entry CreateLengthEntry ()
 		=> new () {
 			WidthRequest = 50,
 			ActivatesDefault = true,
 		};
+
+	private static Gtk.CheckButton CreatePortraitRadio ()
+		=> Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
+
+	private static Gtk.CheckButton CreateLandscapeRadio (Gtk.CheckButton portraitRadio)
+	{
+		Gtk.CheckButton result = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
+		result.SetGroup (portraitRadio);
+		return result;
+	}
 
 	private static Gtk.Label CreateBackgroundLabel ()
 	{

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -72,7 +72,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		// We don't show the background color option if it's the same as "White"
 		allow_background_color = PintaCore.Palette.SecondaryColor.ToColorBgra () != ColorBgra.White;
 
-		var content_area = this.GetContentAreaBox ();
+		Gtk.Box content_area = this.GetContentAreaBox ();
 		content_area.SetAllMargins (8);
 
 		Resizable = false;
@@ -91,17 +91,17 @@ public sealed class NewImageDialog : Gtk.Dialog
 		};
 
 		// Layout table for preset, width, and height
-		var layout_grid = new Gtk.Grid {
+		Gtk.Grid layout_grid = new Gtk.Grid {
 			RowSpacing = 5,
 			ColumnSpacing = 6
 		};
 
 		// Preset Combo
-		var size_label = Gtk.Label.New (Translations.GetString ("Preset:"));
+		Gtk.Label size_label = Gtk.Label.New (Translations.GetString ("Preset:"));
 		size_label.Xalign = 1f;
 		size_label.Yalign = .5f;
 
-		var preset_entries = new List<string> ();
+		List<string> preset_entries = new List<string> ();
 
 		if (has_clipboard)
 			preset_entries.Add (Translations.GetString ("Clipboard"));
@@ -116,7 +116,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layout_grid.Attach (preset_dropdown, 1, 0, 1, 1);
 
 		// Width Entry
-		var width_label = Gtk.Label.New (Translations.GetString ("Width:"));
+		Gtk.Label width_label = Gtk.Label.New (Translations.GetString ("Width:"));
 		width_label.Xalign = 1f;
 		width_label.Yalign = .5f;
 
@@ -125,10 +125,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 			ActivatesDefault = true
 		};
 
-		var width_units = Gtk.Label.New (Translations.GetString ("pixels"));
+		Gtk.Label width_units = Gtk.Label.New (Translations.GetString ("pixels"));
 		width_units.MarginStart = 5;
 
-		var width_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box width_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		width_hbox.Append (width_entry);
 		width_hbox.Append (width_units);
 
@@ -136,7 +136,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layout_grid.Attach (width_hbox, 1, 1, 1, 1);
 
 		// Height Entry
-		var height_label = Gtk.Label.New (Translations.GetString ("Height:"));
+		Gtk.Label height_label = Gtk.Label.New (Translations.GetString ("Height:"));
 		height_label.Xalign = 1f;
 		height_label.Yalign = .5f;
 
@@ -145,10 +145,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 			ActivatesDefault = true
 		};
 
-		var height_units = Gtk.Label.New (Translations.GetString ("pixels"));
+		Gtk.Label height_units = Gtk.Label.New (Translations.GetString ("pixels"));
 		height_units.MarginStart = 5;
 
-		var height_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box height_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		height_hbox.Append (height_entry);
 		height_hbox.Append (height_units);
 
@@ -156,12 +156,12 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layout_grid.Attach (height_hbox, 1, 2, 1, 1);
 
 		// Orientation Radio options
-		var orientation_label = Gtk.Label.New (Translations.GetString ("Orientation:"));
+		Gtk.Label orientation_label = Gtk.Label.New (Translations.GetString ("Orientation:"));
 		orientation_label.Xalign = 0f;
 		orientation_label.Yalign = .5f;
 
 		portrait_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
-		var portrait_image = new Gtk.Image () {
+		Gtk.Image portrait_image = new Gtk.Image () {
 			IconName = Resources.Icons.OrientationPortrait,
 			PixelSize = 16
 		};
@@ -174,34 +174,34 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		landscape_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
 		landscape_radio.SetGroup (portrait_radio);
-		var landscape_image = new Gtk.Image () {
+		Gtk.Image landscape_image = new Gtk.Image () {
 			IconName = Resources.Icons.OrientationLandscape,
 			PixelSize = 16
 		};
 
-		var landscape_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box landscape_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		landscape_image.MarginEnd = 7;
 
 		landscape_hbox.Append (landscape_image);
 		landscape_hbox.Append (landscape_radio);
 
 		// Orientation VBox
-		var orientation_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		Gtk.Box orientation_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		orientation_label.MarginBottom = 4;
 		orientation_vbox.Append (orientation_label);
 		orientation_vbox.Append (portrait_hbox);
 		orientation_vbox.Append (landscape_hbox);
 
 		// Background Color options
-		var background_label = Gtk.Label.New (Translations.GetString ("Background:"));
+		Gtk.Label background_label = Gtk.Label.New (Translations.GetString ("Background:"));
 		background_label.Xalign = 0f;
 		background_label.Yalign = .5f;
 		background_label.MarginBottom = 4;
 
 		white_bg_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("White"));
-		var image_white = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
+		Gtk.Image image_white = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 
-		var hbox_white = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box hbox_white = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		image_white.MarginEnd = 7;
 
 		hbox_white.Append (image_white);
@@ -209,9 +209,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		secondary_bg_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
 		secondary_bg_radio.SetGroup (white_bg_radio);
-		var image_bg = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
+		Gtk.Image image_bg = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
 
-		var hbox_bg = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box hbox_bg = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		image_bg.MarginEnd = 7;
 
 		hbox_bg.Append (image_bg);
@@ -219,16 +219,16 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		trans_bg_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
 		trans_bg_radio.SetGroup (secondary_bg_radio);
-		var image_trans = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
+		Gtk.Image image_trans = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		image_trans.MarginEnd = 7;
 
-		var hbox_trans = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Box hbox_trans = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 
 		hbox_trans.Append (image_trans);
 		hbox_trans.Append (trans_bg_radio);
 
 		// Background VBox
-		var background_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		Gtk.Box background_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		background_vbox.Append (background_label);
 		background_vbox.Append (hbox_white);
 
@@ -238,7 +238,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		background_vbox.Append (hbox_trans);
 
 		// Put all the options together
-		var options_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		Gtk.Box options_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		options_vbox.Spacing = 10;
 
 		layout_grid.MarginBottom = 3;
@@ -253,16 +253,16 @@ public sealed class NewImageDialog : Gtk.Dialog
 			Valign = Gtk.Align.Fill
 		};
 
-		var preview_label = Gtk.Label.New (Translations.GetString ("Preview"));
+		Gtk.Label preview_label = Gtk.Label.New (Translations.GetString ("Preview"));
 
-		var preview_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		Gtk.Box preview_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		preview.Hexpand = true;
 		preview.Halign = Gtk.Align.Fill;
 
 		preview_vbox.Append (preview_label);
 		preview_vbox.Append (preview);
 
-		var main_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
+		Gtk.Box main_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
 		main_hbox.Append (options_vbox);
 		main_hbox.Append (preview_vbox);
 
@@ -324,10 +324,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 	private bool IsValidSize {
 		get {
 
-			if (!int.TryParse (width_entry.Buffer!.Text!, out var width))
+			if (!int.TryParse (width_entry.Buffer!.Text!, out int width))
 				return false;
 
-			if (!int.TryParse (height_entry.Buffer!.Text!, out var height))
+			if (!int.TryParse (height_entry.Buffer!.Text!, out int height))
 				return false;
 
 			return width > 0 && height > 0;
@@ -341,8 +341,8 @@ public sealed class NewImageDialog : Gtk.Dialog
 				return Size.Empty;
 
 			var text_parts = text.Split (' ');
-			var width = int.Parse (text_parts[0]);
-			var height = int.Parse (text_parts[2]);
+			int width = int.Parse (text_parts[0]);
+			int height = int.Parse (text_parts[2]);
 
 			return new Size (width, height);
 		}
@@ -356,7 +356,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			if (args.Pspec.GetName () != "selected")
 				return;
 
-			var new_size = IsValidSize ? NewImageSize : Size.Empty;
+			Size new_size = IsValidSize ? NewImageSize : Size.Empty;
 
 			string? preset_text = preset_dropdown_model.GetString (preset_dropdown.Selected);
 			if (has_clipboard && preset_text == Translations.GetString ("Clipboard"))
@@ -416,7 +416,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		// Handle orientation changes
 		portrait_radio.OnToggled += (o, e) => {
 			if (portrait_radio.Active && IsValidSize && NewImageWidth > NewImageHeight) {
-				var temp = NewImageWidth;
+				int temp = NewImageWidth;
 				width_entry.Buffer!.Text = height_entry.Buffer!.Text;
 				height_entry.Buffer!.Text = temp.ToString ();
 				preview.Update (NewImageSize);
@@ -425,7 +425,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		landscape_radio.OnToggled += (o, e) => {
 			if (landscape_radio.Active && IsValidSize && NewImageWidth < NewImageHeight) {
-				var temp = NewImageWidth;
+				int temp = NewImageWidth;
 				width_entry.Buffer!.Text = height_entry.Buffer!.Text;
 				height_entry.Buffer!.Text = temp.ToString ();
 				preview.Update (NewImageSize);
@@ -446,17 +446,17 @@ public sealed class NewImageDialog : Gtk.Dialog
 			landscape_radio.Activate ();
 
 		for (uint i = 1, n = preset_dropdown_model.GetNItems (); i < n; i++) {
-			var text = preset_dropdown_model.GetString (i)!;
+			string text = preset_dropdown_model.GetString (i)!;
 
 			if (text == Translations.GetString ("Clipboard") || text == Translations.GetString ("Custom"))
 				continue;
 
 			var text_parts = text.Split ('x');
-			var width = int.Parse (text_parts[0].Trim ());
-			var height = int.Parse (text_parts[1].Trim ());
+			int width = int.Parse (text_parts[0].Trim ());
+			int height = int.Parse (text_parts[1].Trim ());
 
-			var new_size = new Size (NewImageWidth < NewImageHeight ? Math.Min (width, height) : Math.Max (width, height), NewImageWidth < NewImageHeight ? Math.Max (width, height) : Math.Min (width, height));
-			var new_text = $"{new_size.Width} x {new_size.Height}";
+			Size new_size = new Size (NewImageWidth < NewImageHeight ? Math.Min (width, height) : Math.Max (width, height), NewImageWidth < NewImageHeight ? Math.Max (width, height) : Math.Min (width, height));
+			string new_text = $"{new_size.Width} x {new_size.Height}";
 
 			if (new_text != text)
 				preset_dropdown_model.Splice (i, 1, new[] { new_text });
@@ -474,7 +474,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		if (!IsValidSize)
 			return;
 
-		var text = $"{NewImageWidth} x {NewImageHeight}";
+		string text = $"{NewImageWidth} x {NewImageHeight}";
 		if (preset_dropdown_model.FindString (text, out uint index) && preset_dropdown.Selected != index) {
 			preset_dropdown.Selected = index;
 		}
@@ -528,7 +528,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			else
 				preview_size = new Size ((int) (MAX_SIZE / (size.Height / (float) size.Width)), MAX_SIZE);
 
-			var r = new RectangleD ((widget_width - preview_size.Width) / 2, (widget_height - preview_size.Height) / 2, preview_size.Width, preview_size.Height);
+			RectangleD r = new RectangleD ((widget_width - preview_size.Width) / 2, (widget_height - preview_size.Height) / 2, preview_size.Width, preview_size.Height);
 
 			if (color.A == 0) {
 				// Fill with transparent checkerboard pattern

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -79,27 +79,13 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.DropDown presetDropdown = Gtk.DropDown.New (presetDropdownModel, expression: null);
 
 		Gtk.Label widthLabel = CreateWidthLabel ();
-
-		Gtk.Entry widthEntry = new () {
-			WidthRequest = 50,
-			ActivatesDefault = true,
-		};
-
-		Gtk.Label widthUnitsLabel = Gtk.Label.New (Translations.GetString ("pixels"));
-		widthUnitsLabel.MarginStart = 5;
-
+		Gtk.Entry widthEntry = CreateLengthEntry ();
+		Gtk.Label widthUnitsLabel = CreateUnitsLabel ();
 		Gtk.Box widthHbox = CreateHorizontalBox (widthEntry, widthUnitsLabel);
 
 		Gtk.Label heightLabel = CreateHeightLabel ();
-
-		Gtk.Entry heightEntry = new () {
-			WidthRequest = 50,
-			ActivatesDefault = true,
-		};
-
-		Gtk.Label heightUnitsLabel = Gtk.Label.New (Translations.GetString ("pixels"));
-		heightUnitsLabel.MarginStart = 5;
-
+		Gtk.Entry heightEntry = CreateLengthEntry ();
+		Gtk.Label heightUnitsLabel = CreateUnitsLabel ();
 		Gtk.Box heightHbox = CreateHorizontalBox (heightEntry, heightUnitsLabel);
 
 		// Orientation Radio options
@@ -287,6 +273,19 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		return vbox;
 	}
+
+	private static Gtk.Label CreateUnitsLabel ()
+	{
+		Gtk.Label label = Gtk.Label.New (Translations.GetString ("pixels"));
+		label.MarginStart = 5;
+		return label;
+	}
+
+	private static Gtk.Entry CreateLengthEntry ()
+		=> new () {
+			WidthRequest = 50,
+			ActivatesDefault = true,
+		};
 
 	private static Gtk.Label CreateBackgroundLabel ()
 	{

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -28,12 +28,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cairo;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta;
 
-public sealed class NewImageDialog : Dialog
+public sealed class NewImageDialog : Gtk.Dialog
 {
 	private readonly bool allow_background_color;
 	private readonly bool has_clipboard;
@@ -45,16 +44,16 @@ public sealed class NewImageDialog : Dialog
 	private readonly PreviewArea preview;
 
 	private readonly Gtk.StringList preset_dropdown_model;
-	private readonly DropDown preset_dropdown;
-	private readonly Entry width_entry;
-	private readonly Entry height_entry;
+	private readonly Gtk.DropDown preset_dropdown;
+	private readonly Gtk.Entry width_entry;
+	private readonly Gtk.Entry height_entry;
 
-	private readonly CheckButton portrait_radio;
-	private readonly CheckButton landscape_radio;
+	private readonly Gtk.CheckButton portrait_radio;
+	private readonly Gtk.CheckButton landscape_radio;
 
-	private readonly CheckButton white_bg_radio;
-	private readonly CheckButton secondary_bg_radio;
-	private readonly CheckButton trans_bg_radio;
+	private readonly Gtk.CheckButton white_bg_radio;
+	private readonly Gtk.CheckButton secondary_bg_radio;
+	private readonly Gtk.CheckButton trans_bg_radio;
 
 	/// <summary>
 	/// Configures and builds a NewImageDialog object.
@@ -68,7 +67,7 @@ public sealed class NewImageDialog : Dialog
 		TransientFor = PintaCore.Chrome.MainWindow;
 		Modal = true;
 		this.AddCancelOkButtons ();
-		this.SetDefaultResponse (ResponseType.Ok);
+		this.SetDefaultResponse (Gtk.ResponseType.Ok);
 
 		// We don't show the background color option if it's the same as "White"
 		allow_background_color = PintaCore.Palette.SecondaryColor.ToColorBgra () != ColorBgra.White;
@@ -92,13 +91,13 @@ public sealed class NewImageDialog : Dialog
 		};
 
 		// Layout table for preset, width, and height
-		var layout_grid = new Grid {
+		var layout_grid = new Gtk.Grid {
 			RowSpacing = 5,
 			ColumnSpacing = 6
 		};
 
 		// Preset Combo
-		var size_label = Label.New (Translations.GetString ("Preset:"));
+		var size_label = Gtk.Label.New (Translations.GetString ("Preset:"));
 		size_label.Xalign = 1f;
 		size_label.Yalign = .5f;
 
@@ -110,26 +109,26 @@ public sealed class NewImageDialog : Dialog
 		preset_entries.Add (Translations.GetString ("Custom"));
 		preset_entries.AddRange (preset_sizes.Select (p => $"{p.Width} x {p.Height}"));
 
-		preset_dropdown_model = StringList.New (preset_entries.ToArray ());
-		preset_dropdown = DropDown.New (preset_dropdown_model, expression: null);
+		preset_dropdown_model = Gtk.StringList.New (preset_entries.ToArray ());
+		preset_dropdown = Gtk.DropDown.New (preset_dropdown_model, expression: null);
 
 		layout_grid.Attach (size_label, 0, 0, 1, 1);
 		layout_grid.Attach (preset_dropdown, 1, 0, 1, 1);
 
 		// Width Entry
-		var width_label = Label.New (Translations.GetString ("Width:"));
+		var width_label = Gtk.Label.New (Translations.GetString ("Width:"));
 		width_label.Xalign = 1f;
 		width_label.Yalign = .5f;
 
-		width_entry = new Entry {
+		width_entry = new Gtk.Entry {
 			WidthRequest = 50,
 			ActivatesDefault = true
 		};
 
-		var width_units = Label.New (Translations.GetString ("pixels"));
+		var width_units = Gtk.Label.New (Translations.GetString ("pixels"));
 		width_units.MarginStart = 5;
 
-		var width_hbox = Box.New (Orientation.Horizontal, 0);
+		var width_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		width_hbox.Append (width_entry);
 		width_hbox.Append (width_units);
 
@@ -137,19 +136,19 @@ public sealed class NewImageDialog : Dialog
 		layout_grid.Attach (width_hbox, 1, 1, 1, 1);
 
 		// Height Entry
-		var height_label = Label.New (Translations.GetString ("Height:"));
+		var height_label = Gtk.Label.New (Translations.GetString ("Height:"));
 		height_label.Xalign = 1f;
 		height_label.Yalign = .5f;
 
-		height_entry = new Entry {
+		height_entry = new Gtk.Entry {
 			WidthRequest = 50,
 			ActivatesDefault = true
 		};
 
-		var height_units = Label.New (Translations.GetString ("pixels"));
+		var height_units = Gtk.Label.New (Translations.GetString ("pixels"));
 		height_units.MarginStart = 5;
 
-		var height_hbox = Box.New (Orientation.Horizontal, 0);
+		var height_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		height_hbox.Append (height_entry);
 		height_hbox.Append (height_units);
 
@@ -157,79 +156,79 @@ public sealed class NewImageDialog : Dialog
 		layout_grid.Attach (height_hbox, 1, 2, 1, 1);
 
 		// Orientation Radio options
-		var orientation_label = Label.New (Translations.GetString ("Orientation:"));
+		var orientation_label = Gtk.Label.New (Translations.GetString ("Orientation:"));
 		orientation_label.Xalign = 0f;
 		orientation_label.Yalign = .5f;
 
-		portrait_radio = CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
-		var portrait_image = new Image () {
+		portrait_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
+		var portrait_image = new Gtk.Image () {
 			IconName = Resources.Icons.OrientationPortrait,
 			PixelSize = 16
 		};
 
-		var portrait_hbox = Box.New (Orientation.Horizontal, 0);
+		var portrait_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		portrait_image.MarginEnd = 7;
 
 		portrait_hbox.Append (portrait_image);
 		portrait_hbox.Append (portrait_radio);
 
-		landscape_radio = CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
+		landscape_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
 		landscape_radio.SetGroup (portrait_radio);
-		var landscape_image = new Image () {
+		var landscape_image = new Gtk.Image () {
 			IconName = Resources.Icons.OrientationLandscape,
 			PixelSize = 16
 		};
 
-		var landscape_hbox = Box.New (Orientation.Horizontal, 0);
+		var landscape_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		landscape_image.MarginEnd = 7;
 
 		landscape_hbox.Append (landscape_image);
 		landscape_hbox.Append (landscape_radio);
 
 		// Orientation VBox
-		var orientation_vbox = Box.New (Orientation.Vertical, 0);
+		var orientation_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		orientation_label.MarginBottom = 4;
 		orientation_vbox.Append (orientation_label);
 		orientation_vbox.Append (portrait_hbox);
 		orientation_vbox.Append (landscape_hbox);
 
 		// Background Color options
-		var background_label = Label.New (Translations.GetString ("Background:"));
+		var background_label = Gtk.Label.New (Translations.GetString ("Background:"));
 		background_label.Xalign = 0f;
 		background_label.Yalign = .5f;
 		background_label.MarginBottom = 4;
 
-		white_bg_radio = CheckButton.NewWithLabel (Translations.GetString ("White"));
-		var image_white = Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
+		white_bg_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("White"));
+		var image_white = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 
-		var hbox_white = Box.New (Orientation.Horizontal, 0);
+		var hbox_white = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		image_white.MarginEnd = 7;
 
 		hbox_white.Append (image_white);
 		hbox_white.Append (white_bg_radio);
 
-		secondary_bg_radio = CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
+		secondary_bg_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
 		secondary_bg_radio.SetGroup (white_bg_radio);
-		var image_bg = Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
+		var image_bg = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
 
-		var hbox_bg = Box.New (Orientation.Horizontal, 0);
+		var hbox_bg = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		image_bg.MarginEnd = 7;
 
 		hbox_bg.Append (image_bg);
 		hbox_bg.Append (secondary_bg_radio);
 
-		trans_bg_radio = CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
+		trans_bg_radio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
 		trans_bg_radio.SetGroup (secondary_bg_radio);
-		var image_trans = Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
+		var image_trans = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		image_trans.MarginEnd = 7;
 
-		var hbox_trans = Box.New (Orientation.Horizontal, 0);
+		var hbox_trans = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 
 		hbox_trans.Append (image_trans);
 		hbox_trans.Append (trans_bg_radio);
 
 		// Background VBox
-		var background_vbox = Box.New (Orientation.Vertical, 0);
+		var background_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		background_vbox.Append (background_label);
 		background_vbox.Append (hbox_white);
 
@@ -239,7 +238,7 @@ public sealed class NewImageDialog : Dialog
 		background_vbox.Append (hbox_trans);
 
 		// Put all the options together
-		var options_vbox = Box.New (Orientation.Vertical, 0);
+		var options_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		options_vbox.Spacing = 10;
 
 		layout_grid.MarginBottom = 3;
@@ -251,19 +250,19 @@ public sealed class NewImageDialog : Dialog
 		// Layout the preview + the options
 		preview = new PreviewArea {
 			Vexpand = true,
-			Valign = Align.Fill
+			Valign = Gtk.Align.Fill
 		};
 
-		var preview_label = Label.New (Translations.GetString ("Preview"));
+		var preview_label = Gtk.Label.New (Translations.GetString ("Preview"));
 
-		var preview_vbox = Box.New (Orientation.Vertical, 0);
+		var preview_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 		preview.Hexpand = true;
-		preview.Halign = Align.Fill;
+		preview.Halign = Gtk.Align.Fill;
 
 		preview_vbox.Append (preview_label);
 		preview_vbox.Append (preview);
 
-		var main_hbox = Box.New (Orientation.Horizontal, 10);
+		var main_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
 		main_hbox.Append (options_vbox);
 		main_hbox.Append (preview_vbox);
 
@@ -466,7 +465,7 @@ public sealed class NewImageDialog : Dialog
 
 	private void UpdateOkButton ()
 	{
-		var button = GetWidgetForResponse ((int) ResponseType.Ok)!;
+		var button = GetWidgetForResponse ((int) Gtk.ResponseType.Ok)!;
 		button.Sensitive = IsValidSize;
 	}
 
@@ -481,7 +480,7 @@ public sealed class NewImageDialog : Dialog
 		}
 	}
 
-	private sealed class PreviewArea : DrawingArea
+	private sealed class PreviewArea : Gtk.DrawingArea
 	{
 		private Size size;
 		private Cairo.Color color;

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -88,7 +88,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label widthUnitsLabel = Gtk.Label.New (Translations.GetString ("pixels"));
 		widthUnitsLabel.MarginStart = 5;
 
-		Gtk.Box widthHbox = CreateWidthBox (widthEntry, widthUnitsLabel);
+		Gtk.Box widthHbox = CreateHorizontalBox (widthEntry, widthUnitsLabel);
 
 		Gtk.Label heightLabel = CreateHeightLabel ();
 
@@ -100,7 +100,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label heightUnitsLabel = Gtk.Label.New (Translations.GetString ("pixels"));
 		heightUnitsLabel.MarginStart = 5;
 
-		Gtk.Box heightHbox = CreateHeightBox (heightEntry, heightUnitsLabel);
+		Gtk.Box heightHbox = CreateHorizontalBox (heightEntry, heightUnitsLabel);
 
 		// Orientation Radio options
 		Gtk.Label orientationLabel = CreateOrientationLabel ();
@@ -113,7 +113,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			MarginEnd = 7,
 		};
 
-		Gtk.Box portraitHbox = CreatePortraitBox (portraitImage, portraitRadio);
+		Gtk.Box portraitHbox = CreateHorizontalBox (portraitImage, portraitRadio);
 
 		Gtk.CheckButton landscapeRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
 		landscapeRadio.SetGroup (portraitRadio);
@@ -124,13 +124,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 			MarginEnd = 7,
 		};
 
-		Gtk.Box landscapeHbox = CreateLandscapeBox (landscapeImage, landscapeRadio);
+		Gtk.Box landscapeHbox = CreateHorizontalBox (landscapeImage, landscapeRadio);
 
-		// Orientation VBox
-		Gtk.Box orientationVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		orientationVbox.Append (orientationLabel);
-		orientationVbox.Append (portraitHbox);
-		orientationVbox.Append (landscapeHbox);
+		Gtk.Box orientationVbox = CreateVerticalBox (orientationLabel, portraitHbox, landscapeHbox);
 
 		// Background Color options
 		Gtk.Label backgroundLabel = CreateBackgroundLabel ();
@@ -140,9 +136,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageWhite = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 		imageWhite.MarginEnd = 7;
 
-		Gtk.Box hboxWhite = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		hboxWhite.Append (imageWhite);
-		hboxWhite.Append (whiteBackgroundRadio);
+		Gtk.Box hboxWhite = CreateHorizontalBox (imageWhite, whiteBackgroundRadio);
 
 		Gtk.CheckButton secondaryBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
 		secondaryBackgroundRadio.SetGroup (whiteBackgroundRadio);
@@ -150,9 +144,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
 		imageBackground.MarginEnd = 7;
 
-		Gtk.Box hboxBackground = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		hboxBackground.Append (imageBackground);
-		hboxBackground.Append (secondaryBackgroundRadio);
+		Gtk.Box hboxBackground = CreateHorizontalBox (imageBackground, secondaryBackgroundRadio);
 
 		Gtk.CheckButton transparentBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
 		transparentBackgroundRadio.SetGroup (secondaryBackgroundRadio);
@@ -160,13 +152,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageTransparent = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		imageTransparent.MarginEnd = 7;
 
-		Gtk.Box hboxTransparent = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		hboxTransparent.Append (imageTransparent);
-		hboxTransparent.Append (transparentBackgroundRadio);
+		Gtk.Box hboxTransparent = CreateHorizontalBox (imageTransparent, transparentBackgroundRadio);
 
-		Gtk.Box backgroundVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		backgroundVbox.Append (backgroundLabel);
-		backgroundVbox.Append (hboxWhite);
+		Gtk.Box backgroundVbox = CreateVerticalBox (backgroundLabel, hboxWhite);
 
 		if (allowBackgroundColor)
 			backgroundVbox.Append (hboxBackground);
@@ -274,44 +262,30 @@ public sealed class NewImageDialog : Gtk.Dialog
 		previewBox.Update (NewImageSize, NewImageBackground);
 	}
 
-	private static Gtk.Box CreatePortraitBox (
-		Gtk.Image portraitImage,
-		Gtk.CheckButton portraitRadio)
+	private static Gtk.Box CreateHorizontalBox (Gtk.Widget w1, Gtk.Widget w2)
 	{
-		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		result.Append (portraitImage);
-		result.Append (portraitRadio);
-		return result;
+		Gtk.Box hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		hbox.Append (w1);
+		hbox.Append (w2);
+		return hbox;
 	}
 
-	private static Gtk.Box CreateLandscapeBox (
-		Gtk.Image landscapeImage,
-		Gtk.CheckButton landscapeRadio)
+	private static Gtk.Box CreateVerticalBox (Gtk.Widget w1, Gtk.Widget w2)
 	{
-		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		result.Append (landscapeImage);
-		result.Append (landscapeRadio);
-		return result;
+		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		vbox.Append (w1);
+		vbox.Append (w2);
+		return vbox;
 	}
 
-	private static Gtk.Box CreateWidthBox (
-		Gtk.Entry widthEntry,
-		Gtk.Label widthUnitsLabel)
+	private static Gtk.Box CreateVerticalBox (params Gtk.Widget[] children)
 	{
-		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		result.Append (widthEntry);
-		result.Append (widthUnitsLabel);
-		return result;
-	}
+		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
 
-	private static Gtk.Box CreateHeightBox (
-		Gtk.Entry heightEntry,
-		Gtk.Label heightUnitsLabel)
-	{
-		Gtk.Box result = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		result.Append (heightEntry);
-		result.Append (heightUnitsLabel);
-		return result;
+		foreach (var child in children)
+			vbox.Append (child);
+
+		return vbox;
 	}
 
 	private static Gtk.Label CreateBackgroundLabel ()

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -60,8 +60,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 	/// <param name="imgHeight">Initial value of the height entry.</param>
 	/// <param name="isClipboardSize">Indicates if there is an image on the clipboard (and the size parameters represent the clipboard image size).</param>
 	public NewImageDialog (
-		int initialWidth,
-		int initialHeight,
+		Size initialSize,
 		BackgroundType initialBackgroundType,
 		bool isClipboardSize)
 	{
@@ -252,9 +251,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 			whiteBackgroundRadio.Active = true;
 
 
-		heightEntry.Buffer!.Text = initialHeight.ToString ();
+		heightEntry.Buffer!.Text = initialSize.Height.ToString ();
 
-		widthEntry.Buffer!.Text = initialWidth.ToString ();
+		widthEntry.Buffer!.Text = initialSize.Width.ToString ();
 		widthEntry.GrabFocus ();
 		widthEntry.SelectRegion (0, (int) widthEntry.TextLength);
 
@@ -274,7 +273,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		// --- References to keep
 
 		has_clipboard = hasClipboard;
-		clipboard_size = new Size (initialWidth, initialHeight);
+		clipboard_size = initialSize;
 		preset_dropdown_model = presetDropdownModel;
 		preset_dropdown = presetDropdown;
 		width_entry = widthEntry;

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -59,145 +59,96 @@ public sealed class NewImageDialog : Gtk.Dialog
 	/// <param name="imgWidth">Initial value of the width entry.</param>
 	/// <param name="imgHeight">Initial value of the height entry.</param>
 	/// <param name="isClipboardSize">Indicates if there is an image on the clipboard (and the size parameters represent the clipboard image size).</param>
-	public NewImageDialog (int initialWidth, int initialHeight, BackgroundType initial_bg_type, bool isClipboardSize)
+	public NewImageDialog (
+		int initialWidth,
+		int initialHeight,
+		BackgroundType initialBackgroundType,
+		bool isClipboardSize)
 	{
-		Title = Translations.GetString ("New Image");
-		TransientFor = PintaCore.Chrome.MainWindow;
-		Modal = true;
-		this.AddCancelOkButtons ();
-		this.SetDefaultResponse (Gtk.ResponseType.Ok);
-
 		// We don't show the background color option if it's the same as "White"
 		bool allowBackgroundColor = PintaCore.Palette.SecondaryColor.ToColorBgra () != ColorBgra.White;
 
-		Gtk.Box contentArea = this.GetContentAreaBox ();
-		contentArea.SetAllMargins (8);
-
-		Resizable = false;
-
-		IconName = Resources.StandardIcons.DocumentNew;
-
 		bool hasClipboard = isClipboardSize;
-		has_clipboard = hasClipboard;
-		clipboard_size = new Size (initialWidth, initialHeight);
-
-		// Some arbitrary presets
-		IReadOnlyList<Size> presetSizes = new Size[] {
-			new (640, 480),
-			new (800, 600),
-			new (1024, 768),
-			new (1600, 1200),
-		};
-
-		// Layout table for preset, width, and height
-		Gtk.Grid layout_grid = new () {
-			RowSpacing = 5,
-			ColumnSpacing = 6
-		};
 
 		// Preset Combo
 		Gtk.Label sizeLabel = Gtk.Label.New (Translations.GetString ("Preset:"));
 		sizeLabel.Xalign = 1f;
 		sizeLabel.Yalign = .5f;
 
-		List<string> presetEntries = new ();
-
-		if (hasClipboard)
-			presetEntries.Add (Translations.GetString ("Clipboard"));
-
-		presetEntries.Add (Translations.GetString ("Custom"));
-		presetEntries.AddRange (presetSizes.Select (p => $"{p.Width} x {p.Height}"));
-
-		Gtk.StringList presetDropdownModel = Gtk.StringList.New (presetEntries.ToArray ());
-		preset_dropdown_model = presetDropdownModel;
+		Gtk.StringList presetDropdownModel = Gtk.StringList.New (GeneratePresetEntries (hasClipboard).ToArray ());
 
 		Gtk.DropDown presetDropdown = Gtk.DropDown.New (presetDropdownModel, expression: null);
-		preset_dropdown = presetDropdown;
-
-		layout_grid.Attach (sizeLabel, 0, 0, 1, 1);
-		layout_grid.Attach (presetDropdown, 1, 0, 1, 1);
 
 		// Width Entry
-		Gtk.Label width_label = Gtk.Label.New (Translations.GetString ("Width:"));
-		width_label.Xalign = 1f;
-		width_label.Yalign = .5f;
+		Gtk.Label widthLabel = Gtk.Label.New (Translations.GetString ("Width:"));
+		widthLabel.Xalign = 1f;
+		widthLabel.Yalign = .5f;
 
-		Gtk.Entry widthEntry = new Gtk.Entry () {
+		Gtk.Entry widthEntry = new () {
 			WidthRequest = 50,
 			ActivatesDefault = true
 		};
-		width_entry = widthEntry;
 
 		Gtk.Label widthUnits = Gtk.Label.New (Translations.GetString ("pixels"));
 		widthUnits.MarginStart = 5;
 
-		Gtk.Box width_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		width_hbox.Append (widthEntry);
-		width_hbox.Append (widthUnits);
-
-		layout_grid.Attach (width_label, 0, 1, 1, 1);
-		layout_grid.Attach (width_hbox, 1, 1, 1, 1);
+		Gtk.Box widthHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		widthHbox.Append (widthEntry);
+		widthHbox.Append (widthUnits);
 
 		// Height Entry
-		Gtk.Label height_label = Gtk.Label.New (Translations.GetString ("Height:"));
-		height_label.Xalign = 1f;
-		height_label.Yalign = .5f;
+		Gtk.Label heightLabel = Gtk.Label.New (Translations.GetString ("Height:"));
+		heightLabel.Xalign = 1f;
+		heightLabel.Yalign = .5f;
 
-		Gtk.Entry heightEntry = new Gtk.Entry () {
+		Gtk.Entry heightEntry = new () {
 			WidthRequest = 50,
 			ActivatesDefault = true
 		};
-		height_entry = heightEntry;
 
 		Gtk.Label heightUnits = Gtk.Label.New (Translations.GetString ("pixels"));
 		heightUnits.MarginStart = 5;
 
-		Gtk.Box height_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		height_hbox.Append (heightEntry);
-		height_hbox.Append (heightUnits);
-
-		layout_grid.Attach (height_label, 0, 2, 1, 1);
-		layout_grid.Attach (height_hbox, 1, 2, 1, 1);
+		Gtk.Box heightHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		heightHbox.Append (heightEntry);
+		heightHbox.Append (heightUnits);
 
 		// Orientation Radio options
-		Gtk.Label orientation_label = Gtk.Label.New (Translations.GetString ("Orientation:"));
-		orientation_label.Xalign = 0f;
-		orientation_label.Yalign = .5f;
+		Gtk.Label orientationLabel = Gtk.Label.New (Translations.GetString ("Orientation:"));
+		orientationLabel.Xalign = 0f;
+		orientationLabel.Yalign = .5f;
 
 		Gtk.CheckButton portraitRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
-		portrait_radio = portraitRadio;
 
-		Gtk.Image portrait_image = new () {
+		Gtk.Image portraitImage = new () {
 			IconName = Resources.Icons.OrientationPortrait,
-			PixelSize = 16
+			PixelSize = 16,
+			MarginEnd = 7,
 		};
 
-		Gtk.Box portrait_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		portrait_image.MarginEnd = 7;
-
-		portrait_hbox.Append (portrait_image);
-		portrait_hbox.Append (portraitRadio);
+		Gtk.Box portraitHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		portraitHbox.Append (portraitImage);
+		portraitHbox.Append (portraitRadio);
 
 		Gtk.CheckButton landscapeRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Landscape"));
-		landscape_radio = landscapeRadio;
 		landscapeRadio.SetGroup (portraitRadio);
-		Gtk.Image landscape_image = new () {
+
+		Gtk.Image landscapeImage = new () {
 			IconName = Resources.Icons.OrientationLandscape,
-			PixelSize = 16
+			PixelSize = 16,
+			MarginEnd = 7,
 		};
 
 		Gtk.Box landscape_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		landscape_image.MarginEnd = 7;
-
-		landscape_hbox.Append (landscape_image);
+		landscape_hbox.Append (landscapeImage);
 		landscape_hbox.Append (landscapeRadio);
 
 		// Orientation VBox
-		Gtk.Box orientation_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		orientation_label.MarginBottom = 4;
-		orientation_vbox.Append (orientation_label);
-		orientation_vbox.Append (portrait_hbox);
-		orientation_vbox.Append (landscape_hbox);
+		Gtk.Box orientationVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		orientationLabel.MarginBottom = 4;
+		orientationVbox.Append (orientationLabel);
+		orientationVbox.Append (portraitHbox);
+		orientationVbox.Append (landscape_hbox);
 
 		// Background Color options
 		Gtk.Label background_label = Gtk.Label.New (Translations.GetString ("Background:"));
@@ -206,97 +157,160 @@ public sealed class NewImageDialog : Gtk.Dialog
 		background_label.MarginBottom = 4;
 
 		Gtk.CheckButton whiteBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("White"));
-		white_background_radio = whiteBackgroundRadio;
-		Gtk.Image image_white = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 
-		Gtk.Box hbox_white = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		image_white.MarginEnd = 7;
+		Gtk.Image imageWhite = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
+		imageWhite.MarginEnd = 7;
 
-		hbox_white.Append (image_white);
-		hbox_white.Append (whiteBackgroundRadio);
+		Gtk.Box hboxWhite = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		hboxWhite.Append (imageWhite);
+		hboxWhite.Append (whiteBackgroundRadio);
 
 		Gtk.CheckButton secondaryBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
-		secondary_background_radio = secondaryBackgroundRadio;
 		secondaryBackgroundRadio.SetGroup (whiteBackgroundRadio);
-		Gtk.Image image_bg = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
 
-		Gtk.Box hbox_bg = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		image_bg.MarginEnd = 7;
+		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
 
-		hbox_bg.Append (image_bg);
-		hbox_bg.Append (secondaryBackgroundRadio);
+		Gtk.Box hboxBackground = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		imageBackground.MarginEnd = 7;
+
+		hboxBackground.Append (imageBackground);
+		hboxBackground.Append (secondaryBackgroundRadio);
 
 		Gtk.CheckButton transparentBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
-		transparent_background_radio = transparentBackgroundRadio;
 		transparentBackgroundRadio.SetGroup (secondaryBackgroundRadio);
-		Gtk.Image image_trans = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
-		image_trans.MarginEnd = 7;
 
-		Gtk.Box hbox_trans = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		Gtk.Image imageTransparent = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
+		imageTransparent.MarginEnd = 7;
 
-		hbox_trans.Append (image_trans);
-		hbox_trans.Append (transparentBackgroundRadio);
+		Gtk.Box hboxTransparent = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		hboxTransparent.Append (imageTransparent);
+		hboxTransparent.Append (transparentBackgroundRadio);
 
-		// Background VBox
-		Gtk.Box background_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		background_vbox.Append (background_label);
-		background_vbox.Append (hbox_white);
+		Gtk.Box backgroundVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		backgroundVbox.Append (background_label);
+		backgroundVbox.Append (hboxWhite);
 
 		if (allowBackgroundColor)
-			background_vbox.Append (hbox_bg);
+			backgroundVbox.Append (hboxBackground);
 
-		background_vbox.Append (hbox_trans);
+		backgroundVbox.Append (hboxTransparent);
+		backgroundVbox.MarginTop = 4;
+
+		// Layout table for preset, width, and height
+		Gtk.Grid layoutGrid = new () {
+			RowSpacing = 5,
+			ColumnSpacing = 6,
+			MarginBottom = 3,
+		};
+		layoutGrid.Attach (sizeLabel, 0, 0, 1, 1);
+		layoutGrid.Attach (presetDropdown, 1, 0, 1, 1);
+		layoutGrid.Attach (widthLabel, 0, 1, 1, 1);
+		layoutGrid.Attach (widthHbox, 1, 1, 1, 1);
+		layoutGrid.Attach (heightLabel, 0, 2, 1, 1);
+		layoutGrid.Attach (heightHbox, 1, 2, 1, 1);
 
 		// Put all the options together
-		Gtk.Box options_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		options_vbox.Spacing = 10;
-
-		layout_grid.MarginBottom = 3;
-		background_vbox.MarginTop = 4;
-		options_vbox.Append (layout_grid);
-		options_vbox.Append (orientation_vbox);
-		options_vbox.Append (background_vbox);
+		Gtk.Box optionsVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		optionsVbox.Spacing = 10;
+		optionsVbox.Append (layoutGrid);
+		optionsVbox.Append (orientationVbox);
+		optionsVbox.Append (backgroundVbox);
 
 		// Layout the preview + the options
-		PreviewArea previewBox = new PreviewArea () {
+
+		Gtk.Label previewLabel = Gtk.Label.New (Translations.GetString ("Preview"));
+
+		PreviewArea previewBox = new () {
 			Vexpand = true,
-			Valign = Gtk.Align.Fill
+			Valign = Gtk.Align.Fill,
+			Hexpand = true,
+			Halign = Gtk.Align.Fill,
 		};
-		preview_box = previewBox;
 
-		Gtk.Label preview_label = Gtk.Label.New (Translations.GetString ("Preview"));
+		Gtk.Box previewVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
+		previewVbox.Append (previewLabel);
+		previewVbox.Append (previewBox);
 
-		Gtk.Box preview_vbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		previewBox.Hexpand = true;
-		previewBox.Halign = Gtk.Align.Fill;
+		Gtk.Box mainHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
+		mainHbox.Append (optionsVbox);
+		mainHbox.Append (previewVbox);
 
-		preview_vbox.Append (preview_label);
-		preview_vbox.Append (previewBox);
+		Gtk.Box contentArea = this.GetContentAreaBox ();
+		contentArea.SetAllMargins (8);
+		contentArea.Append (mainHbox);
 
-		Gtk.Box main_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 10);
-		main_hbox.Append (options_vbox);
-		main_hbox.Append (preview_vbox);
-
-		contentArea.Append (main_hbox);
-
-		if (initial_bg_type == BackgroundType.SecondaryColor && allowBackgroundColor)
+		if (initialBackgroundType == BackgroundType.SecondaryColor && allowBackgroundColor)
 			secondaryBackgroundRadio.Active = true;
-		else if (initial_bg_type == BackgroundType.Transparent)
+
+		if (initialBackgroundType == BackgroundType.Transparent)
 			transparentBackgroundRadio.Active = true;
-		else
+
+		if (initialBackgroundType == BackgroundType.White)
 			whiteBackgroundRadio.Active = true;
 
-		widthEntry.Buffer!.Text = initialWidth.ToString ();
+
 		heightEntry.Buffer!.Text = initialHeight.ToString ();
 
+		widthEntry.Buffer!.Text = initialWidth.ToString ();
 		widthEntry.GrabFocus ();
 		widthEntry.SelectRegion (0, (int) widthEntry.TextLength);
+
+		// --- Initialization (Gtk.Window)
+
+		Title = Translations.GetString ("New Image");
+		TransientFor = PintaCore.Chrome.MainWindow;
+		Modal = true;
+		Resizable = false;
+		IconName = Resources.StandardIcons.DocumentNew;
+
+		// --- Initialization (Gtk.Dialog)
+
+		this.AddCancelOkButtons ();
+		this.SetDefaultResponse (Gtk.ResponseType.Ok);
+
+		// --- References to keep
+
+		has_clipboard = hasClipboard;
+		clipboard_size = new Size (initialWidth, initialHeight);
+		preset_dropdown_model = presetDropdownModel;
+		preset_dropdown = presetDropdown;
+		width_entry = widthEntry;
+		height_entry = heightEntry;
+		portrait_radio = portraitRadio;
+		landscape_radio = landscapeRadio;
+		white_background_radio = whiteBackgroundRadio;
+		secondary_background_radio = secondaryBackgroundRadio;
+		transparent_background_radio = transparentBackgroundRadio;
+		preview_box = previewBox;
+
+		// --- TODO: Refactor this post-initialization
 
 		WireUpEvents ();
 
 		UpdateOrientation ();
+
 		UpdatePresetSelection ();
+
 		previewBox.Update (NewImageSize, NewImageBackground);
+	}
+
+	// Some arbitrary presets
+	private static readonly IReadOnlyList<Size> preset_sizes = new Size[] {
+		new (640, 480),
+		new (800, 600),
+		new (1024, 768),
+		new (1600, 1200),
+	};
+
+	private static IEnumerable<string> GeneratePresetEntries (bool hasClipboard)
+	{
+		if (hasClipboard)
+			yield return Translations.GetString ("Clipboard");
+
+		yield return Translations.GetString ("Custom");
+
+		foreach (Size p in preset_sizes)
+			yield return $"{p.Width} x {p.Height}";
 	}
 
 	public int NewImageWidth

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -65,6 +65,8 @@ public sealed class NewImageDialog : Gtk.Dialog
 		BackgroundType initialBackgroundType,
 		bool isClipboardSize)
 	{
+		// --- Control creation
+
 		// We don't show the background color option if it's the same as "White"
 		bool allowBackgroundColor = PintaCore.Palette.SecondaryColor.ToColorBgra () != ColorBgra.White;
 
@@ -117,6 +119,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label orientationLabel = Gtk.Label.New (Translations.GetString ("Orientation:"));
 		orientationLabel.Xalign = 0f;
 		orientationLabel.Yalign = .5f;
+		orientationLabel.MarginBottom = 4;
 
 		Gtk.CheckButton portraitRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Portrait"));
 
@@ -139,22 +142,21 @@ public sealed class NewImageDialog : Gtk.Dialog
 			MarginEnd = 7,
 		};
 
-		Gtk.Box landscape_hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
-		landscape_hbox.Append (landscapeImage);
-		landscape_hbox.Append (landscapeRadio);
+		Gtk.Box landscapeHbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
+		landscapeHbox.Append (landscapeImage);
+		landscapeHbox.Append (landscapeRadio);
 
 		// Orientation VBox
 		Gtk.Box orientationVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		orientationLabel.MarginBottom = 4;
 		orientationVbox.Append (orientationLabel);
 		orientationVbox.Append (portraitHbox);
-		orientationVbox.Append (landscape_hbox);
+		orientationVbox.Append (landscapeHbox);
 
 		// Background Color options
-		Gtk.Label background_label = Gtk.Label.New (Translations.GetString ("Background:"));
-		background_label.Xalign = 0f;
-		background_label.Yalign = .5f;
-		background_label.MarginBottom = 4;
+		Gtk.Label backgroundLabel = Gtk.Label.New (Translations.GetString ("Background:"));
+		backgroundLabel.Xalign = 0f;
+		backgroundLabel.Yalign = .5f;
+		backgroundLabel.MarginBottom = 4;
 
 		Gtk.CheckButton whiteBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("White"));
 
@@ -169,10 +171,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 		secondaryBackgroundRadio.SetGroup (whiteBackgroundRadio);
 
 		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, PintaCore.Palette.SecondaryColor).ToPixbuf ());
-
-		Gtk.Box hboxBackground = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		imageBackground.MarginEnd = 7;
 
+		Gtk.Box hboxBackground = Gtk.Box.New (Gtk.Orientation.Horizontal, 0);
 		hboxBackground.Append (imageBackground);
 		hboxBackground.Append (secondaryBackgroundRadio);
 
@@ -187,7 +188,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		hboxTransparent.Append (transparentBackgroundRadio);
 
 		Gtk.Box backgroundVbox = Gtk.Box.New (Gtk.Orientation.Vertical, 0);
-		backgroundVbox.Append (background_label);
+		backgroundVbox.Append (backgroundLabel);
 		backgroundVbox.Append (hboxWhite);
 
 		if (allowBackgroundColor)
@@ -238,6 +239,8 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Box contentArea = this.GetContentAreaBox ();
 		contentArea.SetAllMargins (8);
 		contentArea.Append (mainHbox);
+
+		// --- Sub-component post-initialization
 
 		if (initialBackgroundType == BackgroundType.SecondaryColor && allowBackgroundColor)
 			secondaryBackgroundRadio.Active = true;
@@ -326,7 +329,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 	{
 		White,
 		Transparent,
-		SecondaryColor
+		SecondaryColor,
 	}
 
 	public BackgroundType NewImageBackgroundType {
@@ -340,15 +343,12 @@ public sealed class NewImageDialog : Gtk.Dialog
 		}
 	}
 
-	public Cairo.Color NewImageBackground {
-		get {
-			return NewImageBackgroundType switch {
-				BackgroundType.White => new Cairo.Color (1, 1, 1),
-				BackgroundType.Transparent => new Cairo.Color (1, 1, 1, 0),
-				_ => PintaCore.Palette.SecondaryColor,
-			};
-		}
-	}
+	public Cairo.Color NewImageBackground =>
+		NewImageBackgroundType switch {
+			BackgroundType.White => new Cairo.Color (1, 1, 1),
+			BackgroundType.Transparent => new Cairo.Color (1, 1, 1, 0),
+			_ => PintaCore.Palette.SecondaryColor,
+		};
 
 
 	private bool IsValidSize {
@@ -370,9 +370,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 			if (text == Translations.GetString ("Clipboard") || text == Translations.GetString ("Custom"))
 				return Size.Empty;
 
-			var text_parts = text.Split (' ');
-			int width = int.Parse (text_parts[0]);
-			int height = int.Parse (text_parts[2]);
+			var textParts = text.Split (' ');
+			int width = int.Parse (textParts[0]);
+			int height = int.Parse (textParts[2]);
 
 			return new (width, height);
 		}
@@ -481,15 +481,15 @@ public sealed class NewImageDialog : Gtk.Dialog
 			if (text == Translations.GetString ("Clipboard") || text == Translations.GetString ("Custom"))
 				continue;
 
-			var text_parts = text.Split ('x');
-			int width = int.Parse (text_parts[0].Trim ());
-			int height = int.Parse (text_parts[1].Trim ());
+			var textParts = text.Split ('x');
+			int width = int.Parse (textParts[0].Trim ());
+			int height = int.Parse (textParts[1].Trim ());
 
-			Size new_size = new (NewImageWidth < NewImageHeight ? Math.Min (width, height) : Math.Max (width, height), NewImageWidth < NewImageHeight ? Math.Max (width, height) : Math.Min (width, height));
-			string new_text = $"{new_size.Width} x {new_size.Height}";
+			Size newSize = new (NewImageWidth < NewImageHeight ? Math.Min (width, height) : Math.Max (width, height), NewImageWidth < NewImageHeight ? Math.Max (width, height) : Math.Min (width, height));
+			string newText = $"{newSize.Width} x {newSize.Height}";
 
-			if (new_text != text)
-				preset_dropdown_model.Splice (i, 1, new[] { new_text });
+			if (newText != text)
+				preset_dropdown_model.Splice (i, 1, new[] { newText });
 		}
 	}
 


### PR DESCRIPTION
I've identified some patterns used in the creation of dialogs, which I've abstracted into methods. I plan to move these methods to `GtkExtensions` (or some other class, as appropriate) in a future pull request, and then get other dialog classes to use them. The end goal would be having a convenient way to lay items out and effortlessly have a consistent visual style throughout the application.