### PR TITLE
Removed unused method `AfterRender` from `GradientRenderer`

### DIFF
--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -79,8 +79,6 @@ public abstract class GradientRenderer
 
 	public abstract byte ComputeByteLerp (int x, int y);
 
-	public virtual void AfterRender () { }
-
 	private static AlphaBounds ComputeAlphaOnlyValuesFromColors (
 		ColorBgra startColor,
 		ColorBgra endColor)
@@ -134,7 +132,6 @@ public abstract class GradientRenderer
 		}
 
 		surface.MarkDirty ();
-		AfterRender ();
 	}
 
 	private ColorBgra GetFinalSolidColor (
@@ -186,7 +183,7 @@ public abstract class GradientRenderer
 				byte lerpByte = ComputeByteLerp (x, y);
 				byte lerpAlpha = lerp_alphas[lerpByte];
 				ColorBgra original = row[x];
-				var color = original.ToStraightAlpha ();
+				ColorBgra color = original.ToStraightAlpha ();
 				color.A = lerpAlpha;
 				row[x] = color.ToPremultipliedAlpha ();
 			}
@@ -194,7 +191,7 @@ public abstract class GradientRenderer
 			// If we're doing all color channels, and we're doing alpha blending, and if alpha blending is necessary
 			for (var x = rect.Left; x <= right; ++x) {
 				byte lerpByte = ComputeByteLerp (x, y);
-				var lerpColor = lerp_colors[lerpByte];
+				ColorBgra lerpColor = lerp_colors[lerpByte];
 				ColorBgra originalPixel = row[x];
 				row[x] = normal_blend_op.Apply (originalPixel, lerpColor);
 			}
@@ -202,7 +199,7 @@ public abstract class GradientRenderer
 		} else {
 			for (int x = rect.Left; x <= right; ++x) {
 				byte lerpByte = ComputeByteLerp (x, y);
-				var lerpColor = lerp_colors[lerpByte];
+				ColorBgra lerpColor = lerp_colors[lerpByte];
 				row[x] = lerpColor;
 			}
 		}

--- a/Pinta.Core/Effects/GradientRenderers.cs
+++ b/Pinta.Core/Effects/GradientRenderers.cs
@@ -23,6 +23,8 @@ public static class GradientRenderers
 
 			dtdx = EndPoint.X == StartPoint.X ? 0 : vec.X / (mag * mag);
 			dtdy = EndPoint.Y == StartPoint.Y ? 0 : vec.Y / (mag * mag);
+
+			base.BeforeRender ();
 		}
 
 		protected internal LinearBase (bool alphaOnly, BinaryPixelOp normalBlendOp) : base (alphaOnly, normalBlendOp)
@@ -121,6 +123,8 @@ public static class GradientRenderers
 				0 => 0,
 				_ => 1f / distanceScale,
 			};
+
+			base.BeforeRender ();
 		}
 
 		public override byte ComputeByteLerp (int x, int y)
@@ -158,6 +162,8 @@ public static class GradientRenderers
 			double t = theta * InvPi;
 
 			t_offset = -t;
+
+			base.BeforeRender ();
 		}
 
 		public override byte ComputeByteLerp (int x, int y)

--- a/Pinta.Core/Effects/GradientRenderers.cs
+++ b/Pinta.Core/Effects/GradientRenderers.cs
@@ -23,8 +23,6 @@ public static class GradientRenderers
 
 			dtdx = EndPoint.X == StartPoint.X ? 0 : vec.X / (mag * mag);
 			dtdy = EndPoint.Y == StartPoint.Y ? 0 : vec.Y / (mag * mag);
-
-			base.BeforeRender ();
 		}
 
 		protected internal LinearBase (bool alphaOnly, BinaryPixelOp normalBlendOp) : base (alphaOnly, normalBlendOp)
@@ -51,15 +49,14 @@ public static class GradientRenderers
 
 			start_x = (int) StartPoint.X;
 			start_y = (int) StartPoint.Y;
