### PR TITLE
`PaletteManager.RecentlyUsedColors` is now a `ReadOnlyCollection`

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -62,7 +62,7 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		SetDrawFunc ((area, context, width, height) => Draw (context));
 
 		// Handle mouse clicks.
-		var click_gesture = Gtk.GestureClick.New ();
+		Gtk.GestureClick click_gesture = Gtk.GestureClick.New ();
 		click_gesture.SetButton (0); // Listen for all mouse buttons.
 		click_gesture.OnReleased += (_, e) => {
 			HandleClick (new PointD (e.X, e.Y), click_gesture.GetCurrentButton ());
@@ -148,13 +148,13 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		// Draw recently used color swatches
 		var recent = PintaCore.Palette.RecentlyUsedColors;
 
-		for (var i = 0; i < recent.Count (); i++)
+		for (int i = 0; i < recent.Count; i++)
 			g.FillRectangle (GetSwatchBounds (i, true), recent.ElementAt (i));
 
 		// Draw color swatches
 		var palette = PintaCore.Palette.CurrentPalette;
 
-		for (var i = 0; i < palette.Count; i++)
+		for (int i = 0; i < palette.Count; i++)
 			g.FillRectangle (GetSwatchBounds (i), palette[i]);
 	}
 
@@ -168,8 +168,10 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 		const double radius = 11;
 		const double offset = 1;
+
 		double x = swap_rect.Left + radius;
 		double y = swap_rect.Bottom - offset;
+
 		g.MoveTo (x, y);
 		g.CurveTo (x, y - radius - 2, x, y - radius + offset, swap_rect.Left + offset, swap_rect.Bottom - radius);
 
@@ -192,13 +194,15 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		int width = e.Width;
 
 		// Store the bounds allocated for our palette
-		var recent_cols = PintaCore.Palette.MaxRecentlyUsedColor / PALETTE_ROWS;
+		int recent_cols = PintaCore.Palette.MaxRecentlyUsedColor / PALETTE_ROWS;
 
 		recent_palette_rect = new RectangleD (50, 2, SWATCH_SIZE * recent_cols, SWATCH_SIZE * PALETTE_ROWS);
 		palette_rect = new RectangleD (recent_palette_rect.Right + PALETTE_MARGIN, 2, width - recent_palette_rect.Right - PALETTE_MARGIN, SWATCH_SIZE * PALETTE_ROWS);
 	}
 
-	private RectangleD GetSwatchBounds (int index, bool recentColorPalette = false)
+	private RectangleD GetSwatchBounds (
+		int index,
+		bool recentColorPalette = false)
 	{
 		// Normal swatches are laid out like this:
 		// 0 | 2 | 4 | 6
@@ -208,24 +212,27 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		// 4 | 5 | 6 | 7
 
 		// First we need to figure out what row and column the color is
-		var recent_cols = PintaCore.Palette.MaxRecentlyUsedColor / PALETTE_ROWS;
-		var row = recentColorPalette ? index / recent_cols : index % PALETTE_ROWS;
-		var col = recentColorPalette ? index % recent_cols : index / PALETTE_ROWS;
+		int recent_cols = PintaCore.Palette.MaxRecentlyUsedColor / PALETTE_ROWS;
+		int row = recentColorPalette ? index / recent_cols : index % PALETTE_ROWS;
+		int col = recentColorPalette ? index % recent_cols : index / PALETTE_ROWS;
 
 		// Now we need to construct the bounds of that row/column
-		var palette_bounds = recentColorPalette ? recent_palette_rect : palette_rect;
-		var x = palette_bounds.X + (col * SWATCH_SIZE);
-		var y = palette_bounds.Y + (row * SWATCH_SIZE);
+		RectangleD palette_bounds = recentColorPalette ? recent_palette_rect : palette_rect;
+		double x = palette_bounds.X + (col * SWATCH_SIZE);
+		double y = palette_bounds.Y + (row * SWATCH_SIZE);
 
-		return new RectangleD (x, y, SWATCH_SIZE, SWATCH_SIZE);
+		return new (x, y, SWATCH_SIZE, SWATCH_SIZE);
 	}
 
 	private int GetSwatchAtLocation (PointD point, bool recentColorPalette = false)
 	{
-		var max = recentColorPalette ? PintaCore.Palette.RecentlyUsedColors.Count () : PintaCore.Palette.CurrentPalette.Count;
+		int max =
+			recentColorPalette
+			? PintaCore.Palette.RecentlyUsedColors.Count
+			: PintaCore.Palette.CurrentPalette.Count;
 
 		// This could be more efficient, but is good enough for now
-		for (var i = 0; i < max; i++)
+		for (int i = 0; i < max; i++)
 			if (GetSwatchBounds (i, recentColorPalette).ContainsPoint (point))
 				return i;
 
@@ -238,7 +245,7 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 	private bool HandleQueryTooltip (object o, Gtk.Widget.QueryTooltipSignalArgs args)
 	{
 		string? text = null;
-		var point = new PointD (args.X, args.Y);
+		PointD point = new (args.X, args.Y);
 
 		switch (GetElementAtPoint (point)) {
 			case WidgetElement.Palette:
@@ -256,8 +263,8 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 				text = Translations.GetString ("Click to select secondary color.");
 				break;
 			case WidgetElement.SwapColors:
-				var label = Translations.GetString ("Click to switch between primary and secondary color.");
-				var shortcut_label = Translations.GetString ("Shortcut key");
+				string label = Translations.GetString ("Click to switch between primary and secondary color.");
+				string shortcut_label = Translations.GetString ("Shortcut key");
 				text = $"{label} {shortcut_label}: {"X"}";
 				break;
 			case WidgetElement.ResetColors:
@@ -320,6 +327,6 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		PrimaryColor,
 		SecondaryColor,
 		SwapColors,
-		ResetColors
+		ResetColors,
 	}
 }


### PR DESCRIPTION
Mostly so that the `Count` property can be used instead of the LINQ `Count()` method