### PR TITLE
Refactored tools so that they don't reference `PintaCore` directly

### DIFF
--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -36,6 +36,9 @@ public interface IPaletteService
 	Color PrimaryColor { get; set; }
 	Color SecondaryColor { get; set; }
 	void SetColor (bool setPrimary, Color color, bool addToRecent = true);
+
+	public event EventHandler? PrimaryColorChanged;
+	public event EventHandler? SecondaryColorChanged;
 }
 
 public sealed class PaletteManager : IPaletteService
@@ -198,9 +201,7 @@ public sealed class PaletteManager : IPaletteService
 		SecondaryColorChanged?.Invoke (this, EventArgs.Empty);
 	}
 
-	#region Events
 	public event EventHandler? PrimaryColorChanged;
 	public event EventHandler? SecondaryColorChanged;
 	public event EventHandler? RecentColorsChanged;
-	#endregion
 }

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -45,6 +45,36 @@ public interface IWorkspaceService
 	SelectionModeHandler SelectionHandler { get; }
 }
 
+public static class WorkspaceServiceExtensions
+{
+	public static void Invalidate (this IWorkspaceService workspace)
+	{
+		if (workspace.HasOpenDocuments)
+			workspace.ActiveWorkspace.Invalidate ();
+	}
+
+	public static void Invalidate (this IWorkspaceService workspace, RectangleI rect)
+	{
+		workspace.ActiveWorkspace.Invalidate (rect);
+	}
+
+	public static void InvalidateWindowRect (this IWorkspaceService workspace, RectangleI windowRect)
+	{
+		workspace.ActiveWorkspace.InvalidateWindowRect (windowRect);
+	}
+
+	/// <summary>
+	/// Converts a point from the active document's canvas coordinates to view coordinates.
+	/// </summary>
+	/// <param name='canvas_pos'>
+	/// The position of the canvas point
+	/// </param>
+	public static PointD CanvasPointToView (this IWorkspaceService workspace, PointD canvas_pos)
+	{
+		return workspace.ActiveWorkspace.CanvasPointToView (canvas_pos);
+	}
+}
+
 public sealed class WorkspaceManager : IWorkspaceService
 {
 	private int active_document_index = -1;
@@ -151,22 +181,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 		OnDocumentClosed (new DocumentEventArgs (document));
 	}
 
-	public void Invalidate ()
-	{
-		if (HasOpenDocuments)
-			ActiveWorkspace.Invalidate ();
-	}
-
-	public void Invalidate (RectangleI rect)
-	{
-		ActiveWorkspace.Invalidate (rect);
-	}
-
-	public void InvalidateWindowRect (RectangleI windowRect)
-	{
-		ActiveWorkspace.InvalidateWindowRect (windowRect);
-	}
-
 	public Document NewDocument (Size imageSize, Color backgroundColor)
 	{
 		Document doc = CreateAndActivateDocument (null, null, imageSize);
@@ -269,6 +283,11 @@ public sealed class WorkspaceManager : IWorkspaceService
 		ActiveDocument.ResizeCanvas (newSize, anchor, compoundAction);
 	}
 
+	public RectangleI ClampToImageSize (RectangleI r)
+	{
+		return ActiveDocument.ClampToImageSize (r);
+	}
+
 	/// <summary>
 	/// Converts a point from the active document's view coordinates to canvas coordinates.
 	/// </summary>
@@ -278,22 +297,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 	public PointD ViewPointToCanvas (PointD view_pos)
 	{
 		return ActiveWorkspace.ViewPointToCanvas (view_pos);
-	}
-
-	/// <summary>
-	/// Converts a point from the active document's canvas coordinates to view coordinates.
-	/// </summary>
-	/// <param name='canvas_pos'>
-	/// The position of the canvas point
-	/// </param>
-	public PointD CanvasPointToView (PointD canvas_pos)
-	{
-		return ActiveWorkspace.CanvasPointToView (canvas_pos);
-	}
-
-	public RectangleI ClampToImageSize (RectangleI r)
-	{
-		return ActiveDocument.ClampToImageSize (r);
 	}
 
 	public bool ImageFitsInWindow => ActiveWorkspace.ImageFitsInWindow;

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -108,7 +108,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 		SelectionHandler = new SelectionModeHandler ();
 	}
 
