### PR TITLE
Add feather effect

### DIFF
--- a/Pinta.Effects/CoreEffectsExtension.cs
+++ b/Pinta.Effects/CoreEffectsExtension.cs
@@ -1,21 +1,21 @@
-// 
+//
 // CoreEffectsExtension.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2011 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -67,6 +67,7 @@ internal sealed class CoreEffectsExtension : IExtension
 		PintaCore.Effects.RegisterEffect (new FrostedGlassEffect (services));
 		PintaCore.Effects.RegisterEffect (new GaussianBlurEffect (services));
 		PintaCore.Effects.RegisterEffect (new GlowEffect (services));
+		PintaCore.Effects.RegisterEffect (new FeatherEffect (services));
 		PintaCore.Effects.RegisterEffect (new InkSketchEffect (services));
 		PintaCore.Effects.RegisterEffect (new JuliaFractalEffect (services));
 		PintaCore.Effects.RegisterEffect (new MandelbrotFractalEffect (services));
@@ -116,6 +117,7 @@ internal sealed class CoreEffectsExtension : IExtension
 		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (FrostedGlassEffect));
 		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (GaussianBlurEffect));
 		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (GlowEffect));
+		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (FeatherEffect));
 		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (InkSketchEffect));
 		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (JuliaFractalEffect));
 		PintaCore.Effects.UnregisterInstanceOfEffect (typeof (MandelbrotFractalEffect));

