### PR TITLE
Fixes to shape drawing

### DIFF
--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -1,21 +1,21 @@
-// 
+//
 // CairoExtensions.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -227,7 +227,8 @@ namespace Pinta.Core
 		public static RectangleD DrawPolygonal (
 			this Context g,
 			ReadOnlySpan<PointD> points,
-			Color color)
+			Color color,
+			LineCap lineCap)
 		{
 			g.Save ();
 			g.MoveTo (points[0].X, points[0].Y);
@@ -236,7 +237,7 @@ namespace Pinta.Core
 				g.LineTo (point.X, point.Y);
 
 			g.SetSourceColor (color);
-			g.LineCap = LineCap.Square;
+			g.LineCap = lineCap;
 
 			RectangleD dirty = g.StrokeExtents ();
 			g.Stroke ();
@@ -993,10 +994,10 @@ namespace Pinta.Core
 		/// <summary>
 		/// Computes and returns the Union (largest possible combination) of two Rectangles.
 		/// The two given Rectangles do not need to intersect.
-		/// 
+		///
 		/// Another way to understand this function is that it computes and returns the
 		/// smallest possible Rectangle that encompasses both given Rectangles.
-		/// 
+		///
 		/// This function works as is intuitively expected with neither, either, or both given Rectangles being null.
 		/// </summary>
 		/// <param name="r1">The first given Rectangle.</param>

--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -8,24 +8,24 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 // Additional code:
-// 
+//
 // HistogramWidget.cs
-//  
+//
 // Author:
 //      Krzysztof Marecki <marecki.krzysztof@gmail.com>
-// 
+//
 // Copyright (c) 2010 Krzysztof Marecki
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -149,7 +149,7 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 
 		g.Rectangle (rect);
 		g.Clip ();
-		g.DrawPolygonal (points, pen_color.ToCairoColor ());
+		g.DrawPolygonal (points, pen_color.ToCairoColor (), LineCap.Square);
 		g.FillPolygonal (points, brush_color.ToCairoColor ());
 	}
 

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -1158,12 +1158,7 @@ public abstract class BaseEditEngine
 
 		g.Antialias = activeEngine.AntiAliasing ? Antialias.Subpixel : Antialias.None;
 
-		// dashpattern "-" and "" produce different results at high brush size (see #733)
-		var dashPattern = activeEngine.DashPattern;
-		if (dashPattern == "-")
-			dashPattern = "";
-
-		g.SetDashFromString (dashPattern, activeEngine.BrushWidth, LineCap.Square);
+		var isDashedLine = g.SetDashFromString (activeEngine.DashPattern, activeEngine.BrushWidth, LineCap.Square);
 
 		g.LineWidth = activeEngine.BrushWidth;
 
@@ -1187,7 +1182,7 @@ public abstract class BaseEditEngine
 
 				// dashpatterns cannot work with butt, so if we are using a dashpattern we default to square.
 				var lineCap = activeEngine.LineCap;
-				if (dashPattern != "")
+				if (isDashedLine)
 					lineCap = LineCap.Square;
 
 				dirty = dirty.UnionRectangles (g.DrawPolygonal (points.AsSpan (), activeEngine.OutlineColor, lineCap));

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -1158,7 +1158,12 @@ public abstract class BaseEditEngine
 
 		g.Antialias = activeEngine.AntiAliasing ? Antialias.Subpixel : Antialias.None;
 
-		g.SetDashFromString (activeEngine.DashPattern, activeEngine.BrushWidth, LineCap.Square);
+		// dashpattern "-" and "" produce different results at high brush size (see #733)
+		var dashPattern = activeEngine.DashPattern;
+		if (dashPattern == "-")
+			dashPattern = "";
+
+		g.SetDashFromString (dashPattern, activeEngine.BrushWidth, LineCap.Square);
 
 		g.LineWidth = activeEngine.BrushWidth;
 
@@ -1179,7 +1184,13 @@ public abstract class BaseEditEngine
 			}
 
 			if (StrokeShape) {
-				dirty = dirty.UnionRectangles (g.DrawPolygonal (points.AsSpan (), activeEngine.OutlineColor));
+
+				// dashpatterns cannot work with butt, so if we are using a dashpattern we default to square.
+				var lineCap = activeEngine.LineCap;
+				if (dashPattern != "")
+					lineCap = LineCap.Square;
+
+				dirty = dirty.UnionRectangles (g.DrawPolygonal (points.AsSpan (), activeEngine.OutlineColor, lineCap));
 			}
 		}
 

--- a/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/EllipseEditEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // EllipseEditEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cairo;
 using Pinta.Core;
 
 namespace Pinta.Tools;
@@ -50,7 +51,8 @@ public sealed class EllipseEditEngine : BaseEditEngine
 			owner.UseAntialiasing,
 			BaseEditEngine.OutlineColor,
 			BaseEditEngine.FillColor,
