### PR TITLE
Methods `ShowMessage` and `ShowError` in `ChromeManager` made asynchronous

### DIFF
--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Cairo;
 using Gtk;
 
@@ -185,7 +186,7 @@ public sealed class Palette
 		saver.Save (colors, file);
 	}
 
-	private static void ShowUnsupportedFormatDialog (Window parent, string filename, string message, string errors)
+	private static Task ShowUnsupportedFormatDialog (Window parent, string filename, string message, string errors)
 	{
 		var details = new StringBuilder ();
 		details.AppendLine (Translations.GetString ("Could not open file: {0}", filename));
@@ -203,6 +204,6 @@ public sealed class Palette
 		details.AppendLine ();
 		details.AppendLine (errors);
 
-		PintaCore.Chrome.ShowMessageDialog (parent, message, details.ToString ());
+		return PintaCore.Chrome.ShowMessageDialog (parent, message, details.ToString ());
 	}
 }

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -159,9 +159,9 @@ public sealed class ChromeManager : IChromeService
 		}
 	}
 
-	public async void ShowMessageDialog (Gtk.Window parent, string message, string body)
+	public Task ShowMessageDialog (Gtk.Window parent, string message, string body)
 	{
-		await message_dialog_handler (parent, message, body);
+		return message_dialog_handler (parent, message, body);
 	}
 
 	public void SetStatusBarText (string text)

--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -60,8 +60,6 @@ public sealed class ChromeManager : IChromeService
 	public Gio.Menu AdjustmentsMenu { get; private set; } = null!;
 	public Gio.Menu EffectsMenu { get; private set; } = null!;
 
