### PR TITLE
Fix dotted brushstrokes when drawing with semitransparent colors

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -177,6 +177,13 @@ public sealed class Document
 		return g;
 	}
 
+	public Context CreateClippedContextFromSurface(ImageSurface surf)
+	{
+		Context g = new (surf);
+		Selection.Clip (g);
+		return g;
+	}
+
 	public Context CreateClippedContext (bool antialias)
 	{
 		Context g = new (Layers.CurrentUserLayer.Surface);

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -177,13 +177,6 @@ public sealed class Document
 		return g;
 	}
 
-	public Context CreateClippedContextFromSurface(ImageSurface surf)
-	{
-		Context g = new (surf);
-		Selection.Clip (g);
-		return g;
-	}
-
 	public Context CreateClippedContext (bool antialias)
 	{
 		Context g = new (Layers.CurrentUserLayer.Surface);

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -43,6 +43,8 @@ public sealed class PlainBrush : BasePaintBrush
 		ImageSurface surface,
 		BrushStrokeArgs strokeArgs)
 	{
+		surface.Clear ();
+
 		g.LineCap = g.LineWidth == 1 ? LineCap.Butt : LineCap.Round;
 
 		if (path is null)

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -52,7 +52,7 @@ public sealed class PlainBrush : BasePaintBrush
 		else
 			g.AppendPath (path);
 
-		DrawNonSinglePixelLine (g, strokeArgs);
+		Draw (g, strokeArgs);
 
 		path = g.CopyPath ();
 
@@ -65,7 +65,7 @@ public sealed class PlainBrush : BasePaintBrush
 		return inflated;
 	}
 
