### PR TITLE
Add antialiasing toggle to text tool

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // BaseTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -304,6 +304,14 @@ public abstract class BaseTool
 	}
 
 	/// <summary>
+	/// Called when the tool is deselected from the toolbox.
+	/// </summary>
+	protected virtual void OnChangeAntialias (object? sender, EventArgs e)
+	{
+
+	}
+
+	/// <summary>
 	/// Tool should call this in order to change the application cursor.
 	/// Pass 'null' to reset the cursor back to the default.
 	/// </summary>
@@ -350,6 +358,8 @@ public abstract class BaseTool
 
 				antialiasing_button.SelectedIndex = Settings.GetSetting (ANTIALIAS_SETTING, 0);
 			}
+
+			antialiasing_button.SelectedItemChanged += OnChangeAntialias;
 
 			return antialiasing_button;
 		}

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -304,9 +304,9 @@ public abstract class BaseTool
 	}
 
 	/// <summary>
-	/// Called when the tool is deselected from the toolbox.
+	/// Called when the antialias setting is changed.
 	/// </summary>
-	protected virtual void OnChangeAntialias (object? sender, EventArgs e)
+	protected virtual void OnAntialiasingChanged ()
 	{
 
 	}
@@ -357,9 +357,11 @@ public abstract class BaseTool
 				antialiasing_button.AddItem (Translations.GetString ("Antialiasing Off"), Pinta.Resources.Icons.AntiAliasingDisabled, false);
 
 				antialiasing_button.SelectedIndex = Settings.GetSetting (ANTIALIAS_SETTING, 0);
-			}
 
-			antialiasing_button.SelectedItemChanged += OnChangeAntialias;
+				antialiasing_button.SelectedItemChanged += (object? sender, EventArgs e) => {
+					OnAntialiasingChanged();
+				};
+			}
 
 			return antialiasing_button;
 		}

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -359,7 +359,7 @@ public abstract class BaseTool
 				antialiasing_button.SelectedIndex = Settings.GetSetting (ANTIALIAS_SETTING, 0);
 
 				antialiasing_button.SelectedItemChanged += (object? sender, EventArgs e) => {
-					OnAntialiasingChanged();
+					OnAntialiasingChanged ();
 				};
 			}
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -27,7 +27,6 @@ public sealed class TextTool : BaseTool
 
 	private PointI click_point;
 	private bool is_editing;
-	private bool is_antialiased = true;
 	private RectangleI old_cursor_bounds = RectangleI.Zero;
 
 	//This is used to temporarily store the UserLayer's and TextLayer's previous ImageSurface states.

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -419,7 +419,7 @@ public sealed class TextTool : BaseTool
 
 	protected override void OnAntialiasingChanged ()
 	{
-		UpdateFont();
+		UpdateFont ();
 	}
 
 	private void UpdateFont ()

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -417,7 +417,7 @@ public sealed class TextTool : BaseTool
 		UpdateFont ();
 	}
 
-	protected override void OnChangeAntialias (object? sender, EventArgs e)
+	protected override void OnAntialiasingChanged ()
 	{
 		UpdateFont();
 	}
@@ -984,36 +984,23 @@ public sealed class TextTool : BaseTool
 			ClearTextLayer ();
 		}
 
-		/*		var antialiasing = antialiasing_button.SelectedItem.GetTagOrDefault (true);
-		   if (antialiasing) {
-
-		   } else {
-		   	Settings.PutSetting (ANTIALIAS_SETTING, 1);
-		   	var options = new Cairo.FontOptions ();
-		   	options.Antialias = Antialias.None;
-		   	PangoCairo.Functions.ContextSetFontOptions (PintaCore.Chrome.MainWindow.GetPangoContext (), options);
-		   }
-*/
-
 		Cairo.Context g = new (surf);
+
+		var options = new Cairo.FontOptions ();
 
 		if (UseAntialiasing) {
 			// Adjusts antialiasing JUST for the outline brush
 			g.Antialias = Cairo.Antialias.Gray;
 			// Adjusts antialiasing for PangoCairo's text draw function
-			var options = new Cairo.FontOptions ();
 			options.Antialias = Antialias.Gray;
-			PangoCairo.Functions.ContextSetFontOptions (PintaCore.Chrome.MainWindow.GetPangoContext (), options);
-		}
-		else
-		{
+		} else {
 			g.Antialias = Cairo.Antialias.None;
-			var options = new Cairo.FontOptions ();
 			options.Antialias = Antialias.None;
-			PangoCairo.Functions.ContextSetFontOptions (PintaCore.Chrome.MainWindow.GetPangoContext (), options);
 		}
 
 		g.Save ();
+		PangoCairo.Functions.ContextSetFontOptions (PintaCore.Chrome.MainWindow.GetPangoContext (), options);
+
 
 		// Show selection if on text layer
 		if (useTextLayer) {


### PR DESCRIPTION
I was frustrated with the lack of ability to disable antialiasing on Pinta, so I decided to just go and add it.

Please note this was cobbled together. I have zero experience with Cairo/Pango/PangoCairo but in my brief testing there didn't seem to be any obvious problems.

Thank you in advance.