### PR TITLE
Created (and started using) `RunAsync` extension method for `Gtk.Dialog`

### DIFF
--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -416,15 +416,15 @@ public static partial class GtkExtensions
 	}
 
 	/// <returns>Task whose result is the response ID</returns>
-	public static Task<int> RunAsync (this Gtk.Dialog dialog)
+	public static Task<Gtk.ResponseType> RunAsync (this Gtk.Dialog dialog)
 	{
-		TaskCompletionSource<int> completionSource = new ();
+		TaskCompletionSource<Gtk.ResponseType> completionSource = new ();
 
 		void ResponseCallback (
 			Gtk.Dialog sender,
 			Gtk.Dialog.ResponseSignalArgs args)
 		{
-			completionSource.SetResult (args.ResponseId);
+			completionSource.SetResult ((Gtk.ResponseType) args.ResponseId);
 			dialog.OnResponse -= ResponseCallback;
 		}
 

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -415,7 +415,6 @@ public static partial class GtkExtensions
 		return completionSource.Task;
 	}
 
-	/// <returns>Task whose result is the response ID</returns>
 	public static Task<Gtk.ResponseType> RunAsync (this Gtk.Dialog dialog)
 	{
 		TaskCompletionSource<Gtk.ResponseType> completionSource = new ();

--- a/Pinta.Core/Extensions/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/GtkExtensions.cs
@@ -399,20 +399,39 @@ public static partial class GtkExtensions
 	// TODO-GTK4 (bindings) - replace with adw_message_dialog_choose() once adwaita 1.3 is available, like in v0.4 of gir.core
 	public static Task<string> RunAsync (this Adw.MessageDialog dialog)
 	{
-		TaskCompletionSource<string> tcs = new ();
+		TaskCompletionSource<string> completionSource = new ();
 
 		void ResponseCallback (
 			Adw.MessageDialog sender,
 			Adw.MessageDialog.ResponseSignalArgs args)
 		{
-			tcs.SetResult (args.Response);
+			completionSource.SetResult (args.Response);
 			dialog.OnResponse -= ResponseCallback;
 		}
 
 		dialog.OnResponse += ResponseCallback;
 		dialog.Present ();
 
-		return tcs.Task;
+		return completionSource.Task;
+	}
+
+	/// <returns>Task whose result is the response ID</returns>
+	public static Task<int> RunAsync (this Gtk.Dialog dialog)
+	{
+		TaskCompletionSource<int> completionSource = new ();
+
+		void ResponseCallback (
+			Gtk.Dialog sender,
+			Gtk.Dialog.ResponseSignalArgs args)
+		{
+			completionSource.SetResult (args.ResponseId);
+			dialog.OnResponse -= ResponseCallback;
+		}
+
+		dialog.OnResponse += ResponseCallback;
+		dialog.Present ();
+
+		return completionSource.Task;
 	}
 
 	/// <summary>

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -41,23 +41,19 @@ public sealed class CurvesEffect : BaseEffect
 		EffectData = new CurvesData ();
 	}
 
-	public override Task<bool> LaunchConfiguration ()
+	public override async Task<bool> LaunchConfiguration ()
 	{
-		TaskCompletionSource<bool> completionSource = new ();
-
+		// TODO: Delegate `EffectData` changes to event handlers or similar
 		CurvesDialog dialog = new (chrome, Data) {
 			Title = Name,
 			IconName = Icon,
 		};
 
-		dialog.OnResponse += (_, args) => {
-			completionSource.SetResult (Gtk.ResponseType.Ok == (Gtk.ResponseType) args.ResponseId);
-			dialog.Destroy ();
-		};
+		int responseId = await dialog.RunAsync ();
 
-		dialog.Present ();
+		dialog.Destroy ();
 
-		return completionSource.Task;
+		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -49,11 +49,11 @@ public sealed class CurvesEffect : BaseEffect
 			IconName = Icon,
 		};
 
-		int responseId = await dialog.RunAsync ();
+		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
 
 		dialog.Destroy ();
 
-		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
+		return Gtk.ResponseType.Ok == response;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -49,7 +49,7 @@ public sealed class CurvesEffect : BaseEffect
 			IconName = Icon,
 		};
 
-		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
 		dialog.Destroy ();
 

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -49,7 +49,7 @@ public sealed class LevelsEffect : BaseEffect
 			IconName = Icon,
 		};
 
-		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
 		dialog.Destroy ();
 

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -41,23 +41,19 @@ public sealed class LevelsEffect : BaseEffect
 		EffectData = new LevelsData ();
 	}
 
-	public override Task<bool> LaunchConfiguration ()
+	public override async Task<bool> LaunchConfiguration ()
 	{
-		TaskCompletionSource<bool> completionSource = new ();
-
+		// TODO: Delegate `EffectData` changes to event handlers or similar
 		LevelsDialog dialog = new (chrome, workspace, Data) {
 			Title = Name,
 			IconName = Icon,
 		};
 
-		dialog.OnResponse += (_, args) => {
-			completionSource.SetResult (Gtk.ResponseType.Ok == (Gtk.ResponseType) args.ResponseId);
-			dialog.Destroy ();
-		};
+		int responseId = await dialog.RunAsync ();
 
-		dialog.Present ();
+		dialog.Destroy ();
 
-		return completionSource.Task;
+		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Adjustments/LevelsEffect.cs
+++ b/Pinta.Effects/Adjustments/LevelsEffect.cs
@@ -49,11 +49,11 @@ public sealed class LevelsEffect : BaseEffect
 			IconName = Icon,
 		};
 
-		int responseId = await dialog.RunAsync ();
+		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
 
 		dialog.Destroy ();
 
