### PR TITLE
Optimization to `MandelbrotFractalEffect` calculations

### DIFF
--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -54,7 +54,6 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 	private const double Max = 100000;
 
 	private static readonly double inv_log_max = 1.0 / Math.Log (Max);
-	private const double Zoom_factor = 20.0;
 
 	private static readonly PointD offset_basis = new (X: -0.7, Y: -0.29);
 
@@ -62,9 +61,10 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 	private static double Mandelbrot (double r, double i, int factor)
 	{
+		const int MAX_ITERATIONS = 1024;
 		int c = 0;
 		PointD p = new (0, 0);
-		while ((c * factor) < 1024 && Utility.MagnitudeSquared (p) < Max) {
+		while ((c * factor) < MAX_ITERATIONS && Utility.MagnitudeSquared (p) < Max) {
 			p = NextLocation (p, r, i);
 			++c;
 		}
@@ -92,11 +92,12 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		ColorGradient colorGradient);
 	private MandelbrotSettings CreateSettings (ImageSurface dst)
 	{
+		const double ZOOM_FACTOR = 20.0;
 		Size canvasSize = new (dst.Width, dst.Height);
-		double zoom = 1 + Zoom_factor * Data.Zoom;
+		double zoom = 1 + ZOOM_FACTOR * Data.Zoom;
 		int count = Data.Quality * Data.Quality + 1;
 
-		var baseGradient =
+		ColorGradient baseGradient =
 			GradientHelper
 			.CreateBaseGradientForEffect (
 				palette,

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -153,7 +153,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		for (double i = 0; i < settings.count; i++) {
 
 			double u = baseU + i * deltaU;
-			double v = baseV + i * settings.invQuality % 1 * settings.invH;
+			double v = baseV + (i * settings.invQuality % 1) * settings.invH;
 
 			double radius = Utility.Magnitude (u, v);
 			double theta = Math.Atan2 (v, u);

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -150,7 +150,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 		double deltaU = settings.invCount * settings.invH;
 
-		for (int i = 0; i < settings.count; i++) {
+		for (double i = 0; i < settings.count; i++) {
 
 			double u = baseU + i * deltaU;
 			double v = baseV + i * settings.invQuality % 1 * settings.invH;

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -145,10 +145,15 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int b = 0;
 		int a = 0;
 
+		double baseU = ((2.0 * target.X) - settings.canvasSize.Width) * settings.invH;
+		double baseV = ((2.0 * target.Y) - settings.canvasSize.Height) * settings.invH;
+
+		double deltaU = settings.invCount * settings.invH;
+
 		for (int i = 0; i < settings.count; i++) {
 
-			double u = (2.0 * target.X - settings.canvasSize.Width + (i * settings.invCount)) * settings.invH;
-			double v = (2.0 * target.Y - settings.canvasSize.Height + (i * settings.invQuality % 1)) * settings.invH;
+			double u = baseU + i * deltaU;
+			double v = baseV + i * settings.invQuality % 1 * settings.invH;
 
 			double radius = Utility.Magnitude (u, v);
 			double theta = Math.Atan2 (v, u);

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -145,7 +145,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int b = 0;
 		int a = 0;
 
-		for (double i = 0; i < settings.count; i++) {
+		for (int i = 0; i < settings.count; i++) {
 
 			double u = (2.0 * target.X - settings.canvasSize.Width + (i * settings.invCount)) * settings.invH;
 			double v = (2.0 * target.Y - settings.canvasSize.Height + (i * settings.invQuality % 1)) * settings.invH;
@@ -154,12 +154,12 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 			double theta = Math.Atan2 (v, u);
 			double thetaP = theta + settings.angleTheta.Radians;
 
-			double uP = radius * Math.Cos (thetaP);
-			double vP = radius * Math.Sin (thetaP);
+			double rotatedU = radius * Math.Cos (thetaP);
+			double rotatedV = radius * Math.Sin (thetaP);
 
 			double m = Mandelbrot (
-				r: (uP * settings.invZoom) + offset_basis.X,
-				i: (vP * settings.invZoom) + offset_basis.Y,
+				r: (rotatedU * settings.invZoom) + offset_basis.X,
+				i: (rotatedV * settings.invZoom) + offset_basis.Y,
 				factor: settings.factor);
 
 			double c = 64 + settings.factor * m;


### PR DESCRIPTION
A few loop invariants were extracted.

You can see that if you distribute the multiplication done when calculating `u` and `v` there is a part that is independent of `i`