### PR TITLE
All types related to warping were nested inside the `Warp` class

### DIFF
--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -135,7 +135,7 @@ public sealed class DentsEffect : BaseEffect
 	}
 }
 
-public sealed class DentsData : EffectData, IWarpData
+public sealed class DentsData : EffectData, Warp.IEffectData
 {
 	[MinimumValue (1), MaximumValue (200)]
 	public double Scale { get; set; } = 25;
@@ -159,5 +159,5 @@ public sealed class DentsData : EffectData, IWarpData
 	[Caption ("Center Offset")]
 	public PointD CenterOffset { get; set; }
 
-	public WarpEdgeBehavior EdgeBehavior { get; set; } = WarpEdgeBehavior.Wrap;
+	public Warp.EdgeBehavior EdgeBehavior { get; set; } = Warp.EdgeBehavior.Wrap;
 }

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -89,7 +89,7 @@ public sealed class PolarInversionEffect : BaseEffect
 	}
 }
 
-public sealed class PolarInversionData : EffectData, IWarpData
+public sealed class PolarInversionData : EffectData, Warp.IEffectData
 {
 	[MinimumValue (-4), MaximumValue (4)]
 	public double Amount { get; set; } = 0;
@@ -100,5 +100,5 @@ public sealed class PolarInversionData : EffectData, IWarpData
 	[Caption ("Center Offset")]
 	public PointD CenterOffset { get; set; }
 
-	public WarpEdgeBehavior EdgeBehavior { get; set; } = WarpEdgeBehavior.Reflect;
+	public Warp.EdgeBehavior EdgeBehavior { get; set; } = Warp.EdgeBehavior.Reflect;
 }


### PR DESCRIPTION
I think this would make things clearer and establish how this kind of refactoring should be done — for example, if we wanted to refactor away `ColorDifferenceEffect`, we could follow a similar structure