-			owner.EditEngine.BrushWidth);
+			owner.EditEngine.BrushWidth,
+			LineCap.Butt);
 
 		AddRectanglePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
 

--- a/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/LineCurveEditEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // LineCurveEditEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cairo;
 using Pinta.Core;
 
 namespace Pinta.Tools;
@@ -60,7 +61,8 @@ public sealed class LineCurveEditEngine : ArrowedEditEngine
 			false,
 			BaseEditEngine.OutlineColor,
 			BaseEditEngine.FillColor,
-			owner.EditEngine.BrushWidth);
+			owner.EditEngine.BrushWidth,
+			LineCap.Square);
 
 		AddLinePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
 

--- a/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RectangleEditEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // RectangleEditEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cairo;
 using Pinta.Core;
 
 namespace Pinta.Tools;
@@ -52,7 +53,7 @@ public sealed class RectangleEditEngine : BaseEditEngine
 		Document doc = workspace.ActiveDocument;
 
 		LineCurveSeriesEngine newEngine = new (doc.Layers.CurrentUserLayer, null, BaseEditEngine.ShapeTypes.ClosedLineCurveSeries,
-			owner.UseAntialiasing, true, BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth);
+			owner.UseAntialiasing, true, BaseEditEngine.OutlineColor, BaseEditEngine.FillColor, owner.EditEngine.BrushWidth, LineCap.Square);
 
 		AddRectanglePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
 

--- a/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // RoundedLineEditEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cairo;
 using Pinta.Core;
 
 namespace Pinta.Tools;
@@ -129,7 +130,8 @@ public sealed class RoundedLineEditEngine : BaseEditEngine
 			owner.UseAntialiasing,
 			BaseEditEngine.OutlineColor,
 			BaseEditEngine.FillColor,
-			owner.EditEngine.BrushWidth);
+			owner.EditEngine.BrushWidth,
+			LineCap.Butt);
 
 		AddRectanglePoints (ctrlKey, clickedOnControlPoint, newEngine, prevSelPoint);
 

--- a/Pinta.Tools/Editable/Shapes/EllipseEngine.cs
+++ b/Pinta.Tools/Editable/Shapes/EllipseEngine.cs
@@ -264,7 +264,7 @@ public class EllipseEngine : ShapeEngine
 
 		// Close the curve.
 		// Do not close the curve if no dash pattern used, or else dash pattern wraps past the end of the ellipse
