### PR TITLE
`ErrorDialog.ShowError` and `ErrorDialog.ShowMessage` were made asynchronous

### DIFF
--- a/Pinta.Core/Actions/HelpActions.cs
+++ b/Pinta.Core/Actions/HelpActions.cs
@@ -84,21 +84,21 @@ public sealed class HelpActions
 
 	private void Bugs_Activated (object sender, EventArgs e)
 	{
-		GtkExtensions.LaunchUri ("https://github.com/PintaProject/Pinta/issues");
+		system.LaunchUri ("https://github.com/PintaProject/Pinta/issues");
 	}
 
 	private void DisplayHelp (object sender, EventArgs e)
 	{
-		GtkExtensions.LaunchUri ("https://pinta-project.com/user-guide");
+		system.LaunchUri ("https://pinta-project.com/user-guide");
 	}
 
 	private void Translate_Activated (object sender, EventArgs e)
 	{
-		GtkExtensions.LaunchUri ("https://hosted.weblate.org/engage/pinta/");
+		system.LaunchUri ("https://hosted.weblate.org/engage/pinta/");
 	}
 
 	private void Website_Activated (object sender, EventArgs e)
 	{
-		GtkExtensions.LaunchUri ("https://www.pinta-project.com");
+		system.LaunchUri ("https://www.pinta-project.com");
 	}
 }

--- a/Pinta.Core/DialogResponses.cs
+++ b/Pinta.Core/DialogResponses.cs
@@ -1,0 +1,7 @@
+namespace Pinta.Core;
+
+public enum DialogResponses
+{
+	OK,
+	Bug,
+}

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -400,8 +400,18 @@ public static partial class GtkExtensions
 	public static Task<string> RunAsync (this Adw.MessageDialog dialog)
 	{
 		TaskCompletionSource<string> tcs = new ();
-		dialog.OnResponse += (_, args) => tcs.SetResult (args.Response);
-		dialog.Show ();
+
+		void ResponseCallback (
+			Adw.MessageDialog sender,
+			Adw.MessageDialog.ResponseSignalArgs args)
+		{
+			tcs.SetResult (args.Response);
+			dialog.OnResponse -= ResponseCallback;
+		}
+
+		dialog.OnResponse += ResponseCallback;
+		dialog.Present ();
+
 		return tcs.Task;
 	}
 

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -605,10 +605,12 @@ public static partial class GtkExtensions
 		attrs = new Pango.AttrList (attrs_handle);
 	}
 
-	public static async void LaunchUri (string uri)
+	public static async void LaunchUri (
+		this SystemManager system,
+		string uri)
 	{
 		// Workaround for macOS, which produces an "unsupported on current backend" error (https://gitlab.gnome.org/GNOME/gtk/-/issues/6788)
-		if (PintaCore.System.OperatingSystem == OS.Mac) {
+		if (system.OperatingSystem == OS.Mac) {
 			var process = System.Diagnostics.Process.Start ("open", uri);
 			process.WaitForExit ();
 		} else {

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -159,9 +159,9 @@ public sealed class ChromeManager : IChromeService
 		}
 	}
 
-	public void ShowMessageDialog (Gtk.Window parent, string message, string body)
+	public async void ShowMessageDialog (Gtk.Window parent, string message, string body)
 	{
-		message_dialog_handler (parent, message, body);
+		await message_dialog_handler (parent, message, body);
 	}
 
 	public void SetStatusBarText (string text)
@@ -199,5 +199,5 @@ public interface IProgressDialog
 }
 
 public delegate Task<string> ErrorDialogHandler (Gtk.Window parent, string message, string body, string details);
-public delegate void MessageDialogHandler (Gtk.Window parent, string message, string body);
+public delegate Task MessageDialogHandler (Gtk.Window parent, string message, string body);
 public delegate Task<bool> SimpleEffectDialogHandler (BaseEffect effect, IAddinLocalizer localizer);

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -145,9 +145,18 @@ public sealed class ChromeManager : IChromeService
 		simple_effect_dialog_handler = handler;
 	}
 