-
 		}
 
 		public override byte ComputeByteLerp (int x, int y)
 		{
-			var dx = x - start_x;
-			var dy = y - start_y;
+			int dx = x - start_x;
+			int dy = y - start_y;
 
-			var lerp = (dx * dtdx) + (dy * dtdy);
+			double lerp = (dx * dtdx) + (dy * dtdy);
 
 			return BoundLerp (lerp);
 		}
@@ -90,14 +87,14 @@ public static class GradientRenderers
 
 		public override byte ComputeByteLerp (int x, int y)
 		{
-			var dx = x - StartPoint.X;
-			var dy = y - StartPoint.Y;
+			double dx = x - StartPoint.X;
+			double dy = y - StartPoint.Y;
 
-			var lerp1 = (dx * dtdx) + (dy * dtdy);
-			var lerp2 = (dx * dtdy) - (dy * dtdx);
+			double lerp1 = (dx * dtdx) + (dy * dtdy);
+			double lerp2 = (dx * dtdy) - (dy * dtdx);
 
-			var absLerp1 = Math.Abs (lerp1);
-			var absLerp2 = Math.Abs (lerp2);
+			double absLerp1 = Math.Abs (lerp1);
+			double absLerp2 = Math.Abs (lerp2);
 
 			return BoundLerp (absLerp1 + absLerp2);
 		}
@@ -115,7 +112,7 @@ public static class GradientRenderers
 
 		public override void BeforeRender ()
 		{
-			var distanceScale = StartPoint.Distance (EndPoint);
+			double distanceScale = StartPoint.Distance (EndPoint);
 
 			start_x = (int) StartPoint.X;
 			start_y = (int) StartPoint.Y;
@@ -124,20 +121,20 @@ public static class GradientRenderers
 				0 => 0,
 				_ => 1f / distanceScale,
 			};
-
-			base.BeforeRender ();
 		}
 
 		public override byte ComputeByteLerp (int x, int y)
 		{
-			var dx = x - start_x;
-			var dy = y - start_y;
+			int dx = x - start_x;
+			int dy = y - start_y;
 
-			var distance = Math.Sqrt (dx * dx + dy * dy);
+			double distance = Math.Sqrt (dx * dx + dy * dy);
 
-			var result = distance * inv_distance_scale;
+			double result = distance * inv_distance_scale;
+
 			if (result < 0.0)
 				return 0;
+
 			return result > 1.0 ? (byte) 255 : (byte) (result * 255f);
 		}
 	}
@@ -153,25 +150,24 @@ public static class GradientRenderers
 
 		public override void BeforeRender ()
 		{
-			var ax = EndPoint.X - StartPoint.X;
-			var ay = EndPoint.Y - StartPoint.Y;
+			double ax = EndPoint.X - StartPoint.X;
+			double ay = EndPoint.Y - StartPoint.Y;
 
-			var theta = Math.Atan2 (ay, ax);
+			double theta = Math.Atan2 (ay, ax);
 
-			var t = theta * InvPi;
+			double t = theta * InvPi;
 
 			t_offset = -t;
-			base.BeforeRender ();
 		}
 
 		public override byte ComputeByteLerp (int x, int y)
 		{
-			var ax = x - StartPoint.X;
-			var ay = y - StartPoint.Y;
+			double ax = x - StartPoint.X;
+			double ay = y - StartPoint.Y;
 
-			var theta = Math.Atan2 (ay, ax);
+			double theta = Math.Atan2 (ay, ax);
 
-			var t = theta * InvPi;
+			double t = theta * InvPi;
 
 			return (byte) (BoundLerp (t + t_offset) * 255f);
 		}


### PR DESCRIPTION
I have a refactoring in mind that would make all derived classes immutable and also handle all the rendering from the outside, but doing everything in a single go would make the changes hard to review.