### PR TITLE
Combobox creation in `SimpleEffectDialog.CreateComboBox()` now looks for an `IDictionary<T>`, and not a `Dictionary<T>`

### DIFF
--- a/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
+++ b/Pinta.Gui.Widgets/Dialogs/ReflectionHelper.cs
@@ -7,12 +7,17 @@ internal static class ReflectionHelper
 {
 	public static object? GetValue (object o, string name)
 	{
-		if (o.GetType ().GetField (name) is FieldInfo fi)
+		Type objectType = o.GetType ();
+
+		if (objectType.GetField (name) is FieldInfo fi)
 			return fi.GetValue (o);
 
-		if (o.GetType ().GetProperty (name) is PropertyInfo pi)
+		if (objectType.GetProperty (name) is PropertyInfo pi)
 			return pi.GetGetMethod ()?.Invoke (o, Array.Empty<object> ());
 
-		throw new ArgumentException ("Only fields and attributes are supported");
+		if (objectType.GetMember (name).Length > 0)
+			throw new ArgumentException ($"Can't get value from member \'{name}\'. Only fields and attributes are supported");
+		else
+			throw new ArgumentException ($"Member \'{name}\' does not exist");
 	}
 }


### PR DESCRIPTION
Otherwise the lookup in `BlendOps` from `CloudsEffect` might just fail anyway because it is a `ReadOnlyDictionary`, but with this change it should work with any dictionary structure.

Also, made messages in exceptions more informative.