### PR TITLE
Further refactorings in `AsyncEffectRenderer`

### DIFF
--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -190,13 +190,13 @@ internal abstract class AsyncEffectRenderer
 		int threadCount = settings.ThreadCount;
 		var slaves = new Thread[threadCount - 1];
 		for (int threadId = 1; threadId < threadCount; threadId++)
-			slaves[threadId - 1] = StartSlaveThread (renderId, threadId);
+			slaves[threadId - 1] = StartSlaveThread (renderId);
 
 		// Start the master render thread.
 		Thread master = new (() => {
 
 			// Do part of the rendering on the master thread.
-			Render (renderId, 0);
+			Render (renderId);
 
 			// Wait for slave threads to complete.
 			foreach (var slave in slaves)
@@ -216,10 +216,10 @@ internal abstract class AsyncEffectRenderer
 		timer_tick_id = GLib.Functions.TimeoutAdd (0, (uint) settings.UpdateMillis, () => HandleTimerTick ());
 	}
 
-	Thread StartSlaveThread (int renderId, int threadId)
+	Thread StartSlaveThread (int renderId)
 	{
 		Thread slave = new (() => {
-			Render (renderId, threadId);
+			Render (renderId);
 		}) {
 			Priority = settings.ThreadPriority
 		};
@@ -229,19 +229,19 @@ internal abstract class AsyncEffectRenderer
 	}
 
 	// Runs on a background thread.
-	void Render (int renderId, int threadId)
+	void Render (int renderId)
 	{
 		// Fetch the next tile index and render it.
 		for (; ; ) {
 			int tileIndex = Interlocked.Increment (ref current_tile);
 			if (tileIndex >= target_tiles.Length || cancel_render_flag)
 				return;
-			RenderTile (renderId, threadId, tileIndex);
+			RenderTile (renderId, tileIndex);
 		}
 	}
 
 	// Runs on a background thread.
-	void RenderTile (int renderId, int threadId, int tileIndex)
+	void RenderTile (int renderId, int tileIndex)
 	{
 		Exception? exception = null;
 		RectangleI tileBounds = target_tiles[tileIndex];

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -205,7 +205,7 @@ internal abstract class AsyncEffectRenderer
 		return StartRenderThread (() => {
 
 			// Do part of the rendering on the master thread.
-			Render (renderId);
+			RenderNextTile (renderId);
 
 			// Wait for slave threads to complete.
 			foreach (var slave in slaves)
@@ -222,7 +222,7 @@ internal abstract class AsyncEffectRenderer
 
 	Thread StartSlaveThread (int renderId)
 	{
-		return StartRenderThread (() => Render (renderId));
+		return StartRenderThread (() => RenderNextTile (renderId));
 	}
 
 	Thread StartRenderThread (ThreadStart callback)
@@ -233,55 +233,50 @@ internal abstract class AsyncEffectRenderer
 	}
 
 	// Runs on a background thread.
-	void Render (int renderId)
+	void RenderNextTile (int renderId)
 	{
 		// Fetch the next tile index and render it.
 		for (; ; ) {
+
 			int tileIndex = Interlocked.Increment (ref current_tile);
-			if (tileIndex >= target_tiles.Length || cancel_render_flag)
-				return;
-			RenderTile (renderId, tileIndex);
-		}
-	}
+			if (tileIndex >= target_tiles.Length || cancel_render_flag) return;
 
-	// Runs on a background thread.
-	void RenderTile (int renderId, int tileIndex)
-	{
-		Exception? exception = null;
-		RectangleI tileBounds = target_tiles[tileIndex];
+			Exception? exception = null;
+			RectangleI tileBounds = target_tiles[tileIndex];
 
-		try {
-			// NRT - These are set in Start () before getting here
-			if (!cancel_render_flag) {
-				dest_surface!.Flush ();
-				effect!.Render (source_surface!, dest_surface, stackalloc[] { tileBounds });
-				dest_surface.MarkDirty (tileBounds);
+			try {
+				// NRT - These are set in Start () before getting here
+				if (!cancel_render_flag) {
+					dest_surface!.Flush ();
+					effect!.Render (source_surface!, dest_surface, stackalloc[] { tileBounds });
+					dest_surface.MarkDirty (tileBounds);
+				}
+
+			} catch (Exception ex) {
+				exception = ex;
+				Debug.WriteLine ("AsyncEffectRenderer Error while rendering effect: " + effect!.Name + " exception: " + ex.Message + "\n" + ex.StackTrace);
 			}
 
-		} catch (Exception ex) {
-			exception = ex;
-			Debug.WriteLine ("AsyncEffectRenderer Error while rendering effect: " + effect!.Name + " exception: " + ex.Message + "\n" + ex.StackTrace);
-		}
+			// Ignore completions of tiles after a cancel or from a previous render.
+			if (!IsRendering || renderId != render_id)
+				continue;
 
-		// Ignore completions of tiles after a cancel or from a previous render.
-		if (!IsRendering || renderId != render_id)
-			return;
-
-		// Update bounds to be shown on next expose.
-		lock (updated_lock) {
-			if (is_updated) {
-				updated_area = RectangleI.Union (tileBounds, updated_area);
-			} else {
-				is_updated = true;
-				updated_area = tileBounds;
+			// Update bounds to be shown on next expose.
+			lock (updated_lock) {
+				if (is_updated) {
+					updated_area = RectangleI.Union (tileBounds, updated_area);
+				} else {
+					is_updated = true;
+					updated_area = tileBounds;
+				}
 			}
-		}
 
-		if (exception == null)
-			return;
+			if (exception == null)
+				continue;
 
-		lock (render_exceptions) {
-			render_exceptions.Add (exception);
+			lock (render_exceptions) {
+				render_exceptions.Add (exception);
+			}
 		}
 	}
 


### PR DESCRIPTION
- Inlined `RenderTile`
- Extracted method `StartMasterThread`. Now it's obvious what the mechanism does (one tile per thread, including the master thread, which additionally coordinates the slave joins)
- Used concurrent structure for exception list, in order to remove lock