### PR TITLE
Re-set name and directory in the file picker dialogue when a save fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Thanks to the following contributors who worked on this release:
 - The angle picker widget now supports fractional angles (#807)
 - Fixed issues with restoring saved settings in the Eraser tool (#839)
 - Fixed dragging issues in the Curves adjustment dialog with modifiers such as Num Lock active (#871)
+- Fixed a bug where the file picker dialogue would open the wrong directory after a failed save (#914)
 
 ## [2.1.2](https://github.com/PintaProject/Pinta/releases/tag/2.1.2) - 2024/04/20
 

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -178,8 +178,12 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 
 			// If saving the file failed or was cancelled, let the user select
 			// a different file type.
-			if (!SaveFile (document, file, format, chrome.MainWindow))
+			if (!SaveFile (document, file, format, chrome.MainWindow)) {
+				// Re-set the current name and directory
+				fcd.SetCurrentName (display_name);
+				fcd.SetCurrentFolder (directory);
 				continue;
+			}
 
 			//The user is saving the Document to a new file, so technically it
 			//hasn't been saved to its associated file in this session.


### PR DESCRIPTION
This fixes #914

It's a pretty simple fix, simply manually setting the directory and name back to the value the user picked before re-opening the dialogue.  
This fixes the issue on Linux, but testing on Mac and Windows would be nice to ensure there isn't any regression.