### PR TITLE
`InverseTransform` in `PolarInversionEffect` and `DentsEffect` is now independent of `WarpEffect`'s state

### DIFF
--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -67,7 +67,9 @@ public sealed class DentsEffect : WarpEffect
 	}
 
 	// Algorithm code ported from PDN
-	protected override TransformData InverseTransform (TransformData data)
+	protected override TransformData InverseTransform (
+		TransformData data,
+		WarpSettings settings)
 	{
 		double scale = Data.Scale;
 
@@ -80,8 +82,8 @@ public sealed class DentsEffect : WarpEffect
 
 		byte seed = Utility.ClampToByte (Data.Seed.Value);
 
-		double scaleR = (400.0 / DefaultRadius) / scale;
-		double refractionScale = (refraction / 100.0) / scaleR;
+		double scaleR = 400.0 / settings.defaultRadius / scale;
+		double refractionScale = refraction / 100.0 / scaleR;
 		double theta = Math.PI * 2.0 * turbulence / 10.0;
 		double effectiveRoughness = roughness / 100.0;
 
@@ -102,8 +104,7 @@ public sealed class DentsEffect : WarpEffect
 
 		return new (
 			X: data.X + (refractionScale * Math.Sin (-bumpAngle)),
-			Y: data.Y + (refractionScale * Math.Cos (bumpAngle))
-		);
+			Y: data.Y + (refractionScale * Math.Cos (bumpAngle)));
 	}
 }
 

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -38,18 +38,22 @@ public sealed class PolarInversionEffect : WarpEffect
 	}
 
 	#region Algorithm Code Ported From PDN
-	protected override TransformData InverseTransform (TransformData transData)
+	protected override TransformData InverseTransform (
+		TransformData transData,
+		WarpSettings settings)
 	{
 		double x = transData.X;
 		double y = transData.Y;
 
 		// NOTE: when x and y are zero, this will divide by zero and return NaN
-		double invertDistance = Utility.Lerp (1.0, DefaultRadius2 / Utility.MagnitudeSquared (x, y), Data.Amount);
+		double invertDistance = Utility.Lerp (
+			1.0,
+			settings.defaultRadius2 / Utility.MagnitudeSquared (x, y),
+			Data.Amount);
 
 		return new (
 			X: x * invertDistance,
-			Y: y * invertDistance
-		);
+			Y: y * invertDistance);
 	}
 	#endregion
 


### PR DESCRIPTION
Now all the necessary settings are passed as an argument.

The end goal of this is eventually getting rid of `WarpEffect`, i.e. having a flat class hierarchy so that an effect can use these mechanisms without having to inherit from that specific class.