### PR TITLE
Moving "activate document" part out of file format class

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -96,19 +96,6 @@ public sealed class Document
 		ResetSelectionPaths ();
 	}
 
-	// This pair of methods is temporary, in order to ensure that a document is attached to a single workspace at a time
-	// While it exists, it is to be called exclusively from the workspace manager
-	private bool is_attached = false; // By default detached from workspace
-	internal void MarkAttached ()
-	{
-		if (is_attached) throw new InvalidOperationException ("Document is already attached to a workspace. Detach it first");
-		is_attached = true;
-	}
-	internal void MarkDetached ()
-	{
-		is_attached = false;
-	}
-
 	/// <summary>
 	/// Just the file name, like "dog.jpg".
 	/// If HasFile is false, this may be something like "Unsaved image 1".

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -70,6 +70,20 @@ public sealed class Document
 		ResetSelectionPaths ();
 	}
 
+	private bool is_attached = false; // By default detached from workspace
+	internal void MarkAttached ()
+	{
+		if (is_attached)
+			throw new InvalidOperationException ("Document is already attached to a workspace. Detach it first");
+
+		is_attached = true;
+	}
+
+	internal void MarkDetached ()
+	{
+		is_attached = false;
+	}
+
 	/// <summary>
 	/// Just the file name, like "dog.jpg".
 	/// If HasFile is false, this may be something like "Unsaved image 1".

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -91,6 +91,8 @@ public sealed class Document
 		} else
 			DisplayName = Translations.GetString ("Unsaved Image {0}", name_counter++);
 
+		Workspace.ViewSize = size;
+
 		ResetSelectionPaths ();
 	}
 

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -40,7 +40,7 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 
 	#region IImageImporter implementation
 
-	public void Import (Gio.File file, Gtk.Window parent)
+	public Document Import (Gio.File file, Gtk.Window parent)
 	{
 		Pixbuf bg;
 
@@ -57,17 +57,16 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 
 		Size imageSize = new (bg.Width, bg.Height);
 
-		// TODO: Move "attach document" part out of file format class.
-		//       The creation of the document should be separate from
-		//       its activation.
 		Document newDocument = new (imageSize, file, filetype);
 		newDocument.Workspace.ViewSize = imageSize;
-		PintaCore.Workspace.AttachDocument (newDocument, PintaCore.Actions);
 
 		Layer layer = newDocument.Layers.AddNewLayer (file.GetDisplayName ());
 
 		Cairo.Context g = new (layer.Surface);
+
 		g.DrawPixbuf (bg, PointD.Zero);
+
+		return newDocument;
 	}
 	#endregion
 

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -60,14 +60,13 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 		// TODO: Move "attach document" part out of file format class.
 		//       The creation of the document should be separate from
 		//       its activation.
-		Document newDocument = PintaCore.Workspace.CreateDocument (imageSize, file, filetype);
-		newDocument.ImageSize = imageSize;
+		Document newDocument = new (imageSize, file, filetype);
 		newDocument.Workspace.ViewSize = imageSize;
 		PintaCore.Workspace.AttachDocument (newDocument, PintaCore.Actions);
 
 		Layer layer = newDocument.Layers.AddNewLayer (file.GetDisplayName ());
 
-		var g = new Cairo.Context (layer.Surface);
+		Cairo.Context g = new (layer.Surface);
 		g.DrawPixbuf (bg, PointD.Zero);
 	}
 	#endregion

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -38,7 +38,7 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 		this.filetype = filetype;
 	}
 