-	public void ShowErrorDialog (Gtk.Window parent, string message, string body, string details)
+	public async void ShowErrorDialog (
+		Gtk.Window parent,
+		string message,
+		string body,
+		string details)
 	{
-		error_dialog_handler (parent, message, body, details);
+		string response = await error_dialog_handler (parent, message, body, details);
+		switch (response) {
+			case nameof (DialogResponses.Bug):
+				PintaCore.Actions.Help.Bugs.Activate ();
+				break;
+		}
 	}
 
 	public void ShowMessageDialog (Gtk.Window parent, string message, string body)
@@ -189,6 +198,6 @@ public interface IProgressDialog
 	event EventHandler<EventArgs> Canceled;
 }
 
-public delegate void ErrorDialogHandler (Gtk.Window parent, string message, string body, string details);
+public delegate Task<string> ErrorDialogHandler (Gtk.Window parent, string message, string body, string details);
 public delegate void MessageDialogHandler (Gtk.Window parent, string message, string body);
 public delegate Task<bool> SimpleEffectDialogHandler (BaseEffect effect, IAddinLocalizer localizer);

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -151,9 +151,9 @@ public sealed class ChromeManager : IChromeService
 		string body,
 		string details)
 	{
-		string response = await error_dialog_handler (parent, message, body, details);
+		ErrorDialogResponse response = await error_dialog_handler (parent, message, body, details);
 		switch (response) {
-			case nameof (DialogResponses.Bug):
+			case ErrorDialogResponse.Bug:
 				PintaCore.Actions.Help.Bugs.Activate ();
 				break;
 		}
@@ -198,6 +198,6 @@ public interface IProgressDialog
 	event EventHandler<EventArgs> Canceled;
 }
 
-public delegate Task<string> ErrorDialogHandler (Gtk.Window parent, string message, string body, string details);
+public delegate Task<ErrorDialogResponse> ErrorDialogHandler (Gtk.Window parent, string message, string body, string details);
 public delegate Task MessageDialogHandler (Gtk.Window parent, string message, string body);
 public delegate Task<bool> SimpleEffectDialogHandler (BaseEffect effect, IAddinLocalizer localizer);

--- a/Pinta.Core/Messages/ErrorDialogResponse.cs
+++ b/Pinta.Core/Messages/ErrorDialogResponse.cs
@@ -1,6 +1,6 @@
 namespace Pinta.Core;
 