--- a/Pinta.Effects/Effects/FeatherEffect.cs
+++ b/Pinta.Effects/Effects/FeatherEffect.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Cairo;
+using Pinta.Core;
+using Pinta.Gui.Widgets;
+
+namespace Pinta.Effects;
+
+public sealed class FeatherEffect : BaseEffect
+{
+
+	public override string Icon => Pinta.Resources.Icons.EffectsDefault;
+
+	public sealed override bool IsTileable => true;
+
+	public override string Name => Translations.GetString ("Feather");
+
+	public override bool IsConfigurable => true;
+
+	public override string EffectMenuCategory => Translations.GetString ("Stylize");
+
+	public FeatherData Data => (FeatherData) EffectData!;  // NRT - Set in constructor
+
+	private readonly IChromeService chrome;
+
+	public FeatherEffect (IServiceProvider services)
+	{
+		chrome = services.GetService<IChromeService> ();
+		EffectData = new FeatherData ();
+	}
+
+	public override void LaunchConfiguration ()
+		=> chrome.LaunchSimpleEffectDialog (this);
+
+	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)
+	{
+		int radius = Data.Radius;
+		var src_data = src.GetReadOnlyPixelData ();
+		int src_width = src.Width;
+		int src_height = src.Height;
+		var dst_data = dest.GetPixelData ();
+		int dst_width = dest.Width;
+
+		// reset dest to src
+		// Removing this causes preview to not update to lower radius levels
+		foreach (RectangleI roi in rois) {
+			for (int y = roi.Top; y <= roi.Bottom; ++y) {
+				var src_row = src_data.Slice (y * src_width + roi.Left, roi.Width);
+				var dst_row = dst_data.Slice (y * dst_width + roi.Left, roi.Width);
+				for (int x = roi.Left; x <= roi.Right; x++) {
+					if (x < dst_row.Length)
+						dst_row[x].Bgra = src_row[x].Bgra;
+				}
+			}
+		}
+
+
+		// Collect a list of pixels that surround the object
+		List<PointI> borderPixels = new List<PointI> ();
+		foreach (RectangleI roi in rois) {
+			for (int y = roi.Top; y <= roi.Bottom; ++y) {
+				for (int x = roi.Left; x <= roi.Right; x++) {
+					PointI potentialBorderPixel = new (x, y);
+					if (src.GetColorBgra (src_data, src_width, potentialBorderPixel).A <= Data.TransparencyThreshold) {
+						for (int sx = x - 1; sx <= x + 1; sx++) {
+							for (int sy = y - 1; sy <= y + 1; sy++) {
+								PointI pixel = new (sx, sy);
+
+								if (sx < 0 || sx >= src_width || sy < 0 || sy >= src_height)
+									continue;
+
+								if (src.GetColorBgra (src_data, src_width, pixel).A != 0)
+									borderPixels.Add (potentialBorderPixel);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// For each pixel, lower alpha based off distance to border pixel
+		foreach (var borderPixel in borderPixels) {
+			for (int y = borderPixel.Y - radius; y <= borderPixel.Y + radius; ++y) {
+				for (int x = borderPixel.X - radius; x <= borderPixel.X + radius; x++) {
+					// Within manhattan distance to narrow points down
+					var dx = borderPixel.X - x;
+					var dy = borderPixel.Y - y;
+					float distance = MathF.Sqrt (dx * dx + dy * dy);
+					// If within actual distance
+					if (distance <= radius) {
+						int pixel_index = y * src_width + x;
+						float mult = distance / radius;
+						byte alpha = (byte) (src_data[pixel_index].A * mult);
+						if (alpha < dst_data[pixel_index].A)
+							dst_data[pixel_index].Bgra = src_data[pixel_index].NewAlpha (alpha).ToPremultipliedAlpha ().Bgra;
+					}
+				}
+			}
+		}
+	}
+
+	public sealed class FeatherData : EffectData
+	{
+		[Caption ("Radius"), MinimumValue (1), MaximumValue (100)]
+		public int Radius { get; set; } = 6;
+
+		[Caption ("Transparency Threshold"), MinimumValue (0), MaximumValue (255)]
+		public int TransparencyThreshold { get; set; } = 20;
+	}
+}

--- a/Pinta.Effects/Effects/FeatherEffect.cs
+++ b/Pinta.Effects/Effects/FeatherEffect.cs
@@ -46,11 +46,10 @@ public sealed class FeatherEffect : BaseEffect
 		// Removing this causes preview to not update to lower radius levels
 		foreach (RectangleI roi in rois) {
 			for (int y = roi.Top; y <= roi.Bottom; ++y) {
-				var src_row = src_data.Slice (y * src_width + roi.Left, roi.Width);
-				var dst_row = dst_data.Slice (y * dst_width + roi.Left, roi.Width);
+				var src_row = src_data.Slice (y * src_width, src_width);
+				var dst_row = dst_data.Slice (y * src_width, src_width);
 				for (int x = roi.Left; x <= roi.Right; x++) {
-					if (x < dst_row.Length)
-						dst_row[x].Bgra = src_row[x].Bgra;
+					dst_row[x].Bgra = src_row[x].Bgra;
 				}
 			}
 		}
@@ -93,7 +92,7 @@ public sealed class FeatherEffect : BaseEffect
 						float mult = distance / radius;
 						byte alpha = (byte) (src_data[pixel_index].A * mult);
 						if (alpha < dst_data[pixel_index].A)
-							dst_data[pixel_index].Bgra = src_data[pixel_index].NewAlpha (alpha).ToPremultipliedAlpha ().Bgra;
+							dst_data[pixel_index].Bgra = src_data[pixel_index].ToStraightAlpha ().NewAlpha (alpha).ToPremultipliedAlpha ().Bgra;
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #886 

Adds feather tool to Effects > Stylize (Considered blur, but I think this is more fitting). This softens the edges of an image without spilling blur out of the image or blurring the contents of the image.

Radius adjusts the strength of the effect, Transparency Threshold is used to determine the "outline" of the object. Requires object be surrounded by transparency to function.

Example with a test image.

![feather effect with test image](https://github.com/user-attachments/assets/3f7b07f2-37cb-40eb-b64b-46415b9739fd)

Only known issue I am aware of is that the effect will spill over outside selection in preview, however it does not spill over after application. Unsure how to fix this.