### PR TITLE
Created method for slicing ROI into tiles, for use inside `AsyncEffectRenderer`

### DIFF
--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -81,7 +81,7 @@ internal abstract class AsyncEffectRenderer
 	bool restart_render_flag;
 	int render_id;
 	int current_tile;
-	ImmutableArray<RectangleI> target_tiles = ImmutableArray<RectangleI>.Empty;
+	readonly ImmutableArray<RectangleI> target_tiles;
 	readonly List<Exception> render_exceptions;
 
 	uint timer_tick_id;
@@ -104,6 +104,10 @@ internal abstract class AsyncEffectRenderer
 		render_exceptions = new List<Exception> ();
 
 		timer_tick_id = 0;
+		target_tiles =
+			settings.EffectIsTileable
+			? settings.RenderBounds.VerticalSliceup ().ToImmutableArray ()
+			: ImmutableArray.Create (settings.RenderBounds);
 
 		this.settings = settings;
 	}
@@ -179,11 +183,6 @@ internal abstract class AsyncEffectRenderer
 		render_exceptions.Clear ();
 
 		current_tile = -1;
-
-		target_tiles =
-			settings.EffectIsTileable
-			? settings.RenderBounds.VerticalSliceup ().ToImmutableArray ()
-			: ImmutableArray.Create (settings.RenderBounds);
 
 		Debug.WriteLine ("AsyncEffectRenderer.Start () Render " + render_id + " starting.");
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -273,10 +273,11 @@ internal abstract class AsyncEffectRenderer
 			}
 		}
 
-		if (exception != null) {
-			lock (render_exceptions) {
-				render_exceptions.Add (exception);
-			}
+		if (exception == null)
+			return;
+
+		lock (render_exceptions) {
+			render_exceptions.Add (exception);
 		}
 	}
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -75,7 +75,6 @@ internal abstract class AsyncEffectRenderer
 	BaseEffect? effect;
 	Cairo.ImageSurface? source_surface;
 	Cairo.ImageSurface? dest_surface;
-	RectangleI render_bounds;
 
 	bool is_rendering;
 	bool cancel_render_flag;
@@ -125,8 +124,7 @@ internal abstract class AsyncEffectRenderer
 	internal void Start (
 		BaseEffect effect,
 		Cairo.ImageSurface source,
-		Cairo.ImageSurface dest,
-		RectangleI renderBounds)
+		Cairo.ImageSurface dest)
 	{
 		Debug.WriteLine ("AsyncEffectRenderer.Start ()");
 
@@ -136,7 +134,6 @@ internal abstract class AsyncEffectRenderer
 
 		source_surface = source;
 		dest_surface = dest;
-		render_bounds = renderBounds;
 
 		// If a render is already in progress, then cancel it,
 		// and start a new render.

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -76,6 +76,18 @@ public static class OtherExtensions
 		}
 	}
 
+	public static IEnumerable<RectangleI> VerticalSliceup (this RectangleI original)
+	{
+		if (original.Height < 0) throw new ArgumentException ("Height cannot be negative", nameof (original));
+		if (original.Height == 0) yield break;
+		for (int i = 0; i < original.Height; i++)
+			yield return new (
+				original.X,
+				original.Y + i,
+				original.Width,
+				1);
+	}
+
 	public static bool In<T> (this T enumeration, params T[] values)
 	{
 		if (enumeration is null)

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -68,12 +68,13 @@ public static class OtherExtensions
 
 	private sealed class ImmutableBackedReadOnlyCollection<T> : ReadOnlyCollection<T>
 	{
-		internal ImmutableBackedReadOnlyCollection (ImmutableList<T> list) : base (list)
-		{
-		}
-		internal ImmutableBackedReadOnlyCollection (ImmutableArray<T> array) : base (array)
-		{
-		}
+		internal ImmutableBackedReadOnlyCollection (ImmutableList<T> list)
+			: base (list)
+		{ }
+
+		internal ImmutableBackedReadOnlyCollection (ImmutableArray<T> array)
+			: base (array)
+		{ }
 	}
 
 	public static IEnumerable<RectangleI> VerticalSliceup (this RectangleI original)

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -77,7 +77,7 @@ public static class OtherExtensions
 		{ }
 	}
 