-	public Document Import (Gio.File file, Gtk.Window parent)
+	public Document Import (Gio.File file)
 	{
 		Pixbuf streamBuffer = ReadPixbuf (file);
 		Pixbuf effectiveBuffer = streamBuffer.ApplyEmbeddedOrientation () ?? streamBuffer;

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -46,7 +46,6 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 		Size imageSize = new (effectiveBuffer.Width, effectiveBuffer.Height);
 
 		Document newDocument = new (imageSize, file, filetype);
-		newDocument.Workspace.ViewSize = imageSize;
 
 		Layer layer = newDocument.Layers.AddNewLayer (file.GetDisplayName ());
 

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -55,20 +55,17 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 
 		bg = bg.ApplyEmbeddedOrientation () ?? bg;
 
-		Size imagesize = new Size (bg.Width, bg.Height);
+		Size imageSize = new (bg.Width, bg.Height);
 
-		// TODO: Move "activate document" part out of file format class.
+		// TODO: Move "attach document" part out of file format class.
 		//       The creation of the document should be separate from
 		//       its activation.
-		Document doc = PintaCore.Workspace.CreateAndActivateDocument (
-			PintaCore.Actions,
-			file,
-			filetype,
-			imagesize);
-		doc.ImageSize = imagesize;
-		doc.Workspace.ViewSize = imagesize;
+		Document newDocument = PintaCore.Workspace.CreateDocument (imageSize, file, filetype);
+		newDocument.ImageSize = imageSize;
+		newDocument.Workspace.ViewSize = imageSize;
+		PintaCore.Workspace.AttachDocument (newDocument, PintaCore.Actions);
 
-		Layer layer = doc.Layers.AddNewLayer (file.GetDisplayName ());
+		Layer layer = newDocument.Layers.AddNewLayer (file.GetDisplayName ());
 
 		var g = new Cairo.Context (layer.Surface);
 		g.DrawPixbuf (bg, PointD.Zero);

--- a/Pinta.Core/ImageFormats/IImageImporter.cs
+++ b/Pinta.Core/ImageFormats/IImageImporter.cs
@@ -35,8 +35,5 @@ public interface IImageImporter
 	/// <param name='file'>
 	/// The identifier of the file to be loaded.
 	/// </param>
-	/// <param name='parent'>
-	/// Window to be used as a parent for any dialogs that are shown.
-	/// </param>
 	Document Import (Gio.File file);
 }

--- a/Pinta.Core/ImageFormats/IImageImporter.cs
+++ b/Pinta.Core/ImageFormats/IImageImporter.cs
@@ -36,5 +36,5 @@ public interface IImageImporter
 	/// <param name='parent'>
 	/// Window to be used as a parent for any dialogs that are shown.
 	/// </param>
-	void Import (Gio.File file, Gtk.Window parent);
+	Document Import (Gio.File file, Gtk.Window parent);
 }

--- a/Pinta.Core/ImageFormats/IImageImporter.cs
+++ b/Pinta.Core/ImageFormats/IImageImporter.cs
@@ -30,11 +30,13 @@ namespace Pinta.Core;
 public interface IImageImporter
 {
 	/// <summary>
-	/// Imports a document into Pinta.
+	/// Loads a new document from a file.
 	/// </summary>
-	/// <param name='file'>The identifier of the file to be imported.</param>
+	/// <param name='file'>
+	/// The identifier of the file to be loaded.
+	/// </param>
 	/// <param name='parent'>
 	/// Window to be used as a parent for any dialogs that are shown.
 	/// </param>
-	Document Import (Gio.File file, Gtk.Window parent);
+	Document Import (Gio.File file);
 }

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -39,7 +39,7 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 
 	#region IImageImporter implementation
 
-	public void Import (Gio.File file, Gtk.Window parent)
+	public Document Import (Gio.File file, Gtk.Window parent)
 	{
 		using var stream = new GioStream (file.Read (cancellable: null));
 		using var zipfile = new ZipArchive (stream);
@@ -58,12 +58,8 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 			Height: int.Parse (imageElement.GetAttribute ("h"))
 		);
 
-		// TODO: Move "attach document" part out of file format class.
-		//       The creation of the document should be separate from
-		//       its activation.
 		Document newDocument = new (imageSize, file, "ora");
 		newDocument.Workspace.ViewSize = imageSize;
-		PintaCore.Workspace.AttachDocument (newDocument, PintaCore.Actions);
 
 		XmlElement stackElement = (XmlElement) stackXml.GetElementsByTagName ("stack")[0]!;
 		XmlNodeList layerElements = stackElement.GetElementsByTagName ("layer");
