### PR TITLE
Removed `PintaCore` references from `ErrorDialog`, `HistoryPad`, and `LayersPad`

### DIFF
--- a/Pinta/Dialogs/ErrorDialog.cs
+++ b/Pinta/Dialogs/ErrorDialog.cs
@@ -24,14 +24,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Gtk;
 using Pinta.Core;
 
 namespace Pinta;
 
-public static class ErrorDialog
+internal sealed class ErrorDialog
 {
-	public static void ShowMessage (Window parent, string message, string body)
+	private readonly HelpActions help;
+	internal ErrorDialog (HelpActions help)
+	{
+		this.help = help;
+	}
+
+	internal static void ShowMessage (
+		Gtk.Window parent,
+		string message,
+		string body)
 	{
 		System.Console.Error.WriteLine ("Pinta: {0}\n{1}", message, body);
 
@@ -45,7 +53,11 @@ public static class ErrorDialog
 		dialog.Present ();
 	}
 
-	public static void ShowError (Window parent, string message, string body, string details)
+	internal void ShowError (
+		Gtk.Window parent,
+		string message,
+		string body,
+		string details)
 	{
 		System.Console.Error.WriteLine ("Pinta: {0}\n{1}", message, details);
 
@@ -72,7 +84,7 @@ public static class ErrorDialog
 
 		dialog.OnResponse += (_, args) => {
 			if (args.Response == bug_response)
-				PintaCore.Actions.Help.Bugs.Activate ();
+				help.Bugs.Activate ();
 		};
 
 		dialog.Present ();

--- a/Pinta/Pads/HistoryPad.cs
+++ b/Pinta/Pads/HistoryPad.cs
@@ -24,30 +24,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Gtk;
 using Pinta.Core;
 using Pinta.Docking;
 using Pinta.Gui.Widgets;
 
 namespace Pinta;
 
-public sealed class HistoryPad : IDockPad
+internal sealed class HistoryPad : IDockPad
 {
-	public void Initialize (Dock workspace, Application app, Gio.Menu padMenu)
+	private readonly EditActions edit;
+	internal HistoryPad (EditActions edit)
 	{
-		var history = new HistoryListView ();
-		DockItem history_item = new DockItem (history, "History", iconName: Pinta.Resources.Icons.HistoryList) {
-			Label = Translations.GetString ("History")
+		this.edit = edit;
+	}
+
+	public void Initialize (
+		Dock workspace,
+		Gtk.Application app,
+		Gio.Menu padMenu)
+	{
+		HistoryListView history = new ();
+		DockItem history_item = new (history, "History", iconName: Pinta.Resources.Icons.HistoryList) {
+			Label = Translations.GetString ("History"),
 		};
 
-		var history_tb = history_item.AddToolBar ();
-		history_tb.Append (PintaCore.Actions.Edit.Undo.CreateDockToolBarItem ());
-		history_tb.Append (PintaCore.Actions.Edit.Redo.CreateDockToolBarItem ());
+		Gtk.Box history_tb = history_item.AddToolBar ();
+		history_tb.Append (edit.Undo.CreateDockToolBarItem ());
+		history_tb.Append (edit.Redo.CreateDockToolBarItem ());
 
 		workspace.AddItem (history_item, DockPlacement.Right);
 
-		var show_history = new ToggleCommand ("history", Translations.GetString ("History"), null, Resources.Icons.LayerDuplicate) {
-			Value = true
+		ToggleCommand show_history = new ("history", Translations.GetString ("History"), null, Resources.Icons.LayerDuplicate) {
+			Value = true,
 		};
 		app.AddAction (show_history);
 		padMenu.AppendItem (show_history.CreateMenuItem ());

--- a/Pinta/Pads/LayersPad.cs
+++ b/Pinta/Pads/LayersPad.cs
@@ -24,34 +24,42 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Gtk;
 using Pinta.Core;
 using Pinta.Docking;
 using Pinta.Gui.Widgets;
 
 namespace Pinta;
 
-public sealed class LayersPad : IDockPad
+internal sealed class LayersPad : IDockPad
 {
-	public void Initialize (Dock workspace, Application app, Gio.Menu padMenu)
+	private readonly LayerActions layer_actions;
+	internal LayersPad (LayerActions layerActions)
 	{
-		var layers = new LayersListView ();
+		layer_actions = layerActions;
+	}
+
+	public void Initialize (
+		Dock workspace,
+		Gtk.Application app,
+		Gio.Menu padMenu)
+	{
+		LayersListView layers = new ();
 		DockItem layers_item = new DockItem (layers, "Layers", iconName: Pinta.Resources.Icons.LayerDuplicate) {
-			Label = Translations.GetString ("Layers")
+			Label = Translations.GetString ("Layers"),
 		};
 
-		var layers_tb = layers_item.AddToolBar ();
-		layers_tb.Append (PintaCore.Actions.Layers.AddNewLayer.CreateDockToolBarItem ());
-		layers_tb.Append (PintaCore.Actions.Layers.DeleteLayer.CreateDockToolBarItem ());
-		layers_tb.Append (PintaCore.Actions.Layers.DuplicateLayer.CreateDockToolBarItem ());
-		layers_tb.Append (PintaCore.Actions.Layers.MergeLayerDown.CreateDockToolBarItem ());
-		layers_tb.Append (PintaCore.Actions.Layers.MoveLayerUp.CreateDockToolBarItem ());
-		layers_tb.Append (PintaCore.Actions.Layers.MoveLayerDown.CreateDockToolBarItem ());
+		Gtk.Box layers_tb = layers_item.AddToolBar ();
+		layers_tb.Append (layer_actions.AddNewLayer.CreateDockToolBarItem ());
+		layers_tb.Append (layer_actions.DeleteLayer.CreateDockToolBarItem ());
+		layers_tb.Append (layer_actions.DuplicateLayer.CreateDockToolBarItem ());
+		layers_tb.Append (layer_actions.MergeLayerDown.CreateDockToolBarItem ());
+		layers_tb.Append (layer_actions.MoveLayerUp.CreateDockToolBarItem ());
+		layers_tb.Append (layer_actions.MoveLayerDown.CreateDockToolBarItem ());
 
 		workspace.AddItem (layers_item, DockPlacement.Right);
 
-		var show_layers = new ToggleCommand ("layers", Translations.GetString ("Layers"), null, Resources.Icons.LayerMergeDown) {
-			Value = true
+		ToggleCommand show_layers = new ("layers", Translations.GetString ("Layers"), null, Resources.Icons.LayerMergeDown) {
+			Value = true,
 		};
 		app.AddAction (show_layers);
 		padMenu.AppendItem (show_layers.CreateMenuItem ());


### PR DESCRIPTION
This required making `ErrorDialog` non-static, because `ShowError` is required to have a specific signature (see argument of `InitializeErrorDialogHandler`)