### PR TITLE
Sign the Windows installer via SignPath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,9 @@ jobs:
         path: installer/windows/Pinta.exe
         if-no-files-found: error
 
+    # Only enable signing for tagged releases.
     - name: Sign Installer
+      if: startsWith( github.ref, 'refs/tags/' )
       uses: signpath/github-action-submit-signing-request@v1
       with:
         api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -165,6 +167,7 @@ jobs:
         output-artifact-directory: './signed-artifacts'
 
     - name: Upload Signed Installer
+      if: startsWith( github.ref, 'refs/tags/' )
       id: upload-signed-installer
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,20 @@ jobs:
         iscc installer/windows/installer.iss
 
     - name: Upload Installer
+      id: upload-unsigned-installer
       uses: actions/upload-artifact@v4
       with:
         name: "Pinta.exe"
         path: installer/windows/Pinta.exe
         if-no-files-found: error
+
+    - name: Sign Installer
+      uses: signpath/github-action-submit-signing-request@v1
+      with:
+        api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+        organization-id: "fb6d32c7-2808-4358-b9eb-f7482eb8c0a5"
+        project-slug: Pinta
+        signing-policy-slug: test-signing
+        artifact-configuration-slug: Zipped_Exe
+        github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
+        wait-for-completion: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
         api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
         organization-id: "fb6d32c7-2808-4358-b9eb-f7482eb8c0a5"
         project-slug: Pinta
-        signing-policy-slug: test-signing
+        signing-policy-slug: release-signing
         artifact-configuration-slug: Zipped_Exe
         github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
         wait-for-completion: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,3 +162,13 @@ jobs:
         artifact-configuration-slug: Zipped_Exe
         github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
         wait-for-completion: true
+        output-artifact-directory: './signed-artifacts'
+
+    - name: Upload Signed Installer
+      id: upload-signed-installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: "Pinta-signed.exe"
+        path: ./signed-artifacts/Pinta.exe
+        if-no-files-found: error
+      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Thanks to the following contributors who worked on this release:
 - Added a new `Offset Selection` option to the `Edit` menu to expand or contract the current selection (#661, #740, #746)
 - The Windows build of Pinta now supports loading `.webp` images (#770)
 - Improved zooming behavior with trackpads, including support for the pinch to zoom gesture (#634, #715)
+- The Windows installer is now signed, thanks to the support of [SignPath](https://about.signpath.io/) (#1054)
 
 ### Changed
 - When building Pinta using the Makefile, 'dotnet publish' is now run during the build step rather than the install step.


### PR DESCRIPTION
TODOs
- [x] Enable less frequently, e.g. only tagged commits / release branches
- [x] Switch to release certificate once approved