-		if (DashPattern == "-") {
+		if (!CairoExtensions.IsValidDashPattern (DashPattern)) {
 			yield return first_quadrant.Take (2).Last ();
 			// Closes the curve in more extreme, near-flat circle (width >>> height) cases.
 			yield return first_quadrant.Take (3).Last ();

--- a/Pinta.Tools/Editable/Shapes/LineCurveSeriesEngine.cs
+++ b/Pinta.Tools/Editable/Shapes/LineCurveSeriesEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // LineCurveSeriesEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,17 +38,18 @@ public sealed class LineCurveSeriesEngine : ShapeEngine
 	/// <summary>
 	/// Create a new LineCurveSeriesEngine.
 	/// </summary>
-	/// <param name="parent_layer">The parent UserLayer for the re-editable DrawingLayer.</param>
-	/// <param name="drawing_layer">An existing ReEditableLayer to reuse. This is for cloning only. If not cloning, pass in null.</param>
-	/// <param name="shape_type">The owner EditEngine.</param>
+	/// <param name="parentLayer">The parent UserLayer for the re-editable DrawingLayer.</param>
+	/// <param name="drawingLayer">An existing ReEditableLayer to reuse. This is for cloning only. If not cloning, pass in null.</param>
+	/// <param name="shapeType">The owner EditEngine.</param>
 	/// <param name="antialiasing">Whether or not antialiasing is enabled.</param>
 	/// <param name="closed">Whether or not the shape is closed (first and last points are connected).</param>
-	/// <param name="outline_color">The outline color for the shape.</param>
-	/// <param name="fill_color">The fill color for the shape.</param>
-	/// <param name="brush_width">The width of the outline of the shape.</param>
-	public LineCurveSeriesEngine (UserLayer parentLayer, ReEditableLayer? passedDrawingLayer, BaseEditEngine.ShapeTypes passedShapeType,
-		bool passedAA, bool passedClosed, Color passedOutlineColor, Color passedFillColor, int passedBrushWidth) : base (parentLayer,
-		passedDrawingLayer, passedShapeType, passedAA, passedClosed, passedOutlineColor, passedFillColor, passedBrushWidth)
+	/// <param name="outlineColor">The outline color for the shape.</param>
+	/// <param name="fillColor">The fill color for the shape.</param>
+	/// <param name="brushWidth">The width of the outline of the shape.</param>
+	/// <param name="lineCap">Defines the edge of the line drawn.</param>
+	public LineCurveSeriesEngine (UserLayer parentLayer, ReEditableLayer? drawingLayer, BaseEditEngine.ShapeTypes shapeType,
+		bool antialiasing, bool closed, Color outlineColor, Color fillColor, int brushWidth, LineCap lineCap) : base (parentLayer,
+		drawingLayer, shapeType, antialiasing, closed, outlineColor, fillColor, brushWidth, lineCap)
 	{
 		Arrow1 = new ();
 		Arrow2 = new ();

--- a/Pinta.Tools/Editable/Shapes/RoundedLineEngine.cs
+++ b/Pinta.Tools/Editable/Shapes/RoundedLineEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // RoundedLineEngine.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,18 +38,19 @@ public sealed class RoundedLineEngine : ShapeEngine
 	/// <summary>
 	/// Create a new RoundedLineEngine.
 	/// </summary>
-	/// <param name="parent_layer">The parent UserLayer for the re-editable DrawingLayer.</param>
-	/// <param name="drawing_layer">An existing ReEditableLayer to reuse. This is for cloning only. If not cloning, pass in null.</param>
-	/// <param name="passedRadius">The radius of the corners.</param>
+	/// <param name="parentLayer">The parent UserLayer for the re-editable DrawingLayer.</param>
+	/// <param name="drawingLayer">An existing ReEditableLayer to reuse. This is for cloning only. If not cloning, pass in null.</param>
+	/// <param name="radius">The radius of the corners.</param>
 	/// <param name="antialiasing">Whether or not antialiasing is enabled.</param>
-	/// <param name="outline_color">The outline color for the shape.</param>
-	/// <param name="fill_color">The fill color for the shape.</param>
-	/// <param name="brush_width">The width of the outline of the shape.</param>
-	public RoundedLineEngine (UserLayer parentLayer, ReEditableLayer? passedDrawingLayer, double passedRadius, bool passedAA,
-		Color passedOutlineColor, Color passedFillColor, int passedBrushWidth) : base (parentLayer, passedDrawingLayer,
-		BaseEditEngine.ShapeTypes.RoundedLineSeries, passedAA, true, passedOutlineColor, passedFillColor, passedBrushWidth)
+	/// <param name="outlineColor">The outline color for the shape.</param>
+	/// <param name="fillColor">The fill color for the shape.</param>
+	/// <param name="brushWidth">The width of the outline of the shape.</param>
+	/// <param name="lineCap">Defines the edge of the line drawn.</param>
+	public RoundedLineEngine (UserLayer parentLayer, ReEditableLayer? drawingLayer, double radius, bool antialiasing,
+		Color outlineColor, Color fillColor, int brushWidth, LineCap lineCap) : base (parentLayer, drawingLayer,
+		BaseEditEngine.ShapeTypes.RoundedLineSeries, antialiasing, true, outlineColor, fillColor, brushWidth, lineCap)
 	{
-		Radius = passedRadius;
+		Radius = radius;
 	}
 
 	public RoundedLineEngine (RoundedLineEngine src) : base (src)

--- a/Pinta.Tools/Editable/Shapes/ShapeEngineCollection.cs
+++ b/Pinta.Tools/Editable/Shapes/ShapeEngineCollection.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ShapeEngineCollection.cs
-//  
+//
 // Author:
 //       Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2013 Andrew Davis, GSoC 2013 & 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -124,6 +124,8 @@ public abstract class ShapeEngine
 
 	public BaseEditEngine.ShapeTypes ShapeType { get; }
 
+	public LineCap LineCap { get; set; }
+
 	/// <summary>
 	/// Create a new ShapeEngine.
 	/// </summary>
@@ -138,7 +140,7 @@ public abstract class ShapeEngine
 	public ShapeEngine (UserLayer parent_layer, ReEditableLayer? drawing_layer,
 			    BaseEditEngine.ShapeTypes shape_type, bool antialiasing,
 			    bool closed, Color outline_color, Color fill_color,
-			    int brush_width)
+			    int brush_width, LineCap lineCap)
 	{
 		this.parent_layer = parent_layer;
 
@@ -153,6 +155,7 @@ public abstract class ShapeEngine
 		OutlineColor = outline_color;
 		FillColor = fill_color;
 		BrushWidth = brush_width;
+		LineCap = lineCap;
 	}
 
 	protected ShapeEngine (ShapeEngine src)
@@ -164,6 +167,7 @@ public abstract class ShapeEngine
 		OutlineColor = src.OutlineColor;
 		FillColor = src.FillColor;
 		BrushWidth = src.BrushWidth;
+		LineCap = src.LineCap;
 
 		// Don't clone the GeneratedPoints or OrganizedPoints, as they will be calculated.
 		ControlPoints = src.ControlPoints.Select (i => i.Clone ()).ToList ();
@@ -197,7 +201,8 @@ public abstract class ShapeEngine
 				true,
 				OutlineColor,
 				FillColor,
-				BrushWidth
+				BrushWidth,
+				LineCap
 			),
 
 			BaseEditEngine.ShapeTypes.Ellipse => new EllipseEngine (
@@ -206,7 +211,8 @@ public abstract class ShapeEngine
 				AntiAliasing,
 				OutlineColor,
 				FillColor,
-				BrushWidth
+				BrushWidth,
+				LineCap
 			),
 
 			BaseEditEngine.ShapeTypes.RoundedLineSeries => new RoundedLineEngine (
@@ -216,7 +222,8 @@ public abstract class ShapeEngine
 				AntiAliasing,
 				OutlineColor,
 				FillColor,
-				BrushWidth
+				BrushWidth,
+				LineCap
 			),
 
 			_ => new LineCurveSeriesEngine (
@@ -227,7 +234,8 @@ public abstract class ShapeEngine
 				false,
 				OutlineColor,
 				FillColor,
-				BrushWidth
+				BrushWidth,
+				LineCap
 			),//Defaults to OpenLineCurveSeries.
 		};
 

