### PR TITLE
Fix canvas not updating when deleting layers or redoing/undoing layer changes

### DIFF
--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -334,6 +334,8 @@ public sealed class DocumentLayers
 
 		LayerAdded?.Invoke (this, new IndexEventArgs (index));
 		PintaCore.Layers.OnLayerAdded ();
+
+		document.Workspace.Invalidate ();
 	}
 
 	/// <summary>

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -177,6 +177,8 @@ public sealed class DocumentLayers
 
 		LayerRemoved?.Invoke (this, new IndexEventArgs (index));
 		PintaCore.Layers.OnLayerRemoved ();
+
+		document.Workspace.Invalidate ();
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes issue: #979

Added a call to `Workspace.Invalidate()` in `DocumentLayers.DeleteLayer()` and `DocumentLayers.Insert()` to always update the canvas when a layer is deleted or inserted.

Another alternative would be to invalidate the workspace from the LayerAction that deletes the layer, and from `Undo()`/`Redo()` in `DeleteLayerHistoryItem` if that is preferred?