### PR TITLE
Added blend op choices property to `CloudsEffect`, and corrected behavior in `MemberReflector`

### DIFF
--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -247,7 +247,10 @@ public sealed class CloudsEffect : BaseEffect
 		[Caption ("Power"), MinimumValue (0), MaximumValue (100)]
 		public int Power { get; set; } = 50;
 
-		[StaticList ("BlendOps")]
+		public ReadOnlyDictionary<string, object> BlendOpChoices
+			=> BlendOps;
+
+		[StaticList (nameof (BlendOps))]
 		public string BlendMode { get; set; } = default_blend_op;
 
 		[Caption ("Random Noise")]

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -250,7 +250,7 @@ public sealed class CloudsEffect : BaseEffect
 		public ReadOnlyDictionary<string, object> BlendOpChoices
 			=> BlendOps;
 
-		[StaticList (nameof (BlendOps))]
+		[StaticList (nameof (BlendOpChoices))]
 		public string BlendMode { get; set; } = default_blend_op;
 
 		[Caption ("Random Noise")]

--- a/Pinta.Gui.Widgets/Dialogs/MemberReflector.cs
+++ b/Pinta.Gui.Widgets/Dialogs/MemberReflector.cs
@@ -40,8 +40,9 @@ internal sealed class MemberReflector
 			case FieldInfo f:
 				return f.SetValue;
 			case PropertyInfo p:
-				MethodInfo setter = p.GetSetMethod () ?? throw new ArgumentException ($"Property {p.Name} has no 'set' method", nameof (memberInfo));
-				return (o, v) => setter.Invoke (o, new[] { v });
+				MethodInfo? setter = p.GetSetMethod ();
+				//if (setter is null) throw new ArgumentException ($"Property {p.Name} has no 'set' method", nameof (memberInfo));
+				return (o, v) => setter?.Invoke (o, new[] { v });
 			default:
 				throw new ArgumentException ($"Member type {memberInfo.GetType ()} not supported", nameof (memberInfo));
 		}

--- a/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
+++ b/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
@@ -13,6 +13,6 @@ internal static class ReflectionHelper
 		if (o.GetType ().GetProperty (name) is PropertyInfo pi)
 			return pi.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
 
-		throw new ArgumentException ("Only fields and attributes are supported");
+		throw new ArgumentException ($"Member '{name}' is not supported. Only fields and attributes are supported");
 	}
 }

--- a/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
+++ b/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
@@ -7,10 +7,12 @@ internal static class ReflectionHelper
 {
 	public static object? GetValue (object o, string name)
 	{
-		if (o.GetType ().GetField (name) is FieldInfo fi)
+		Type objectType = o.GetType ();
+
+		if (objectType.GetField (name) is FieldInfo fi)
 			return fi.GetValue (o);
 
-		if (o.GetType ().GetProperty (name) is PropertyInfo pi)
+		if (objectType.GetProperty (name) is PropertyInfo pi)
 			return pi.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
 
 		throw new ArgumentException ($"Member '{name}' is not supported. Only fields and properties are supported");

--- a/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
+++ b/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
@@ -15,6 +15,6 @@ internal static class ReflectionHelper
 		if (objectType.GetProperty (name) is PropertyInfo pi)
 			return pi.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
 
-		throw new ArgumentException ($"Member '{name}' is not supported. Only fields and properties are supported");
+		throw new ArgumentException ($"Member '{name}' is not supported or does not exist. Only fields and properties are supported");
 	}
 }

--- a/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
+++ b/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
@@ -13,6 +13,6 @@ internal static class ReflectionHelper
 		if (o.GetType ().GetProperty (name) is PropertyInfo pi)
 			return pi.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
 
-		throw new ArgumentException ($"Member '{name}' is not supported. Only fields and attributes are supported");
+		throw new ArgumentException ($"Member '{name}' is not supported. Only fields and properties are supported");
 	}
 }

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -267,10 +267,10 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 
 	private ComboBoxWidget CreateComboBox (string caption, EffectData effectData, MemberSettings settings)
 	{
-		Dictionary<string, object>? dict = null;
+		IDictionary<string, object>? dict = null;
 
 		foreach (var attr in settings.reflector.Attributes)
-			if (attr is StaticListAttribute attribute && ReflectionHelper.GetValue (effectData, attribute.DictionaryName) is Dictionary<string, object> d)
+			if (attr is StaticListAttribute attribute && ReflectionHelper.GetValue (effectData, attribute.DictionaryName) is IDictionary<string, object> d)
 				dict = d;
 
 		var entries =

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -344,7 +344,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 
 	private Gtk.CheckButton CreateCheckBox (string caption, EffectData effectData, MemberSettings settings)
 	{
-		var widget = new Gtk.CheckButton { Label = caption };
+		Gtk.CheckButton widget = new () { Label = caption };
 
 		if (settings.reflector.GetValue (effectData) is bool b)
 			widget.Active = b;


### PR DESCRIPTION
In one of the previous pull requests, I filtered out static properties so that the `SimpleEffectDialog` didn't crash when `CloudsEffect` was chosen.

Now I've found that it still crashes because it can't find the member referenced in `StaticListAttribute`, so I added it as an instance property.

Also, the creation of `MemberReflector` throwed an exception whenever the property in question didn't have a setter. This is a temporary workaround.

Maybe static properties should be supported, at least in a limited fashion?