### PR TITLE
Moved some `WorkspaceManager` code to extension methods

### DIFF
--- a/tests/Pinta.Effects.Tests/Mocks/MockWorkspaceService.cs
+++ b/tests/Pinta.Effects.Tests/Mocks/MockWorkspaceService.cs
@@ -18,9 +18,4 @@ internal sealed class MockWorkspaceService : IWorkspaceService
 	public event EventHandler? ActiveDocumentChanged;
 	public event EventHandler? SelectionChanged;
 #pragma warning restore CS0067
-
-	public RectangleI ClampToImageSize (RectangleI r)
-	{
-		throw new NotImplementedException ();
-	}
 }

--- a/tests/PintaBenchmarks/Mocks/MockWorkspaceService.cs
+++ b/tests/PintaBenchmarks/Mocks/MockWorkspaceService.cs
@@ -17,9 +17,4 @@ internal sealed class MockWorkspaceService : IWorkspaceService
 	public event EventHandler? ActiveDocumentChanged;
 	public event EventHandler? SelectionChanged;
 #pragma warning restore CS0067
-
-	public RectangleI ClampToImageSize (RectangleI r)
-	{
-		throw new NotImplementedException ();
-	}
 }


### PR DESCRIPTION
This helps identify what part of the public interface is actually needed, and which part is just a convenience.

I managed to remove one method from the `IWorkspaceService` interface itself.

The code that uses the service should be able to work without changes.