-	public static IEnumerable<RectangleI> VerticalSliceup (this RectangleI original)
+	public static IEnumerable<RectangleI> ToRows (this RectangleI original)
 	{
 		if (original.Height < 0) throw new ArgumentException ("Height cannot be negative", nameof (original));
 		if (original.Height == 0) yield break;

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -123,17 +123,10 @@ public sealed class LivePreviewManager
 
 		Started?.Invoke (this, new LivePreviewStartedEventArgs ());
 
-		// If the effect isn't tileable, there is a single tile for the entire render bounds.
-		// Otherwise, render each row in parallel.
-		int tileWidth = render_bounds.Width;
-		int tileHeight = 1;
-		if (!effect.IsTileable)
-			tileHeight = render_bounds.Height;
-
 		AsyncEffectRenderer.Settings settings = new (
 			threadCount: system_manager.RenderThreads,
-			tileWidth: tileWidth,
-			tileHeight: tileHeight,
+			renderBounds: render_bounds,
+			effectIsTileable: effect.IsTileable,
 			updateMilliseconds: 100,
 			threadPriority: ThreadPriority.BelowNormal);
 

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -133,7 +133,7 @@ public sealed class LivePreviewManager
 		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "Start Live preview.");
 
 		renderer = new Renderer (this, settings, chrome_manager);
-		renderer.Start (effect, layer.Surface, live_preview_surface, render_bounds);
+		renderer.Start (effect, layer.Surface, live_preview_surface);
 
 		if (effect.IsConfigurable) {
 			EventHandler<BaseEffect.ConfigDialogResponseEventArgs>? handler = null;
@@ -270,7 +270,7 @@ public sealed class LivePreviewManager
 	void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
 	{
 		//TODO calculate bounds.
-		renderer.Start (effect, layer.Surface, live_preview_surface, render_bounds);
+		renderer.Start (effect, layer.Surface, live_preview_surface);
 	}
 
 	private sealed class Renderer : AsyncEffectRenderer

--- a/tests/Pinta.Core.Tests/RectangleTests.cs
+++ b/tests/Pinta.Core.Tests/RectangleTests.cs
@@ -51,7 +51,7 @@ internal sealed class RectangleTests
 	[TestCaseSource (nameof (vertical_slicing_cases))]
 	public void CorrectVerticalSlicing (RectangleI original, IReadOnlyList<RectangleI> expectedSlices)
 	{
-		var actualSlices = original.VerticalSliceup ().ToArray ();
+		var actualSlices = original.ToRows ().ToArray ();
 		Assert.That (actualSlices.Length, Is.EqualTo (expectedSlices.Count));
 		for (int i = 0; i < expectedSlices.Count; i++)
 			Assert.That (actualSlices[i], Is.EqualTo (expectedSlices[i]));

--- a/tests/Pinta.Core.Tests/RectangleTests.cs
+++ b/tests/Pinta.Core.Tests/RectangleTests.cs
@@ -48,6 +48,29 @@ internal sealed class RectangleTests
 	public void CorrectInflation (RectangleI a, int widthInflation, int heightInflation, RectangleI expected)
 		=> Assert.That (a.Inflated (widthInflation, heightInflation), Is.EqualTo (expected));
 
+	[TestCaseSource (nameof (vertical_slicing_cases))]
+	public void CorrectVerticalSlicing (RectangleI original, IReadOnlyList<RectangleI> expectedSlices)
+	{
+		var actualSlices = original.VerticalSliceup ().ToArray ();
+		Assert.That (actualSlices.Length, Is.EqualTo (expectedSlices.Count));
+		for (int i = 0; i < expectedSlices.Count; i++)
+			Assert.That (actualSlices[i], Is.EqualTo (expectedSlices[i]));
+	}
+
+	private static readonly IReadOnlyList<TestCaseData> vertical_slicing_cases = CreateVerticalSlicingCases ().ToArray ();
+	private static IEnumerable<TestCaseData> CreateVerticalSlicingCases ()
+	{
+		yield return new (
+			new RectangleI (1, 1, 5, 5),
+			new[] {
+				new RectangleI(1,1,5,1),
+				new RectangleI(1,2,5,1),
+				new RectangleI(1,3,5,1),
+				new RectangleI(1,4,5,1),
+				new RectangleI(1,5,5,1),
+			});
+	}
+
 	private static readonly IReadOnlyList<TestCaseData> inflation_cases = CreateInflationCases ().ToArray ();
 	private static IEnumerable<TestCaseData> CreateInflationCases ()
 	{


### PR DESCRIPTION
This should get us a step closer towards handling parallelism inside the effects themselves, as discussed in #808 