-	public int ActiveDocumentIndex => active_document_index;
+	public int ActiveDocumentIndex
+		=> active_document_index;
 
 	public Document ActiveDocument {
 		get {
@@ -119,7 +120,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 		}
 	}
 
-	public Document? ActiveDocumentOrDefault => HasOpenDocuments ? open_documents[active_document_index] : null;
+	public Document? ActiveDocumentOrDefault
+		=> HasOpenDocuments ? open_documents[active_document_index] : null;
 
 	public SelectionModeHandler SelectionHandler { get; }
 
@@ -142,7 +144,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 		set => ActiveWorkspace.ViewSize = value;
 	}
 
-	public PointD Offset => ActiveWorkspace.Offset;
+	public PointD Offset
+		=> ActiveWorkspace.Offset;
 
 	public double Scale {
 		get => ActiveWorkspace.Scale;
@@ -158,6 +161,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 		Document doc = new Document (size);
 
 		if (file is not null) {
+
 			if (string.IsNullOrEmpty (file_type))
 				throw new ArgumentNullException ($"nameof{file_type} must contain value.");
 
@@ -167,6 +171,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 			doc.DisplayName = Translations.GetString ("Unsaved Image {0}", new_file_name++);
 
 		open_documents.Add (doc);
+
 		OnDocumentCreated (new DocumentEventArgs (doc));
 
 		SetActiveDocument (doc);
@@ -299,7 +304,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 		return ActiveDocument.ClampToImageSize (r);
 	}
 
-	public bool ImageFitsInWindow => ActiveWorkspace.ImageFitsInWindow;
+	public bool ImageFitsInWindow
+		=> ActiveWorkspace.ImageFitsInWindow;
 
 	internal void ResetTitle ()
 	{

--- a/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
@@ -27,25 +27,24 @@
 using System;
 using System.Collections.Generic;
 using Cairo;
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Tools;
 
 public abstract class ArrowedEditEngine : BaseEditEngine
 {
-	private Separator? arrow_sep;
-	private Label? arrow_label;
-	private CheckButton? show_arrow_one_box, show_arrow_two_box;
+	private Gtk.Separator? arrow_sep;
+	private Gtk.Label? arrow_label;
+	private Gtk.CheckButton? show_arrow_one_box, show_arrow_two_box;
 
-	private SpinButton? arrow_size;
-	private Label? arrow_size_label;
+	private Gtk.SpinButton? arrow_size;
+	private Gtk.Label? arrow_size_label;
 
-	private SpinButton? arrow_angle_offset;
-	private Label? arrow_angle_offset_label;
+	private Gtk.SpinButton? arrow_angle_offset;
+	private Gtk.Label? arrow_angle_offset_label;
 
-	private SpinButton? arrow_length_offset;
-	private Label? arrow_length_offset_label;
+	private Gtk.SpinButton? arrow_length_offset;
+	private Gtk.Label? arrow_length_offset_label;
 
 	private readonly Arrow previous_settings_1 = new ();
 	private readonly Arrow previous_settings_2 = new ();
@@ -53,7 +52,7 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 	// NRT - These are all set by HandleBuildToolBar
 	private ISettingsService settings = null!;
 	private string tool_prefix = null!;
-	private Box toolbar = null!;
+	private Gtk.Box toolbar = null!;
 	private bool extra_toolbar_items_added = false;
 
 	private static string ARROW1_SETTING (string prefix) => $"{prefix}-arrow1";
@@ -65,7 +64,10 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 	private bool ArrowOneEnabled => ArrowOneEnabledCheckBox.Active;
 	private bool ArrowTwoEnabled => ArrowTwoEnabledCheckBox.Active;
 
-	public ArrowedEditEngine (ShapeTool passedOwner) : base (passedOwner) { }
+	public ArrowedEditEngine (
+		IServiceProvider services,
+		ShapeTool passedOwner
+	) : base (services, passedOwner) { }
 
 	public override void OnSaveSettings (ISettingsService settings, string toolPrefix)
 	{
@@ -87,7 +89,7 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 			settings.PutSetting (ARROW_LENGTH_SETTING (toolPrefix), arrow_length_offset.GetValueAsInt ());
 	}
 
-	public override void HandleBuildToolBar (Box tb, ISettingsService settings, string toolPrefix)
+	public override void HandleBuildToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
 	{
 		base.HandleBuildToolBar (tb, settings, toolPrefix);
 
@@ -132,7 +134,7 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 				return;
 
 			// Carefully insert after our last toolbar widget, since the Antialiasing dropdown may have been added already.
-			Widget after_widget = ArrowTwoEnabledCheckBox;
+			Gtk.Widget after_widget = ArrowTwoEnabledCheckBox;
 			foreach (var widget in GetArrowOptionToolbarItems ()) {
 				toolbar.InsertChildAfter (widget, after_widget);
 				after_widget = widget;
@@ -252,36 +254,43 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 		base.DrawExtras (ref dirty, g, engine);
 	}
 
-	private Separator ArrowSeparator => arrow_sep ??= GtkExtensions.CreateToolBarSeparator ();
-	private Label ArrowLabel => arrow_label ??= Label.New (string.Format (" {0}: ", Translations.GetString ("Arrow")));
+	private Gtk.Separator ArrowSeparator
+		=> arrow_sep ??= GtkExtensions.CreateToolBarSeparator ();
 
-	private CheckButton ArrowOneEnabledCheckBox => show_arrow_one_box ??= CreateArrowOneEnabledCheckBox ();
+	private Gtk.Label ArrowLabel
+		=> arrow_label ??= Gtk.Label.New (string.Format (" {0}: ", Translations.GetString ("Arrow")));
 
-	private CheckButton CreateArrowOneEnabledCheckBox ()
+	private Gtk.CheckButton ArrowOneEnabledCheckBox
+		=> show_arrow_one_box ??= CreateArrowOneEnabledCheckBox ();
+
+	private Gtk.CheckButton CreateArrowOneEnabledCheckBox ()
 	{
-		var result = CheckButton.NewWithLabel ("1");
+		Gtk.CheckButton result = Gtk.CheckButton.NewWithLabel ("1");
 		result.Active = settings.GetSetting (ARROW1_SETTING (tool_prefix), previous_settings_1.Show);
 		result.OnToggled += (o, e) => ArrowEnabledToggled (true);
 		return result;
 	}
 
-	private CheckButton ArrowTwoEnabledCheckBox => show_arrow_two_box ??= CreateArrowTwoEnabledCheckBox ();
+	private Gtk.CheckButton ArrowTwoEnabledCheckBox
+		=> show_arrow_two_box ??= CreateArrowTwoEnabledCheckBox ();
 
-	private CheckButton CreateArrowTwoEnabledCheckBox ()
+	private Gtk.CheckButton CreateArrowTwoEnabledCheckBox ()
 	{
-		var result = CheckButton.NewWithLabel ("2");
+		Gtk.CheckButton result = Gtk.CheckButton.NewWithLabel ("2");
 		result.Active = settings.GetSetting (ARROW2_SETTING (tool_prefix), previous_settings_2.Show);
 		result.OnToggled += (o, e) => ArrowEnabledToggled (false);
 		return result;
 	}
 
-	private Label ArrowSizeLabel => arrow_size_label ??= Label.New (string.Format (" {0}: ", Translations.GetString ("Size")));
+	private Gtk.Label ArrowSizeLabel
+		=> arrow_size_label ??= Gtk.Label.New (string.Format (" {0}: ", Translations.GetString ("Size")));
 
-	private SpinButton ArrowSize => arrow_size ??= CreateArrowSize ();
+	private Gtk.SpinButton ArrowSize
+		=> arrow_size ??= CreateArrowSize ();
 
-	private SpinButton CreateArrowSize ()
+	private Gtk.SpinButton CreateArrowSize ()
 	{
-		var result = GtkExtensions.CreateToolBarSpinButton (1, 100, 1, settings.GetSetting (ARROW_SIZE_SETTING (tool_prefix), 10));
+		Gtk.SpinButton result = GtkExtensions.CreateToolBarSpinButton (1, 100, 1, settings.GetSetting (ARROW_SIZE_SETTING (tool_prefix), 10));
 		result.OnValueChanged += (o, e) => {
 			var activeEngine = (LineCurveSeriesEngine?) ActiveShapeEngine;
 			if (activeEngine == null)
@@ -295,13 +304,15 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 		return result;
 	}
 
-	private Label ArrowAngleOffsetLabel => arrow_angle_offset_label ??= Label.New (string.Format (" {0}: ", Translations.GetString ("Angle")));
+	private Gtk.Label ArrowAngleOffsetLabel
+		=> arrow_angle_offset_label ??= Gtk.Label.New (string.Format (" {0}: ", Translations.GetString ("Angle")));
 
-	private SpinButton ArrowAngleOffset => arrow_angle_offset ??= CreateArrowAngleOffset ();
+	private Gtk.SpinButton ArrowAngleOffset
+		=> arrow_angle_offset ??= CreateArrowAngleOffset ();
 
-	private SpinButton CreateArrowAngleOffset ()
+	private Gtk.SpinButton CreateArrowAngleOffset ()
 	{
-		var result = GtkExtensions.CreateToolBarSpinButton (-89, 89, 1, settings.GetSetting (ARROW_ANGLE_SETTING (tool_prefix), 15));
+		Gtk.SpinButton result = GtkExtensions.CreateToolBarSpinButton (-89, 89, 1, settings.GetSetting (ARROW_ANGLE_SETTING (tool_prefix), 15));
 		result.OnValueChanged += (o, e) => {
 			var activeEngine = (LineCurveSeriesEngine?) ActiveShapeEngine;
 			if (activeEngine == null)
@@ -315,17 +326,21 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 		return result;
 	}
 
-	private Label ArrowLengthOffsetLabel => arrow_length_offset_label ??= Label.New (string.Format (" {0}: ", Translations.GetString ("Length")));
+	private Gtk.Label ArrowLengthOffsetLabel
+		=> arrow_length_offset_label ??= Gtk.Label.New (string.Format (" {0}: ", Translations.GetString ("Length")));
 
-	private SpinButton ArrowLengthOffset => arrow_length_offset ??= CreateArrowLengthOffset ();
+	private Gtk.SpinButton ArrowLengthOffset
+		=> arrow_length_offset ??= CreateArrowLengthOffset ();
 
-	private SpinButton CreateArrowLengthOffset ()
+	private Gtk.SpinButton CreateArrowLengthOffset ()
 	{
-		var result = GtkExtensions.CreateToolBarSpinButton (-100, 100, 1, settings.GetSetting (ARROW_LENGTH_SETTING (tool_prefix), 10));
+		Gtk.SpinButton result = GtkExtensions.CreateToolBarSpinButton (-100, 100, 1, settings.GetSetting (ARROW_LENGTH_SETTING (tool_prefix), 10));
 		result.OnValueChanged += (o, e) => {
 			var activeEngine = (LineCurveSeriesEngine?) ActiveShapeEngine;
+
 			if (activeEngine == null)
 				return;
+
 			var length = result.Value;
 			activeEngine.Arrow1.LengthOffset = length;
 			activeEngine.Arrow2.LengthOffset = length;
@@ -335,7 +350,7 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 		return result;
 	}
 
-	private IEnumerable<Widget> GetArrowOptionToolbarItems ()
+	private IEnumerable<Gtk.Widget> GetArrowOptionToolbarItems ()
 	{
 		yield return ArrowSizeLabel;
 		yield return ArrowSize;

--- a/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Pinta.Core;
 
@@ -33,14 +34,23 @@ public sealed class EllipseEditEngine : BaseEditEngine
 {
 	protected override string ShapeName => Translations.GetString ("Ellipse");
 
-	public EllipseEditEngine (ShapeTool owner) : base (owner) { }
+	private readonly IWorkspaceService workspace;
+	public EllipseEditEngine (IServiceProvider services, ShapeTool owner) : base (services, owner)
+	{
+		workspace = services.GetService<IWorkspaceService> ();
+	}
 
 	protected override ShapeEngine CreateShape (bool ctrlKey, bool clickedOnControlPoint, PointD prevSelPoint)
 	{
-		Document doc = PintaCore.Workspace.ActiveDocument;
+		Document doc = workspace.ActiveDocument;
 
-		ShapeEngine newEngine = new EllipseEngine (doc.Layers.CurrentUserLayer, null, owner.UseAntialiasing,
-			BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
+		EllipseEngine newEngine = new (
+			doc.Layers.CurrentUserLayer,
+			null,
+			owner.UseAntialiasing,
+			BaseEditEngine.OutlineColor,
+			BaseEditEngine.FillColor,
+			owner.EditEngine.BrushWidth);
 
 		AddRectanglePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
 
@@ -53,7 +63,6 @@ public sealed class EllipseEditEngine : BaseEditEngine
 	protected override void MovePoint (List<ControlPoint> controlPoints)
 	{
 		MoveRectangularPoint (controlPoints);
-
 		base.MovePoint (controlPoints);
 	}
 }

--- a/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Pinta.Core;
 
@@ -31,16 +32,35 @@ namespace Pinta.Tools;
 
 public sealed class LineCurveEditEngine : ArrowedEditEngine
 {
-	protected override string ShapeName => Translations.GetString ("Open Curve Shape");
+	protected override string ShapeName
+		=> Translations.GetString ("Open Curve Shape");
 
-	public LineCurveEditEngine (ShapeTool passedOwner) : base (passedOwner) { }
-
-	protected override ShapeEngine CreateShape (bool ctrlKey, bool clickedOnControlPoint, PointD prevSelPoint)
+	private readonly IWorkspaceService workspace;
+	public LineCurveEditEngine (
+		IServiceProvider services,
+		ShapeTool passedOwner
+	)
+		: base (services, passedOwner)
 	{
-		Document doc = PintaCore.Workspace.ActiveDocument;
+		workspace = services.GetService<IWorkspaceService> ();
+	}
 
-		LineCurveSeriesEngine newEngine = new LineCurveSeriesEngine (doc.Layers.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.OpenLineCurveSeries,
-			owner.UseAntialiasing, false, BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
+	protected override ShapeEngine CreateShape (
+		bool ctrlKey,
+		bool clickedOnControlPoint,
+		PointD prevSelPoint)
+	{
+		Document doc = workspace.ActiveDocument;
+
+		LineCurveSeriesEngine newEngine = new (
+			doc.Layers.CurrentUserLayer,
+			null,
+			BaseEditEngine.ShapeTypes.OpenLineCurveSeries,
+			owner.UseAntialiasing,
+			false,
+			BaseEditEngine.OutlineColor,
+			BaseEditEngine.FillColor,
+			owner.EditEngine.BrushWidth);
 
 		AddLinePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
 

--- a/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Pinta.Core;
 
@@ -31,15 +32,26 @@ namespace Pinta.Tools;
 
 public sealed class RectangleEditEngine : BaseEditEngine
 {
-	protected override string ShapeName => Translations.GetString ("Closed Curve Shape");
+	protected override string ShapeName
+		=> Translations.GetString ("Closed Curve Shape");
 
-	public RectangleEditEngine (ShapeTool passedOwner) : base (passedOwner) { }
-
-	protected override ShapeEngine CreateShape (bool ctrlKey, bool clickedOnControlPoint, PointD prevSelPoint)
+	private readonly IWorkspaceService workspace;
+	public RectangleEditEngine (
+		IServiceProvider services,
+		ShapeTool passedOwner
+	) : base (services, passedOwner)
 	{
-		Document doc = PintaCore.Workspace.ActiveDocument;
+		workspace = services.GetService<IWorkspaceService> ();
+	}
 
-		ShapeEngine newEngine = new LineCurveSeriesEngine (doc.Layers.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.ClosedLineCurveSeries,
+	protected override ShapeEngine CreateShape (
+		bool ctrlKey,
+		bool clickedOnControlPoint,
+		PointD prevSelPoint)
+	{
+		Document doc = workspace.ActiveDocument;
+
+		LineCurveSeriesEngine newEngine = new (doc.Layers.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.ClosedLineCurveSeries,
 			owner.UseAntialiasing, true, BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
 
 		AddRectanglePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
@@ -53,7 +65,6 @@ public sealed class RectangleEditEngine : BaseEditEngine
 	protected override void MovePoint (List<ControlPoint> controlPoints)
 	{
 		MoveRectangularPoint (controlPoints);
-
 		base.MovePoint (controlPoints);
 	}
 }

--- a/Pinta.Tools/Tools/EllipseTool.cs
+++ b/Pinta.Tools/Tools/EllipseTool.cs
@@ -31,17 +31,28 @@ namespace Pinta.Tools;
 
 public sealed class EllipseTool : ShapeTool
 {
+	private readonly IServiceProvider services;
+
 	public EllipseTool (IServiceProvider services) : base (services)
 	{
+		this.services = services;
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}
 
-	public override string Name => Translations.GetString ("Ellipse");
-	public override string Icon => Pinta.Resources.Icons.ToolEllipse;
-	public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Ellipse.png"), 9, 18, null);
+	public override string Name
+		=> Translations.GetString ("Ellipse");
+
+	public override string Icon
+		=> Pinta.Resources.Icons.ToolEllipse;
+
+	public override Gdk.Cursor DefaultCursor
+		=> Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Ellipse.png"), 9, 18, null);
+
 	public override int Priority => 43;
 
-	public override BaseEditEngine.ShapeTypes ShapeType => BaseEditEngine.ShapeTypes.Ellipse;
+	public override BaseEditEngine.ShapeTypes ShapeType
+		=> BaseEditEngine.ShapeTypes.Ellipse;
 
-	protected override BaseEditEngine CreateEditEngine () => new EllipseEditEngine (this);
+	protected override BaseEditEngine CreateEditEngine ()
+		=> new EllipseEditEngine (services, this);
 }

--- a/Pinta.Tools/Tools/LineCurveTool.cs
+++ b/Pinta.Tools/Tools/LineCurveTool.cs
@@ -31,8 +31,10 @@ namespace Pinta.Tools;
 
 public sealed class LineCurveTool : ShapeTool
 {
+	private readonly IServiceProvider services;
 	public LineCurveTool (IServiceProvider services) : base (services)
 	{
+		this.services = services;
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}
 
@@ -41,7 +43,9 @@ public sealed class LineCurveTool : ShapeTool
 	public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.Line.png"), 9, 18, null);
 	public override int Priority => 37;
 
-	public override BaseEditEngine.ShapeTypes ShapeType => BaseEditEngine.ShapeTypes.OpenLineCurveSeries;
+	public override BaseEditEngine.ShapeTypes ShapeType
+		=> BaseEditEngine.ShapeTypes.OpenLineCurveSeries;
 
-	protected override BaseEditEngine CreateEditEngine () => new LineCurveEditEngine (this);
+	protected override BaseEditEngine CreateEditEngine ()
+		=> new LineCurveEditEngine (services, this);
 }

--- a/Pinta.Tools/Tools/RectangleTool.cs
+++ b/Pinta.Tools/Tools/RectangleTool.cs
@@ -31,8 +31,10 @@ namespace Pinta.Tools;
 
 public sealed class RectangleTool : ShapeTool
 {
+	private readonly IServiceProvider services;
 	public RectangleTool (IServiceProvider services) : base (services)
 	{
+		this.services = services;
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}
 
@@ -45,5 +47,5 @@ public sealed class RectangleTool : ShapeTool
 		=> BaseEditEngine.ShapeTypes.ClosedLineCurveSeries;
 
 	protected override BaseEditEngine CreateEditEngine ()
-		=> new RectangleEditEngine (this);
+		=> new RectangleEditEngine (services, this);
 }

--- a/Pinta.Tools/Tools/RoundedRectangleTool.cs
+++ b/Pinta.Tools/Tools/RoundedRectangleTool.cs
@@ -31,17 +31,28 @@ namespace Pinta.Tools;
 
 public sealed class RoundedRectangleTool : ShapeTool
 {
+	private readonly IServiceProvider services;
 	public RoundedRectangleTool (IServiceProvider services) : base (services)
 	{
+		this.services = services;
 		BaseEditEngine.CorrespondingTools[ShapeType] = this;
 	}
 
-	public override string Name => Translations.GetString ("Rounded Rectangle");
-	public override string Icon => Pinta.Resources.Icons.ToolRectangleRounded;
-	public override Gdk.Cursor DefaultCursor => Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.RoundedRectangle.png"), 9, 18, null);
-	public override int Priority => 41;
+	public override string Name
+		=> Translations.GetString ("Rounded Rectangle");
 
-	public override BaseEditEngine.ShapeTypes ShapeType => BaseEditEngine.ShapeTypes.RoundedLineSeries;
+	public override string Icon
+		=> Pinta.Resources.Icons.ToolRectangleRounded;
 
-	protected override BaseEditEngine CreateEditEngine () => new RoundedLineEditEngine (this);
+	public override Gdk.Cursor DefaultCursor
+		=> Gdk.Cursor.NewFromTexture (Resources.GetIcon ("Cursor.RoundedRectangle.png"), 9, 18, null);
+
+	public override int Priority
+		=> 41;
+
+	public override BaseEditEngine.ShapeTypes ShapeType
+		=> BaseEditEngine.ShapeTypes.RoundedLineSeries;
+
+	protected override RoundedLineEditEngine CreateEditEngine ()
+		=> new (services, this);
 }

--- a/tests/Pinta.Effects.Tests/Mocks/MockPalette.cs
+++ b/tests/Pinta.Effects.Tests/Mocks/MockPalette.cs
@@ -1,3 +1,4 @@
+using System;
 using Cairo;
 using Pinta.Core;
 
@@ -7,6 +8,9 @@ internal sealed class MockPalette : IPaletteService
 {
 	public Color PrimaryColor { get; set; } = new (0, 0, 0); // Black
 	public Color SecondaryColor { get; set; } = new (1, 1, 1); // White
+
+	public event EventHandler? PrimaryColorChanged;
+	public event EventHandler? SecondaryColorChanged;
 
 	public void SetColor (bool setPrimary, Color color, bool addToRecent = true)
 	{

--- a/tests/PintaBenchmarks/Mocks/MockPalette.cs
+++ b/tests/PintaBenchmarks/Mocks/MockPalette.cs
@@ -8,6 +8,9 @@ internal sealed class MockPalette : IPaletteService
 	public Color PrimaryColor { get; set; } = new (0, 0, 0); // Black
 	public Color SecondaryColor { get; set; } = new (1, 1, 1); // White
 
+	public event EventHandler? PrimaryColorChanged;
+	public event EventHandler? SecondaryColorChanged;
+
 	public void SetColor (bool setPrimary, Color color, bool addToRecent = true)
 	{
 		if (setPrimary)


### PR DESCRIPTION
This is an effort to get rid of globals.

A few considerations:

- Sometimes, methods that aren't part of the interface of `IWorkspaceService` were called. Luckily, they were simple enough that I could make them into extension methods of the interface itself.
- `static` members of the tools I refactored _still_ reference `PintaCore`. One example is the `TextTool.CurrentTextBounds` property. I think these static members don't belong in their current classes, but somewhere else. However, this is a topic for a future pull request.