### PR TITLE
Fix incorrect cutting/pasting behavior #951 

### DIFF
--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -251,6 +251,10 @@ public sealed class DocumentLayers
 		var surf = CairoExtensions.CreateImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
 
 		var g = new Context (surf);
+
+		// Use the EvenOdd fill rule to account for "holes" in the selection
+		g.FillRule = FillRule.EvenOdd;
+
 		g.AppendPath (document.Selection.SelectionPath);
 		g.Clip ();
 

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -251,7 +251,7 @@ public sealed class DocumentLayers
 		var surf = CairoExtensions.CreateImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
 
 		var g = new Context (surf);
-		document.Selection.Clip(g);
+		document.Selection.Clip (g);
 
 		g.SetSourceSurface (user_layers[index].Surface, 0, 0);
 		g.Paint ();

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -251,12 +251,7 @@ public sealed class DocumentLayers
 		var surf = CairoExtensions.CreateImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
 
 		var g = new Context (surf);
-
-		// Use the EvenOdd fill rule to account for "holes" in the selection
-		g.FillRule = FillRule.EvenOdd;
-
-		g.AppendPath (document.Selection.SelectionPath);
-		g.Clip ();
+		document.Selection.Clip(g);
 
 		g.SetSourceSurface (user_layers[index].Surface, 0, 0);
 		g.Paint ();


### PR DESCRIPTION
Fixes the bug described in #951 about incorrect cutting/pasting behavior.

Previously, the clipping operation would incorrectly include everything within the outer bounds of the selection, even when the selected area contained unselected regions.

This fix makes sure that inner regions are correctly handled as shown in the video.


https://github.com/user-attachments/assets/e454c41a-d632-449c-a0a0-4b8406c667a7