-public enum DialogResponses
+public enum ErrorDialogResponse
 {
 	OK,
 	Bug,

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -24,7 +24,6 @@ internal sealed class AddinInfoView : Adw.Bin
 	private readonly Adw.Bin empty_page;
 
 	private readonly Adw.ViewStack view_stack;
-
 	private AddinListViewItem? current_item;
 
 	/// <summary>
@@ -32,7 +31,9 @@ internal sealed class AddinInfoView : Adw.Bin
 	/// </summary>
 	public event EventHandler? OnAddinChanged;
 
-	public AddinInfoView ()
+	private readonly SystemManager system;
+
+	public AddinInfoView (SystemManager system)
 	{
 		// --- Control creation
 
@@ -109,6 +110,8 @@ internal sealed class AddinInfoView : Adw.Bin
 		empty_page = emptyPage;
 
 		view_stack = viewStack;
+
+		this.system = system;
 	}
 
 	private Gtk.Switch CreateEnableSwitch ()
@@ -229,7 +232,7 @@ internal sealed class AddinInfoView : Adw.Bin
 
 	private void HandleInfoButtonClicked ()
 	{
-		GtkExtensions.LaunchUri (current_item!.Url);
+		system.LaunchUri (current_item!.Url);
 	}
 
 	private void HandleInstallButtonClicked ()

--- a/Pinta.Gui.Addins/AddinListView.cs
+++ b/Pinta.Gui.Addins/AddinListView.cs
@@ -1,5 +1,4 @@
 using System;
-using Gtk;
 using Mono.Addins;
 using Mono.Addins.Setup;
 using Pinta.Core;
@@ -25,7 +24,7 @@ internal sealed class AddinListView : Adw.Bin
 	/// </summary>
 	public event EventHandler? OnAddinChanged;
 
-	public AddinListView ()
+	public AddinListView (SystemManager system)
 	{
 		model = Gio.ListStore.New (AddinListViewItem.GetGType ());
 
@@ -46,12 +45,12 @@ internal sealed class AddinListView : Adw.Bin
 		};
 
 		// TODO - have an option to group by category like the old GTK2 addin dialog.
-		list_view = ListView.New (selection_model, factory);
+		list_view = Gtk.ListView.New (selection_model, factory);
 
 		list_view_scroll = Gtk.ScrolledWindow.New ();
 		list_view_scroll.SetChild (list_view);
 		list_view_scroll.SetSizeRequest (300, 400);
-		list_view_scroll.SetPolicy (PolicyType.Automatic, PolicyType.Automatic);
+		list_view_scroll.SetPolicy (Gtk.PolicyType.Automatic, Gtk.PolicyType.Automatic);
 
 		empty_list_page = new Adw.StatusPage () {
 			IconName = StandardIcons.SystemSearch,
@@ -63,15 +62,15 @@ internal sealed class AddinListView : Adw.Bin
 		list_view_stack.Add (list_view_scroll);
 		list_view_stack.Add (empty_list_page);
 
-		info_view = new AddinInfoView ();
+		info_view = new AddinInfoView (system);
 		info_view.OnAddinChanged += (o, e) => OnAddinChanged?.Invoke (o, e);
 
 		var flap = Adw.Flap.New ();
 		flap.FoldPolicy = Adw.FlapFoldPolicy.Never;
 		flap.Locked = true;
 		flap.Content = list_view_stack;
-		flap.Separator = Gtk.Separator.New (Orientation.Vertical);
-		flap.FlapPosition = PackType.End;
+		flap.Separator = Gtk.Separator.New (Gtk.Orientation.Vertical);
+		flap.FlapPosition = Gtk.PackType.End;
 		flap.SetFlap (info_view);
 		SetChild (flap);
 	}

--- a/Pinta.Gui.Addins/AddinManagerDialog.cs
+++ b/Pinta.Gui.Addins/AddinManagerDialog.cs
@@ -12,6 +12,7 @@ namespace Pinta.Gui.Addins;
 public sealed class AddinManagerDialog : Adw.Window
 {
 	private readonly SetupService service;
+	private readonly SystemManager system;
 
 	private readonly AddinListView installed_list;
 	private readonly AddinListView updates_list;
@@ -19,7 +20,10 @@ public sealed class AddinManagerDialog : Adw.Window
 
 	private readonly StatusProgressBar progress_bar;
 
-	public AddinManagerDialog (Gtk.Window parent, SetupService service)
+	public AddinManagerDialog (
+		Gtk.Window parent,
+		SetupService service,
+		SystemManager system)
 	{
 		// TODO - add a dialog for managing the list of repositories.
 		// TODO - support searching through the gallery
@@ -63,6 +67,7 @@ public sealed class AddinManagerDialog : Adw.Window
 		// --- References to keep
 
 		this.service = service;
+		this.system = system;
 
 		progress_bar = progressBar;
 
@@ -89,7 +94,7 @@ public sealed class AddinManagerDialog : Adw.Window
 
 	private AddinListView CreateAddinList ()
 	{
-		AddinListView result = new ();
+		AddinListView result = new (system);
 		result.OnAddinChanged += (_, _) => LoadAll ();
 		return result;
 	}

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -42,6 +42,7 @@ public sealed class ActionHandlers
 		RecentFileManager recentFiles = PintaCore.RecentFiles;
 		ImageConverterManager imageFormats = PintaCore.ImageFormats;
 		SettingsManager settings = PintaCore.Settings;
+		SystemManager system = PintaCore.System;
 		ToolManager tools = PintaCore.Tools;
 		PaletteManager palette = PintaCore.Palette;
 		string applicationVersion = PintaCore.ApplicationVersion;
@@ -66,7 +67,7 @@ public sealed class ActionHandlers
 			new PasteIntoNewLayerAction (actions, chrome, workspace, tools),
 			new PasteIntoNewImageAction (actions, chrome, workspace),
 			new ResizePaletteAction (actions.Edit, chrome, palette),
-			new AddinManagerAction (actions.Addins, chrome),
+			new AddinManagerAction (actions.Addins, chrome, system),
 
 			// Image
 			new ResizeImageAction (actions.Image, chrome, workspace),

--- a/Pinta/Actions/Addins/AddinManagerAction.cs
+++ b/Pinta/Actions/Addins/AddinManagerAction.cs
@@ -34,12 +34,15 @@ internal sealed class AddinManagerAction : IActionHandler
 {
 	private readonly AddinActions addins;
 	private readonly ChromeManager chrome;
+	private readonly SystemManager system;
 	internal AddinManagerAction (
 		AddinActions addins,
-		ChromeManager chrome)
+		ChromeManager chrome,
+		SystemManager system)
 	{
 		this.addins = addins;
 		this.chrome = chrome;
+		this.system = system;
 	}
 
 	void IActionHandler.Initialize ()
@@ -55,7 +58,7 @@ internal sealed class AddinManagerAction : IActionHandler
 	private void Activated (object sender, EventArgs e)
 	{
 		AddinSetupService service = new (Mono.Addins.AddinManager.Registry);
-		AddinManagerDialog dialog = new (chrome.MainWindow, service);
+		AddinManagerDialog dialog = new (chrome.MainWindow, service, system);
 		dialog.Show ();
 	}
 }

--- a/Pinta/Dialogs/ErrorDialog.cs
+++ b/Pinta/Dialogs/ErrorDialog.cs
@@ -31,20 +31,20 @@ namespace Pinta;
 
 internal static class ErrorDialog
 {
-	internal static void ShowMessage (
+	internal static Task ShowMessage (
 		Gtk.Window parent,
 		string message,
 		string body)
 	{
 		System.Console.Error.WriteLine ("Pinta: {0}\n{1}", message, body);
 
-		var dialog = Adw.MessageDialog.New (parent, message, body);
+		Adw.MessageDialog dialog = Adw.MessageDialog.New (parent, message, body);
 
 		dialog.AddResponse (nameof (DialogResponses.OK), Translations.GetString ("_OK"));
 		dialog.DefaultResponse = nameof (DialogResponses.OK);
 		dialog.CloseResponse = nameof (DialogResponses.OK);
 
-		dialog.Present ();
+		return dialog.RunAsync ();
 	}
 
 	/// <returns>

--- a/Pinta/Dialogs/ErrorDialog.cs
+++ b/Pinta/Dialogs/ErrorDialog.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Threading.Tasks;
 using Pinta.Core;
 
@@ -40,21 +41,14 @@ internal static class ErrorDialog
 
 		Adw.MessageDialog dialog = Adw.MessageDialog.New (parent, message, body);
 
-		dialog.AddResponse (nameof (DialogResponses.OK), Translations.GetString ("_OK"));
-		dialog.DefaultResponse = nameof (DialogResponses.OK);
-		dialog.CloseResponse = nameof (DialogResponses.OK);
+		dialog.AddResponse (nameof (ErrorDialogResponse.OK), Translations.GetString ("_OK"));
+		dialog.DefaultResponse = nameof (ErrorDialogResponse.OK);
+		dialog.CloseResponse = nameof (ErrorDialogResponse.OK);
 
 		return dialog.RunAsync ();
 	}
 
-	/// <returns>
-	/// Either
-	/// <see cref="DialogResponses.OK"/>
-	/// or
-	/// <see cref="DialogResponses.Bug"/>
-	/// as a string, depending on the user's response
-	/// </returns>
-	internal static Task<string> ShowError (
+	internal static async Task<ErrorDialogResponse> ShowError (
 		Gtk.Window parent,
 		string message,
 		string body,
@@ -74,12 +68,14 @@ internal static class ErrorDialog
 
 		Adw.MessageDialog dialog = Adw.MessageDialog.New (parent, message, body);
 		dialog.SetExtraChild (expander);
-		dialog.AddResponse (nameof (DialogResponses.Bug), Translations.GetString ("Report Bug..."));
-		dialog.SetResponseAppearance (nameof (DialogResponses.Bug), Adw.ResponseAppearance.Suggested);
-		dialog.AddResponse (nameof (DialogResponses.OK), Translations.GetString ("_OK"));
-		dialog.DefaultResponse = nameof (DialogResponses.OK);
-		dialog.CloseResponse = nameof (DialogResponses.OK);
+		dialog.AddResponse (nameof (ErrorDialogResponse.Bug), Translations.GetString ("Report Bug..."));
+		dialog.SetResponseAppearance (nameof (ErrorDialogResponse.Bug), Adw.ResponseAppearance.Suggested);
+		dialog.AddResponse (nameof (ErrorDialogResponse.OK), Translations.GetString ("_OK"));
+		dialog.DefaultResponse = nameof (ErrorDialogResponse.OK);
+		dialog.CloseResponse = nameof (ErrorDialogResponse.OK);
 
-		return dialog.RunAsync ();
+		string responseText = await dialog.RunAsync ();
+
+		return Enum.Parse<ErrorDialogResponse> (responseText);
 	}
 }

--- a/Pinta/Dialogs/ErrorDialog.cs
+++ b/Pinta/Dialogs/ErrorDialog.cs
@@ -24,18 +24,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Threading.Tasks;
 using Pinta.Core;
 
 namespace Pinta;
 
-internal sealed class ErrorDialog
+internal static class ErrorDialog
 {
-	private readonly HelpActions help;
-	internal ErrorDialog (HelpActions help)
-	{
-		this.help = help;
-	}
-
 	internal static void ShowMessage (
 		Gtk.Window parent,
 		string message,
@@ -45,15 +40,14 @@ internal sealed class ErrorDialog
 
 		var dialog = Adw.MessageDialog.New (parent, message, body);
 
-		const string ok_response = "ok";
-		dialog.AddResponse (ok_response, Translations.GetString ("_OK"));
-		dialog.DefaultResponse = ok_response;
-		dialog.CloseResponse = ok_response;
+		dialog.AddResponse (nameof (DialogResponses.OK), Translations.GetString ("_OK"));
+		dialog.DefaultResponse = nameof (DialogResponses.OK);
+		dialog.CloseResponse = nameof (DialogResponses.OK);
 
 		dialog.Present ();
 	}
 
-	internal void ShowError (
+	internal static Task<string> ShowError (
 		Gtk.Window parent,
 		string message,
 		string body,
@@ -61,33 +55,24 @@ internal sealed class ErrorDialog
 	{
 		System.Console.Error.WriteLine ("Pinta: {0}\n{1}", message, details);
 
-		var dialog = Adw.MessageDialog.New (parent, message, body);
-
-		var text_view = Gtk.TextView.New ();
+		Gtk.TextView text_view = Gtk.TextView.New ();
 		text_view.Buffer!.SetText (details, -1);
 
-		var scroll = Gtk.ScrolledWindow.New ();
+		Gtk.ScrolledWindow scroll = Gtk.ScrolledWindow.New ();
 		scroll.HeightRequest = 250;
 		scroll.SetChild (text_view);
 
-		var expander = Gtk.Expander.New (Translations.GetString ("Details"));
+		Gtk.Expander expander = Gtk.Expander.New (Translations.GetString ("Details"));
 		expander.SetChild (scroll);
+
+		Adw.MessageDialog dialog = Adw.MessageDialog.New (parent, message, body);
 		dialog.SetExtraChild (expander);
+		dialog.AddResponse (nameof (DialogResponses.Bug), Translations.GetString ("Report Bug..."));
+		dialog.SetResponseAppearance (nameof (DialogResponses.Bug), Adw.ResponseAppearance.Suggested);
+		dialog.AddResponse (nameof (DialogResponses.OK), Translations.GetString ("_OK"));
+		dialog.DefaultResponse = nameof (DialogResponses.OK);
+		dialog.CloseResponse = nameof (DialogResponses.OK);
 
-		const string bug_response = "bug";
-		const string ok_response = "ok";
-		dialog.AddResponse (bug_response, Translations.GetString ("Report Bug..."));
-		dialog.SetResponseAppearance (bug_response, Adw.ResponseAppearance.Suggested);
-		dialog.AddResponse (ok_response, Translations.GetString ("_OK"));
-		dialog.DefaultResponse = ok_response;
-		dialog.CloseResponse = ok_response;
-
-		dialog.OnResponse += (_, args) => {
-			if (args.Response == bug_response)
-				help.Bugs.Activate ();
-		};
-
-		dialog.Present ();
+		return dialog.RunAsync ();
 	}
 }
-

--- a/Pinta/Dialogs/ErrorDialog.cs
+++ b/Pinta/Dialogs/ErrorDialog.cs
@@ -47,6 +47,13 @@ internal static class ErrorDialog
 		dialog.Present ();
 	}
 
+	/// <returns>
+	/// Either
+	/// <see cref="DialogResponses.OK"/>
+	/// or
+	/// <see cref="DialogResponses.Bug"/>
+	/// as a string, depending on the user's response
+	/// </returns>
 	internal static Task<string> ShowError (
 		Gtk.Window parent,
 		string message,

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -65,10 +65,8 @@ internal sealed class MainWindow
 		// Initialize interface things
 		_ = new ActionHandlers ();
 
-		ErrorDialog errorDialog = new (PintaCore.Actions.Help);
-
 		PintaCore.Chrome.InitializeProgessDialog (new ProgressDialog (PintaCore.Chrome));
-		PintaCore.Chrome.InitializeErrorDialogHandler (errorDialog.ShowError);
+		PintaCore.Chrome.InitializeErrorDialogHandler (ErrorDialog.ShowError);
 		PintaCore.Chrome.InitializeMessageDialog (ErrorDialog.ShowMessage);
 		PintaCore.Chrome.InitializeSimpleEffectDialog (SimpleEffectDialog.Launch);
 


### PR DESCRIPTION
Since the response of `ErrorDialog.ShowError` doesn't have to be handled inside its body anymore, I was able to take out the system manager field out of `ErrorDialog`, which means it can be made `static` again.

I refactored `SystemManager` out of several places, trying very hard not to re-introduce `PintaCore` references to places where it was already gone, but unfortunately I had to do it temporarily inside `ChromeManager.ShowErrorDialog`, for the following reasons:
- I could delegate further and return a `Task<string>` from `ChromeManager.ShowErrorDialog`, and the caller would be responsible for opening the bug tracker, but I think it wouldn't be appropriate
- I could fix that by fixing the interdependencies between services (namely `GtkExtensions.LaunchUri` should instead be part of a separate service, possibly `SystemCommandsManager`, that doesn't exist yet), but that would result in a pull request that is very hard to review, so I propose leaving it like this for now and fixing this later

Other than that, `GtkExtensions.RunAsync` was changed slightly so that it removes the response callback after it runs, to prevent memory leaks just for _showing_ the dialog.