### PR TITLE
Settings for `AsyncEffectRenderer` were made immutable

### DIFF
--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -56,19 +56,14 @@ internal abstract class AsyncEffectRenderer
 			int updateMilliseconds,
 			ThreadPriority threadPriority)
 		{
-			if (tileWidth < 0)
-				throw new ArgumentOutOfRangeException (nameof (tileWidth), "Cannot be negative");
-
-			if (tileHeight < 0)
-				throw new ArgumentOutOfRangeException (nameof (tileHeight), "Cannot be negative");
-
-			// TODO: Prepare the calling code and
-			//       instead of coercing values,
-			//       throw an exception
+			if (tileWidth < 0) throw new ArgumentOutOfRangeException (nameof (tileWidth), "Cannot be negative");
+			if (tileHeight < 0) throw new ArgumentOutOfRangeException (nameof (tileHeight), "Cannot be negative");
+			if (updateMilliseconds <= 0) throw new ArgumentOutOfRangeException (nameof (updateMilliseconds), "Strictly positive value expected");
+			if (threadCount < 1) throw new ArgumentOutOfRangeException (nameof (threadCount), "Invalid number of threads");
 			TileWidth = tileWidth;
 			TileHeight = tileHeight;
-			ThreadCount = Math.Clamp (threadCount, 1, int.MaxValue);
-			UpdateMillis = updateMilliseconds <= 0 ? 100 : updateMilliseconds;
+			ThreadCount = threadCount;
+			UpdateMillis = updateMilliseconds;
 			ThreadPriority = threadPriority;
 		}
 	}

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -130,12 +130,12 @@ public sealed class LivePreviewManager
 		if (!effect.IsTileable)
 			tileHeight = render_bounds.Height;
 
-		var settings = new AsyncEffectRenderer.Settings () {
-			ThreadCount = system_manager.RenderThreads,
-			TileWidth = tileWidth,
-			TileHeight = tileHeight,
-			ThreadPriority = ThreadPriority.BelowNormal
-		};
+		AsyncEffectRenderer.Settings settings = new (
+			threadCount: system_manager.RenderThreads,
+			tileWidth: tileWidth,
+			tileHeight: tileHeight,
+			updateMilliseconds: 100,
+			threadPriority: ThreadPriority.Normal);
 
 		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "Start Live preview.");
 

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -135,7 +135,7 @@ public sealed class LivePreviewManager
 			tileWidth: tileWidth,
 			tileHeight: tileHeight,
 			updateMilliseconds: 100,
-			threadPriority: ThreadPriority.Normal);
+			threadPriority: ThreadPriority.BelowNormal);
 
 		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "Start Live preview.");
 


### PR DESCRIPTION
This is a first step towards handling parallelism inside the effect itself instead of doing it in the LivePreviewManager, as discussed in #808, as identifying the moving parts could be useful in abstracting them away and ultimately achieving our goal (not re-calculating all of the settings for every tile).