-	public ChromeManager () { }
-
 	public PointI LastCanvasCursorPoint {
 		get => last_canvas_cursor_point;
 		set {
@@ -145,7 +143,7 @@ public sealed class ChromeManager : IChromeService
 		simple_effect_dialog_handler = handler;
 	}
 
-	public async void ShowErrorDialog (
+	public async Task ShowErrorDialog (
 		Gtk.Window parent,
 		string message,
 		string body,

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Cairo;
 
 namespace Pinta.Core;
@@ -412,17 +413,17 @@ public sealed class WorkspaceManager : IWorkspaceService
 		SelectionChanged?.Invoke (this, EventArgs.Empty);
 	}
 
-	private void ShowOpenFileErrorDialog (
+	private Task ShowOpenFileErrorDialog (
 		Gtk.Window parent,
 		string filename,
 		string primary_text,
 		string details)
 	{
 		string secondary_text = Translations.GetString ("Could not open file: {0}", filename);
-		chrome_manager.ShowErrorDialog (parent, primary_text, secondary_text, details);
+		return chrome_manager.ShowErrorDialog (parent, primary_text, secondary_text, details);
 	}
 
-	private void ShowUnsupportedFormatDialog (
+	private Task ShowUnsupportedFormatDialog (
 		Gtk.Window parent,
 		string filename,
 		string message,
@@ -443,10 +444,10 @@ public sealed class WorkspaceManager : IWorkspaceService
 
 		body.AppendJoin (", ", extensions);
 
-		chrome_manager.ShowErrorDialog (parent, message, body.ToString (), errors);
+		return chrome_manager.ShowErrorDialog (parent, message, body.ToString (), errors);
 	}
 
-	private void ShowFilePermissionErrorDialog (
+	private Task ShowFilePermissionErrorDialog (
 		Gtk.Window parent,
 		string filename)
 	{
@@ -455,7 +456,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 		// Translators: {0} is the name of a file that the user does not have permission to open.
 		string details = Translations.GetString ("You do not have access to '{0}'.", filename);
 
-		chrome_manager.ShowMessageDialog (parent, message, details);
+		return chrome_manager.ShowMessageDialog (parent, message, details);
 	}
 
 	public event EventHandler<DocumentEventArgs>? DocumentCreated;

--- a/Pinta/Actions/Edit/PasteAction.cs
+++ b/Pinta/Actions/Edit/PasteAction.cs
@@ -132,7 +132,7 @@ internal sealed class PasteAction : IActionHandler
 
 		Gdk.Texture? cb_texture = await cb.ReadTextureAsync ();
 		if (cb_texture is null) {
-			ShowClipboardEmptyDialog (chrome);
+			await ShowClipboardEmptyDialog (chrome);
 			return;
 		}
 
@@ -199,11 +199,11 @@ internal sealed class PasteAction : IActionHandler
 		doc.History.PushNewItem (paste_action);
 	}
 
-	public static void ShowClipboardEmptyDialog (ChromeManager chrome)
+	public static Task ShowClipboardEmptyDialog (ChromeManager chrome)
 	{
 		var primary = Translations.GetString ("Image cannot be pasted");
 		var secondary = Translations.GetString ("The clipboard does not contain an image.");
-		chrome.ShowMessageDialog (chrome.MainWindow, primary, secondary);
+		return chrome.ShowMessageDialog (chrome.MainWindow, primary, secondary);
 	}
 
 	public static async Task<Gtk.ResponseType> ShowExpandCanvasDialog (ChromeManager chrome)

--- a/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
@@ -62,6 +62,6 @@ internal sealed class PasteIntoNewImageAction : IActionHandler
 		if (cb_texture is not null)
 			workspace.NewDocumentFromImage (actions, cb_texture.ToSurface ());
 		else
-			PasteAction.ShowClipboardEmptyDialog (chrome);
+			await PasteAction.ShowClipboardEmptyDialog (chrome);
 	}
 }

--- a/Pinta/Actions/File/NewScreenshotAction.cs
+++ b/Pinta/Actions/File/NewScreenshotAction.cs
@@ -82,7 +82,7 @@ internal sealed class NewScreenshotAction : IActionHandler
 
 		} catch (NoHandlersForOSException e) {
 
-			chrome.ShowMessageDialog (
+			await chrome.ShowMessageDialog (
 				chrome.MainWindow,
 				e.Message,
 				string.Empty);

--- a/Pinta/Actions/File/NewScreenshotAction.cs
+++ b/Pinta/Actions/File/NewScreenshotAction.cs
@@ -74,7 +74,7 @@ internal sealed class NewScreenshotAction : IActionHandler
 
 		} catch (DBusException e) {
 
-			chrome.ShowErrorDialog (
+			await chrome.ShowErrorDialog (
 				chrome.MainWindow,
 				Translations.GetString ("Failed to take screenshot"),
 				Translations.GetString ("Failed to access XDG Desktop Portals"),
@@ -89,7 +89,7 @@ internal sealed class NewScreenshotAction : IActionHandler
 
 		} catch (Exception ex) {
 
-			chrome.ShowErrorDialog (
+			await chrome.ShowErrorDialog (
 				chrome.MainWindow,
 				ex.Message,
 				string.Empty,

--- a/Pinta/Main.cs
+++ b/Pinta/Main.cs
@@ -141,7 +141,7 @@ internal sealed class MainClass
 
 	private static void OnUnhandledException (Exception e)
 	{
-		PintaCore.Chrome.ShowErrorDialog (PintaCore.Chrome.MainWindow,
+		_ = PintaCore.Chrome.ShowErrorDialog (PintaCore.Chrome.MainWindow,
 				"Unhandled exception", e.Message, e.ToString ());
 	}
 

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -273,7 +273,7 @@ internal sealed class MainWindow
 			} catch (Exception e) {
 				// Translators: {0} is the name of an add-in.
 				string body = Translations.GetString ("The '{0}' add-in may not be compatible with this version of Pinta", args.ExtensionNode.Addin.Id);
-				PintaCore.Chrome.ShowErrorDialog (
+				_ = PintaCore.Chrome.ShowErrorDialog (
 					PintaCore.Chrome.MainWindow,
 					Translations.GetString ("Failed to initialize add-in"),
 					body, e.ToString ());


### PR DESCRIPTION
[As discussed before](https://github.com/PintaProject/Pinta/pull/1021#discussion_r1786995885), when a dialog is shown, the caller does not care about the specific response, but it might care to know when the dialog is closed.