### PR TITLE
Add a flathub badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
+
 # Pinta - [Simple Gtk# Paint Program](http://pinta-project.com/)
 
+<a href='https://flathub.org/apps/com.github.PintaProject.Pinta'><img width='200' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en'/></a>
 [![Translation status](https://hosted.weblate.org/widget/pinta/pinta/287x66-grey.png)](https://hosted.weblate.org/engage/pinta/)
 [![Build Status](https://github.com/PintaProject/Pinta/workflows/Build/badge.svg)](https://github.com/PintaProject/Pinta/actions)
 


### PR DESCRIPTION
This simply adds a "Get it on flathub" badge to the README, as is commonly seen for other applications available on flathub.  
This would make it instantly clear that the software works on linux without needing to build it yourself (which is currently not the case, as shown by #982), as well as how the user can install it.