### PR TITLE
Refactored `AsyncEffectRenderer` to use `CancellationToken`

### DIFF
--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -170,16 +170,13 @@ internal abstract class AsyncEffectRenderer
 		timer_tick_id = 0;
 	}
 
-	readonly object cancellation_source_lock = new ();
 	CancellationToken ReplaceCancellationSource ()
 	{
-		lock (cancellation_source_lock) {
-			CancellationTokenSource newSource = new ();
-			cancellation_source.Cancel ();
-			cancellation_source.Dispose ();
-			cancellation_source = newSource;
-			return newSource.Token;
-		}
+		CancellationTokenSource newSource = new ();
+		CancellationTokenSource oldSource = Interlocked.Exchange (ref cancellation_source, newSource);
+		oldSource.Cancel ();
+		oldSource.Dispose ();
+		return newSource.Token;
 	}
 
 	void StartRender ()

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -181,12 +181,11 @@ internal abstract class AsyncEffectRenderer
 		restart_render_flag = false;
 		is_updated = false;
 
-		CancellationToken cancellationToken;
-		lock (cancellation_source) {
-			cancellation_source.Cancel ();
-			cancellation_source = new ();
-			cancellationToken = cancellation_source.Token;
-		}
+		cancellation_source.Cancel ();
+		cancellation_source.Dispose ();
+		cancellation_source = new ();
+
+		CancellationToken cancellationToken = cancellation_source.Token;
 
 		render_exceptions.Clear ();
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -170,10 +170,10 @@ internal abstract class AsyncEffectRenderer
 		timer_tick_id = 0;
 	}
 
-	readonly object cancellation_token_lock = new ();
+	readonly object cancellation_source_lock = new ();
 	CancellationToken ReplaceCancellationSource ()
 	{
-		lock (cancellation_token_lock) {
+		lock (cancellation_source_lock) {
 			CancellationTokenSource newSource = new ();
 			cancellation_source.Cancel ();
 			cancellation_source.Dispose ();

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -173,9 +173,10 @@ internal abstract class AsyncEffectRenderer
 	CancellationToken ReplaceCancellationSource ()
 	{
 		CancellationTokenSource newSource = new ();
-		CancellationTokenSource oldSource = Interlocked.Exchange (ref cancellation_source, newSource);
+		CancellationTokenSource oldSource = cancellation_source;
 		oldSource.Cancel ();
 		oldSource.Dispose ();
+		cancellation_source = newSource;
 		return newSource.Token;
 	}
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -281,7 +281,7 @@ internal abstract class AsyncEffectRenderer
 
 			// Ignore completions of tiles after a cancel or from a previous render.
 			if (!IsRendering || cancellationToken.IsCancellationRequested)
-				continue;
+				return;
 
 			// Update bounds to be shown on next expose.
 			lock (updated_lock) {


### PR DESCRIPTION
The `render_id` is used for cancellation only. Instead of this, we could make it clearer.

Additionally, I made certain methods local _and_ identified a better way to abort a rendering (with `return` instead of `continue`). I tried in an Ubuntu virtual machine and it feels the delay until the start of the next rendering is shorter.

There is still some way to go. If we want to handle parallelism inside the methods, the code for creating and coordinating the tiles and threads needs to be very simple and easy to understand by anyone wanting to develop an extension.