--- a/tests/Pinta.Core.Tests/DashPatternTest.cs
+++ b/tests/Pinta.Core.Tests/DashPatternTest.cs
@@ -7,7 +7,7 @@ namespace Pinta.Core.Tests;
 internal sealed class DashPatternTest
 {
 	[TestCase (LineCap.Butt, "", new double[] { }, 0.0)]
-	[TestCase (LineCap.Butt, "-", new[] { 3.0, 0.0 }, 0.0)]
+	[TestCase (LineCap.Butt, "-", new double[] { }, 0.0)]
 	[TestCase (LineCap.Butt, " ", new double[] { }, 0.0)]
 	[TestCase (LineCap.Butt, " -", new[] { 3.0, 3.0 }, 3.0)]
 	[TestCase (LineCap.Butt, "- -", new[] { 3.0, 3.0, 3.0, 0.0 }, 0.0)]
@@ -19,7 +19,7 @@ internal sealed class DashPatternTest
 	[TestCase (LineCap.Butt, " - - --------", new[] { 3.0, 3.0, 3.0, 3.0, 24.0, 3.0 }, 36.0)]
 
 	[TestCase (LineCap.Square, "", new double[] { }, 0.0)]
-	[TestCase (LineCap.Square, "-", new[] { 1.0, 3.0 }, 0.0)]
+	[TestCase (LineCap.Square, "-", new double[] { }, 0.0)]
 	[TestCase (LineCap.Square, " ", new double[] { }, 0.0)]
 	[TestCase (LineCap.Square, " -", new[] { 1.0, 6.0 }, 2.5)]
 	[TestCase (LineCap.Square, "- -", new[] { 1.0, 6.0, 1.0, 3.0 }, 0.0)]


### PR DESCRIPTION
Fixes #733

I had discovered what caused bug #733 was that "-" and "" are treated differently by the dash engine. So it wasn't noticeable at lower widths, but at larger widths it would cause those artifacts. This fix defaults the "-" dash pattern to "" internally, preventing this issue and drawing it as the user expects.

This approach may be considered a little too hacky? An alternative would be to make the default dashpattern "".

However, this led to a second issue, was that the polygon engine auto-defaults to use `LineCap.Square`. This would produce another artifact in drawing the circle. Defaulting to LineCap.Butt would fix this issue, but it would break rectangle drawing, and hard-coding in to make an exception for ellipse drawing would suck.

So i modified the polygon engine to support each shape drawing tool defining its own linecap. Ellipse tool uses Butt, Rectangle tool uses Square, and Rounded Rectangle uses Butt. Using any dashpattern other than "-" enforces square because dash patterns don't work with butt.

Before dashpattern fix:
![image](https://github.com/user-attachments/assets/380cabc3-62cd-45f5-adfc-b628d4210a81)
![image](https://github.com/user-attachments/assets/1947f648-ff24-4178-801d-42621ddfc027)

After dashpattern fix:

![image](https://github.com/user-attachments/assets/dc2c43fd-503c-4b80-b7af-81cbd9935fa5)
![image](https://github.com/user-attachments/assets/ab009793-acfa-47b3-b349-5f6b0d2755ea)

Final result:

![image](https://github.com/user-attachments/assets/54a0e345-1b98-49a5-9ecf-c652454fc1d6)

And dash patterns still work.

![image](https://github.com/user-attachments/assets/ddc0c050-def1-4861-861d-fc86eb7a8445)