-	private static void DrawNonSinglePixelLine (Context g, BrushStrokeArgs strokeArgs)
+	private static void Draw (Context g, BrushStrokeArgs strokeArgs)
 	{
 		var x = strokeArgs.CurrentPosition.X;
 		var y = strokeArgs.CurrentPosition.Y;

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -67,7 +67,20 @@ public sealed class PlainBrush : BasePaintBrush
 
 	private static void DrawNonSinglePixelLine (Context g, BrushStrokeArgs strokeArgs)
 	{
-		g.LineTo (strokeArgs.CurrentPosition.X + 0.5, strokeArgs.CurrentPosition.Y + 0.5);
+		var x = strokeArgs.CurrentPosition.X;
+		var y = strokeArgs.CurrentPosition.Y;
+
+		if (
+			(x == strokeArgs.LastPosition.X) &&
+			(y == strokeArgs.LastPosition.Y) &&
+			(g.LineWidth == 1) &&
+			PintaCore.Workspace.ActiveWorkspace.PointInCanvas ((PointD) strokeArgs.CurrentPosition)
+		) {
+			x += 1;
+			y += 1;
+		}
+
+		g.LineTo (x, y);
 		g.StrokePreserve ();
 	}
 

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -43,6 +43,8 @@ public sealed class PlainBrush : BasePaintBrush
 		ImageSurface surface,
 		BrushStrokeArgs strokeArgs)
 	{
+		g.LineCap = g.LineWidth == 1 ? LineCap.Butt : LineCap.Round;
+
 		if (path is null)
 			g.MoveTo (strokeArgs.LastPosition.X, strokeArgs.LastPosition.Y);
 		else

--- a/Pinta.Tools/Brushes/PlainBrush.cs
+++ b/Pinta.Tools/Brushes/PlainBrush.cs
@@ -75,7 +75,6 @@ public sealed class PlainBrush : BasePaintBrush
 
 	private static void DrawNonSinglePixelLine (Context g, BrushStrokeArgs strokeArgs)
 	{
-		g.MoveTo (strokeArgs.LastPosition.X + 0.5, strokeArgs.LastPosition.Y + 0.5);
 		g.LineTo (strokeArgs.CurrentPosition.X + 0.5, strokeArgs.CurrentPosition.Y + 0.5);
 		g.StrokePreserve ();
 	}

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -128,7 +128,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 		g.Antialias = UseAntialiasing ? Antialias.Subpixel : Antialias.None;
 		g.LineWidth = BrushWidth;
 		g.LineJoin = LineJoin.Round;
-		g.LineCap = BrushWidth == 1 ? LineCap.Butt : LineCap.Round;
+		g.LineCap = LineCap.Round;
 		g.SetSourceColor (strokeColor);
 
 		if (active_brush is Pinta.Tools.Brushes.PlainBrush)

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -131,9 +131,6 @@ public sealed class PaintBrushTool : BaseBrushTool
 		g.LineCap = LineCap.Round;
 		g.SetSourceColor (strokeColor);
 
-		if (active_brush is Pinta.Tools.Brushes.PlainBrush)
-			document.Layers.ToolLayer.Clear ();
-
 		BrushStrokeArgs strokeArgs = new (strokeColor, e.Point, last_point.Value);
 
 		var invalidate_rect = active_brush.DoMouseMove (g, surf, strokeArgs);

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -83,9 +83,10 @@ public sealed class PaintBrushTool : BaseBrushTool
 
 	protected override void OnMouseDown (Document document, ToolMouseEventArgs e)
 	{
-		base.OnMouseDown (document, e);
-
+		document.Layers.ToolLayer.Clear ();
 		document.Layers.ToolLayer.Hidden = false;
+
+		base.OnMouseDown (document, e);
 
 		active_brush?.DoMouseDown ();
 	}
@@ -151,7 +152,6 @@ public sealed class PaintBrushTool : BaseBrushTool
 
 		document.Layers.ToolLayer.Draw (gDest);
 
-		document.Layers.ToolLayer.Clear ();
 		document.Layers.ToolLayer.Hidden = true;
 
 		base.OnMouseUp (document, e);

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -41,8 +41,6 @@ public sealed class PaintBrushTool : BaseBrushTool
 	private BasePaintBrush? active_brush;
 	private PointI? last_point = PointI.Zero;
 
-	private Path? path;
-
 	private const string BRUSH_SETTING = "paint-brush-brush";
 
 	public PaintBrushTool (IServiceProvider services) : base (services)
@@ -87,9 +85,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 	{
 		base.OnMouseDown (document, e);
 
-		document.Layers.ToolLayer.Clear ();
 		document.Layers.ToolLayer.Hidden = false;
-		path = null;
 
 		active_brush?.DoMouseDown ();
 	}
@@ -135,14 +131,8 @@ public sealed class PaintBrushTool : BaseBrushTool
 		g.LineCap = BrushWidth == 1 ? LineCap.Butt : LineCap.Round;
 		g.SetSourceColor (strokeColor);
 
-		if (active_brush is Pinta.Tools.Brushes.PlainBrush) {
+		if (active_brush is Pinta.Tools.Brushes.PlainBrush)
 			document.Layers.ToolLayer.Clear ();
-
-			if (path is null)
-				g.MoveTo (last_point.Value.X, last_point.Value.Y);
-			else
-				g.AppendPath (path);
-		}
 
 		BrushStrokeArgs strokeArgs = new (strokeColor, e.Point, last_point.Value);
 
@@ -156,13 +146,12 @@ public sealed class PaintBrushTool : BaseBrushTool
 			document.Workspace.Invalidate (document.ClampToImageSize (invalidate_rect));
 
 		last_point = e.Point;
-
-		path = g.CopyPath ();
 	}
 
 	protected override void OnMouseUp (Document document, ToolMouseEventArgs e)
 	{
 		var gDest = new Context (document.Layers.CurrentUserLayer.Surface);
+
 		document.Layers.ToolLayer.Draw (gDest);
 
 		document.Layers.ToolLayer.Clear ();


### PR DESCRIPTION
### This PR deals with issue  #941.

### Why the issue happens:
Each line segment of the stroke in the PlainBrush is drawn independently, one after another. With semitransparent colors, the line segments overlap each other on their ends, causing the dark dots in the stroke.

### How this PR solves it:

Upon `OnMouseDown()`, we create a Cairo Path variable called `path`  as a class member, set it to null, and show the ToolLayer.

During `OnMouseMove()` events, we operate on the ToolLayer surface and clear it before drawing (we only clear for the PlainBrush), append `path` to the cairo context and after stroking, copy the new path back to the class member. Cairo will draw the entire path in one go, which gets rid of the dark dots. Performance hit is negligible.

In `OnMouseUp()` we draw the contents of the ToolLayer onto the destination Layer, clear and hide it.

The Pencil Tool isn't affected by this PR.

Paint strokes before and after applying the PR:
![pinta](https://github.com/user-attachments/assets/db13c68b-2718-44b6-b4a3-d1c09149d8ac)
