### PR TITLE
Allow text tool changes to redraw text when state is NotFinalized #952

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -355,8 +355,8 @@ public sealed class TextTool : BaseTool
 
 	private void HandlePintaCorePalettePrimaryColorChanged (object? sender, EventArgs e)
 	{
-		if (is_editing)
-			RedrawText (true, true);
+		if (is_editing || (workspace.HasOpenDocuments && CurrentTextEngine.State == TextMode.NotFinalized))
+			RedrawText (is_editing, true);
 	}
 
 	private void HandleLeftAlignmentButtonToggled (object? sender, EventArgs e)
@@ -432,9 +432,8 @@ public sealed class TextTool : BaseTool
 
 			CurrentTextEngine.SetFont (font, Alignment, underscore_btn.Active);
 		}
-
-		if (is_editing)
-			RedrawText (true, true);
+		if (is_editing || (workspace.HasOpenDocuments && CurrentTextEngine.State == TextMode.NotFinalized))
+			RedrawText (is_editing, true);
 	}
 
 	private int OutlineWidth

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -355,8 +355,8 @@ public sealed class TextTool : BaseTool
 
 	private void HandlePintaCorePalettePrimaryColorChanged (object? sender, EventArgs e)
 	{
-		if (is_editing)
-			RedrawText (true, true);
+		if (is_editing || (workspace.HasOpenDocuments && CurrentTextEngine.State == TextMode.NotFinalized))
+			RedrawText (is_editing, true);
 	}
 
 	private void HandleLeftAlignmentButtonToggled (object? sender, EventArgs e)
@@ -433,8 +433,8 @@ public sealed class TextTool : BaseTool
 			CurrentTextEngine.SetFont (font, Alignment, underscore_btn.Active);
 		}
 
-		if (is_editing)
-			RedrawText (true, true);
+		if (is_editing || (workspace.HasOpenDocuments && CurrentTextEngine.State == TextMode.NotFinalized))
+			RedrawText (is_editing, true);
 	}
 
 	private int OutlineWidth

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -355,8 +355,8 @@ public sealed class TextTool : BaseTool
 
 	private void HandlePintaCorePalettePrimaryColorChanged (object? sender, EventArgs e)
 	{
-		if (is_editing || (workspace.HasOpenDocuments && CurrentTextEngine.State == TextMode.NotFinalized))
-			RedrawText (is_editing, true);
+		if (is_editing)
+			RedrawText (true, true);
 	}
 
 	private void HandleLeftAlignmentButtonToggled (object? sender, EventArgs e)
@@ -432,8 +432,9 @@ public sealed class TextTool : BaseTool
 
 			CurrentTextEngine.SetFont (font, Alignment, underscore_btn.Active);
 		}
-		if (is_editing || (workspace.HasOpenDocuments && CurrentTextEngine.State == TextMode.NotFinalized))
-			RedrawText (is_editing, true);
+
+		if (is_editing)
+			RedrawText (true, true);
 	}
 
 	private int OutlineWidth


### PR DESCRIPTION
Fixes #952 

Redraws of text tool from font updates and color palette changes are not completely blocked by the variable is_editing anymore, it no longer blocks when CurrentTextEngine's state is NotFinalized . Fix works on Windows for me, but have not checked Linux or Mac.