-		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
+		return Gtk.ResponseType.Ok == response;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -39,24 +39,19 @@ public sealed class PosterizeEffect : BaseEffect
 		EffectData = new PosterizeData ();
 	}
 
-	public override Task<bool> LaunchConfiguration ()
+	public override async Task<bool> LaunchConfiguration ()
 	{
-		TaskCompletionSource<bool> completionSource = new ();
-
 		PosterizeDialog dialog = new (chrome) {
 			Title = Name,
 			IconName = Icon,
-			EffectData = Data,
+			EffectData = Data, // TODO: Delegate `EffectData` changes to event handlers or similar
 		};
 
-		dialog.OnResponse += (_, args) => {
-			completionSource.SetResult (Gtk.ResponseType.Ok == (Gtk.ResponseType) args.ResponseId);
-			dialog.Destroy ();
-		};
+		int responseId = await dialog.RunAsync ();
 
-		dialog.Present ();
+		dialog.Destroy ();
 
-		return completionSource.Task;
+		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -47,7 +47,7 @@ public sealed class PosterizeEffect : BaseEffect
 			EffectData = Data, // TODO: Delegate `EffectData` changes to event handlers or similar
 		};
 
-		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
 		dialog.Destroy ();
 

--- a/Pinta.Effects/Adjustments/PosterizeEffect.cs
+++ b/Pinta.Effects/Adjustments/PosterizeEffect.cs
@@ -47,11 +47,11 @@ public sealed class PosterizeEffect : BaseEffect
 			EffectData = Data, // TODO: Delegate `EffectData` changes to event handlers or similar
 		};
 
-		int responseId = await dialog.RunAsync ();
+		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
 
 		dialog.Destroy ();
 
-		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
+		return Gtk.ResponseType.Ok == response;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/AlignObjectEffect.cs
+++ b/Pinta.Effects/Effects/AlignObjectEffect.cs
@@ -38,7 +38,7 @@ public sealed class AlignObjectEffect : BaseEffect
 			Data.Position = dialog.SelectedPosition;
 		};
 
-		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
 		dialog.Destroy ();
 

--- a/Pinta.Effects/Effects/AlignObjectEffect.cs
+++ b/Pinta.Effects/Effects/AlignObjectEffect.cs
@@ -27,10 +27,8 @@ public sealed class AlignObjectEffect : BaseEffect
 		chrome = services.GetService<IChromeService> ();
 		EffectData = new AlignObjectData ();
 	}
-	public override Task<bool> LaunchConfiguration ()
+	public override async Task<bool> LaunchConfiguration ()
 	{
-		TaskCompletionSource<bool> completionSource = new ();
-
 		AlignmentDialog dialog = new (chrome);
 
 		// Align to the default position
@@ -40,14 +38,11 @@ public sealed class AlignObjectEffect : BaseEffect
 			Data.Position = dialog.SelectedPosition;
 		};
 
-		dialog.OnResponse += (_, args) => {
-			completionSource.SetResult (Gtk.ResponseType.Ok == (Gtk.ResponseType) args.ResponseId);
-			dialog.Destroy ();
-		};
+		int responseId = await dialog.RunAsync ();
 
-		dialog.Present ();
+		dialog.Destroy ();
 
-		return completionSource.Task;
+		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Effects/Effects/AlignObjectEffect.cs
+++ b/Pinta.Effects/Effects/AlignObjectEffect.cs
@@ -38,11 +38,11 @@ public sealed class AlignObjectEffect : BaseEffect
 			Data.Position = dialog.SelectedPosition;
 		};
 
-		int responseId = await dialog.RunAsync ();
+		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
 
 		dialog.Destroy ();
 
-		return Gtk.ResponseType.Ok == (Gtk.ResponseType) responseId;
+		return Gtk.ResponseType.Ok == response;
 	}
 
 	public override void Render (ImageSurface src, ImageSurface dest, ReadOnlySpan<RectangleI> rois)

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -100,7 +100,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 		// Hookup event handling for live preview.
 		dialog.EffectDataChanged += (o, e) => effect.EffectData.FirePropertyChanged (e.PropertyName);
 
-		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
 		dialog.Destroy ();
 

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -86,12 +86,10 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 	/// The IAddinLocalizer provides a generic way to get translated strings both for
 	/// Pinta's effects and for effect add-ins.
 	/// </summary>
-	public static Task<bool> Launch (BaseEffect effect, IAddinLocalizer localizer)
+	public static async Task<bool> Launch (BaseEffect effect, IAddinLocalizer localizer)
 	{
 		if (effect.EffectData == null)
 			throw new ArgumentException ($"{effect.EffectData} should not be null", nameof (effect));
-
-		TaskCompletionSource<bool> responseCompletion = new ();
 
 		SimpleEffectDialog dialog = new (
 			effect.Name,
@@ -102,14 +100,11 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 		// Hookup event handling for live preview.
 		dialog.EffectDataChanged += (o, e) => effect.EffectData.FirePropertyChanged (e.PropertyName);
 
-		dialog.OnResponse += (_, args) => {
-			responseCompletion.SetResult (Gtk.ResponseType.Ok == (Gtk.ResponseType) args.ResponseId);
-			dialog.Destroy ();
-		};
+		Gtk.ResponseType response = (Gtk.ResponseType) await dialog.RunAsync ();
 
-		dialog.Present ();
+		dialog.Destroy ();
 
-		return responseCompletion.Task;
+		return Gtk.ResponseType.Ok == response;
 	}
 
 	public event PropertyChangedEventHandler? EffectDataChanged;


### PR DESCRIPTION
In the first commits, the method is returning an `int` corresponding to the response ID.
In the last two commits, the method is returning an `Gtk.ResponseType`