@@ -126,6 +122,8 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 				PintaCore.Chrome.ShowMessageDialog (PintaCore.Chrome.MainWindow, Translations.GetString ("Error"), details);
 			}
 		}
+
+		return newDocument;
 	}
 	#endregion
 

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -39,10 +39,10 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 
 	#region IImageImporter implementation
 
-	public Document Import (Gio.File file, Gtk.Window parent)
+	public Document Import (Gio.File file)
 	{
-		using var stream = new GioStream (file.Read (cancellable: null));
-		using var zipfile = new ZipArchive (stream);
+		using GioStream stream = new (file.Read (cancellable: null));
+		using ZipArchive zipfile = new (stream);
 
 		XmlDocument stackXml = new ();
 

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -59,7 +59,6 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 		);
 
 		Document newDocument = new (imageSize, file, "ora");
-		newDocument.Workspace.ViewSize = imageSize;
 
 		XmlElement stackElement = (XmlElement) stackXml.GetElementsByTagName ("stack")[0]!;
 		XmlNodeList layerElements = stackElement.GetElementsByTagName ("layer");

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -43,7 +43,8 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 	{
 		using var stream = new GioStream (file.Read (cancellable: null));
 		using var zipfile = new ZipArchive (stream);
-		XmlDocument stackXml = new XmlDocument ();
+
+		XmlDocument stackXml = new ();
 
 		ZipArchiveEntry stackXmlEntry = zipfile.GetEntry ("stack.xml") ?? throw new XmlException ("No 'stack.xml' found in OpenRaster file");
 		stackXml.Load (stackXmlEntry.Open ());
@@ -52,7 +53,7 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 		// valid that we need to guard against.
 		XmlElement imageElement = stackXml.DocumentElement!;
 
-		Size imagesize = new Size (
+		Size imageSize = new (
 			Width: int.Parse (imageElement.GetAttribute ("w")),
 			Height: int.Parse (imageElement.GetAttribute ("h"))
 		);
@@ -60,20 +61,16 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 		// TODO: Move "activate document" part out of file format class.
 		//       The creation of the document should be separate from
 		//       its activation.
-		Document doc = PintaCore.Workspace.CreateAndActivateDocument (
-			PintaCore.Actions,
-			file,
-			"ora",
-			imagesize);
+		Document newDocument = PintaCore.Workspace.CreateDocument (imageSize, file, "ora");
+		newDocument.ImageSize = imageSize;
+		newDocument.Workspace.ViewSize = imageSize;
+		PintaCore.Workspace.AttachDocument (newDocument, PintaCore.Actions);
 
 		XmlElement stackElement = (XmlElement) stackXml.GetElementsByTagName ("stack")[0]!;
 		XmlNodeList layerElements = stackElement.GetElementsByTagName ("layer");
 
 		if (layerElements.Count == 0)
 			throw new XmlException ("No layers found in OpenRaster file");
-
-		doc.ImageSize = imagesize;
-		doc.Workspace.ViewSize = imagesize;
 
 		for (int i = 0; i < layerElements.Count; i++) {
 
@@ -106,8 +103,8 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 					}
 				}
 
-				UserLayer layer = doc.Layers.CreateLayer (name);
-				doc.Layers.Insert (layer, 0);
+				UserLayer layer = newDocument.Layers.CreateLayer (name);
+				newDocument.Layers.Insert (layer, 0);
 
 				string visibility = GetAttribute (layerElement, "visibility", "visible");
 				if (visibility == "hidden") {
@@ -118,7 +115,7 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 				layer.BlendMode = StandardToBlendMode (GetAttribute (layerElement, "composite-op", "svg:src-over"));
 
 				var pb = GdkPixbuf.Pixbuf.NewFromFile (tmp_file)!; // NRT: only nullable when an error is thrown
-				var g = new Context (layer.Surface);
+				Context g = new (layer.Surface);
 				g.DrawPixbuf (pb, (PointD) position);
 
 				try {
@@ -156,7 +153,7 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 	{
 		using MemoryStream ms = new MemoryStream ();
 		using XmlTextWriter writer = new XmlTextWriter (ms, System.Text.Encoding.UTF8) {
-			Formatting = Formatting.Indented
+			Formatting = Formatting.Indented,
 		};
 
 		writer.WriteStartElement ("image");

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -58,11 +58,10 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 			Height: int.Parse (imageElement.GetAttribute ("h"))
 		);
 
-		// TODO: Move "activate document" part out of file format class.
+		// TODO: Move "attach document" part out of file format class.
 		//       The creation of the document should be separate from
 		//       its activation.
-		Document newDocument = PintaCore.Workspace.CreateDocument (imageSize, file, "ora");
-		newDocument.ImageSize = imageSize;
+		Document newDocument = new (imageSize, file, "ora");
 		newDocument.Workspace.ViewSize = imageSize;
 		PintaCore.Workspace.AttachDocument (newDocument, PintaCore.Actions);
 

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -263,7 +263,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 	{
 		int index = open_documents.IndexOf (document);
 
-		if (index == -1) return; // TODO: Maybe throw an exception?
+		if (index == -1)
+			throw new ArgumentException ("Document was not found in workspace. Did you forget to activate it?", nameof (document));
 
 		open_documents.Remove (document);
 

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -160,7 +160,6 @@ public static class WorkspaceServiceExtensions
 public sealed class WorkspaceManager : IWorkspaceService
 {
 	private int active_document_index = -1;
-	private int new_file_name = 1;
 
 	private readonly ChromeManager chrome_manager;
 	private readonly ImageConverterManager image_formats;
@@ -326,14 +325,16 @@ public sealed class WorkspaceManager : IWorkspaceService
 			// Open the image and add it to the layers
 			IImageImporter? importer = image_formats.GetImporterByFile (file.GetDisplayName ());
 			if (importer is not null) {
-				importer.Import (file, parent);
+				Document imported = importer.Import (file, parent);
+				AttachDocument (imported, PintaCore.Actions);
 			} else {
 				// Unknown extension, so try every loader.
 				StringBuilder errors = new ();
 				bool loaded = false;
 				foreach (var format in image_formats.Formats.Where (f => !f.IsWriteOnly ())) {
 					try {
-						format.Importer!.Import (file, parent);
+						Document imported = format.Importer!.Import (file, parent);
+						AttachDocument (imported, PintaCore.Actions);
 						loaded = true;
 						break;
 					} catch (UnauthorizedAccessException) {

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -139,7 +139,7 @@ public static class WorkspaceServiceExtensions
 	{
 		Document doc = new (imageSize);
 		doc.Workspace.ViewSize = imageSize;
-		workspace.AttachDocument (doc, actions);
+		workspace.ActivateDocument (doc, actions);
 
 		// Start with an empty white layer
 		Layer background = doc.Layers.AddNewLayer (Translations.GetString ("Background"));
@@ -219,7 +219,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 	public ReadOnlyCollection<Document> OpenDocuments { get; }
 	public bool HasOpenDocuments => open_documents.Count > 0;
 
-	public void AttachDocument (
+	public void ActivateDocument (
 		Document document,
 		ActionManager actions)
 	{
@@ -231,12 +231,12 @@ public sealed class WorkspaceManager : IWorkspaceService
 
 		open_documents.Add (document);
 
-		OnDocumentAttached (new DocumentEventArgs (document));
+		OnDocumentActivated (new DocumentEventArgs (document));
 
 		actions.Window.SetActiveDocument (document);
 	}
 
-	private void Document_LayerPropertyChanged (object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+	private void Document_LayerPropertyChanged (object? sender, PropertyChangedEventArgs e)
 	{
 		LayerPropertyChanged?.Invoke (sender, e);
 		this.Invalidate ();
@@ -326,7 +326,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 			IImageImporter? importer = image_formats.GetImporterByFile (file.GetDisplayName ());
 			if (importer is not null) {
 				Document imported = importer.Import (file);
-				AttachDocument (imported, PintaCore.Actions);
+				ActivateDocument (imported, PintaCore.Actions);
 			} else {
 				// Unknown extension, so try every loader.
 				StringBuilder errors = new ();
@@ -334,7 +334,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 				foreach (var format in image_formats.Formats.Where (f => !f.IsWriteOnly ())) {
 					try {
 						Document imported = format.Importer!.Import (file);
-						AttachDocument (imported, PintaCore.Actions);
+						ActivateDocument (imported, PintaCore.Actions);
 						loaded = true;
 						break;
 					} catch (UnauthorizedAccessException) {
@@ -421,10 +421,10 @@ public sealed class WorkspaceManager : IWorkspaceService
 		ResetTitle ();
 	}
 
-	private void OnDocumentAttached (DocumentEventArgs e)
+	private void OnDocumentActivated (DocumentEventArgs e)
 	{
 		e.Document.SelectionChanged += (_, _) => OnSelectionChanged ();
-		DocumentAttached?.Invoke (this, e);
+		DocumentActivated?.Invoke (this, e);
 	}
 
 	private void OnDocumentOpened (DocumentEventArgs e)
@@ -493,7 +493,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 	public event EventHandler? SelectedLayerChanged;
 	public event PropertyChangedEventHandler? LayerPropertyChanged;
 
-	public event EventHandler<DocumentEventArgs>? DocumentAttached;
+	public event EventHandler<DocumentEventArgs>? DocumentActivated;
 	public event EventHandler<DocumentEventArgs>? DocumentOpened;
 	public event EventHandler<DocumentEventArgs>? DocumentClosed;
 

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -241,6 +241,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 		} else
 			document.DisplayName = Translations.GetString ("Unsaved Image {0}", new_file_name++);
 
+		document.MarkAttached ();
+
 		open_documents.Add (document);
 
 		OnDocumentCreated (new DocumentEventArgs (document));
@@ -296,6 +298,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 		document.Layers.SelectedLayerChanged -= Document_SelectedLayerChanged;
 		document.Layers.LayerPropertyChanged -= Document_LayerPropertyChanged;
 		document.Close ();
+
+		document.MarkDetached ();
 
 		OnDocumentClosed (new DocumentEventArgs (document));
 	}

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -137,7 +137,7 @@ public static class WorkspaceServiceExtensions
 		Size imageSize,
 		Color backgroundColor)
 	{
-		Document doc = workspace.CreateDocument (imageSize, null, null);
+		Document doc = new (imageSize);
 		doc.Workspace.ViewSize = imageSize;
 		workspace.AttachDocument (doc, actions);
 
@@ -219,25 +219,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 	private readonly List<Document> open_documents;
 	public ReadOnlyCollection<Document> OpenDocuments { get; }
 	public bool HasOpenDocuments => open_documents.Count > 0;
-
-	public Document CreateDocument ( // TODO: Move creation part out of this class. Ideally, only activation/attachment should be here
-		Size size,
-		Gio.File? file,
-		string? file_type)
-	{
-		Document document = new (size);
-		if (file is not null) {
-
-			if (string.IsNullOrEmpty (file_type))
-				throw new ArgumentNullException ($"nameof{file_type} must contain value.");
-
-			document.File = file;
-			document.FileType = file_type;
-		} else
-			document.DisplayName = Translations.GetString ("Unsaved Image {0}", new_file_name++);
-
-		return document;
-	}
 
 	public void AttachDocument (
 		Document document,

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -227,7 +227,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 		document.Layers.LayerRemoved += Document_LayerRemoved;
 		document.Layers.SelectedLayerChanged += Document_SelectedLayerChanged;
 		document.Layers.LayerPropertyChanged += Document_LayerPropertyChanged;
-		document.MarkAttached ();
 
 		open_documents.Add (document);
 
@@ -286,8 +285,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 		document.Layers.SelectedLayerChanged -= Document_SelectedLayerChanged;
 		document.Layers.LayerPropertyChanged -= Document_LayerPropertyChanged;
 		document.Close ();
-
-		document.MarkDetached ();
 
 		OnDocumentClosed (new DocumentEventArgs (document));
 	}

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -427,11 +427,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 		DocumentActivated?.Invoke (this, e);
 	}
 
-	private void OnDocumentOpened (DocumentEventArgs e)
-	{
-		DocumentOpened?.Invoke (this, e);
-	}
-
 	private void OnDocumentClosed (DocumentEventArgs e)
 	{
 		DocumentClosed?.Invoke (this, e);
@@ -494,7 +489,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 	public event PropertyChangedEventHandler? LayerPropertyChanged;
 
 	public event EventHandler<DocumentEventArgs>? DocumentActivated;
-	public event EventHandler<DocumentEventArgs>? DocumentOpened;
 	public event EventHandler<DocumentEventArgs>? DocumentClosed;
 
 	public event EventHandler? ActiveDocumentChanged;

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -325,7 +325,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 			// Open the image and add it to the layers
 			IImageImporter? importer = image_formats.GetImporterByFile (file.GetDisplayName ());
 			if (importer is not null) {
-				Document imported = importer.Import (file, parent);
+				Document imported = importer.Import (file);
 				AttachDocument (imported, PintaCore.Actions);
 			} else {
 				// Unknown extension, so try every loader.
@@ -333,7 +333,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 				bool loaded = false;
 				foreach (var format in image_formats.Formats.Where (f => !f.IsWriteOnly ())) {
 					try {
-						Document imported = format.Importer!.Import (file, parent);
+						Document imported = format.Importer!.Import (file);
 						AttachDocument (imported, PintaCore.Actions);
 						loaded = true;
 						break;

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -98,7 +98,7 @@ public sealed class ActionHandlers
 
 		// We need to toggle actions active/inactive
 		// when there isn't an open document
-		PintaCore.Workspace.DocumentAttached += Workspace_DocumentCreated;
+		PintaCore.Workspace.DocumentActivated += Workspace_DocumentCreated;
 		PintaCore.Workspace.DocumentClosed += Workspace_DocumentClosed;
 
 		// Initially, no documents are open.

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -98,7 +98,7 @@ public sealed class ActionHandlers
 
 		// We need to toggle actions active/inactive
 		// when there isn't an open document
-		PintaCore.Workspace.DocumentCreated += Workspace_DocumentCreated;
+		PintaCore.Workspace.DocumentAttached += Workspace_DocumentCreated;
 		PintaCore.Workspace.DocumentClosed += Workspace_DocumentClosed;
 
 		// Initially, no documents are open.

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -108,7 +108,7 @@ internal sealed class MainWindow
 
 		PintaCore.Workspace.ActiveDocumentChanged += ActiveDocumentChanged;
 
-		PintaCore.Workspace.DocumentCreated += Workspace_DocumentCreated;
+		PintaCore.Workspace.DocumentAttached += Workspace_DocumentCreated;
 		PintaCore.Workspace.DocumentClosed += Workspace_DocumentClosed;
 
 		DockNotebook notebook = canvas_pad.Notebook;

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -108,7 +108,7 @@ internal sealed class MainWindow
 
 		PintaCore.Workspace.ActiveDocumentChanged += ActiveDocumentChanged;
 
-		PintaCore.Workspace.DocumentAttached += Workspace_DocumentCreated;
+		PintaCore.Workspace.DocumentActivated += Workspace_DocumentCreated;
 		PintaCore.Workspace.DocumentClosed += Workspace_DocumentClosed;
 
 		DockNotebook notebook = canvas_pad.Notebook;


### PR DESCRIPTION
Based on what was discussed in https://github.com/PintaProject/Pinta/pull/1012#issuecomment-2384657092
I might end up closing that one and just continuing from here.

Unfortunately, this re-introduced `PintaCore` references in the `WorkspaceManager`, but I'd argue that progress is still being made.

The `IImageImporter` interface was changed