### PR TITLE
Applying `TwistEffect` locally based on selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Thanks to the following contributors who worked on this release:
 - Saving an image already saved in a format that supports multiple layers to a format that does not support layers will now explicitly prompt the user to flatten the image before saving, rather than silently flattening it (#909)
 
 ### Fixed
+- Twist effect applied locally based on selection instead of entire image
 - Fixed issues where the system language settings on macOS did not properly take effect in Pinta ([#1976178](https://bugs.launchpad.net/pinta/+bug/1976178))
 - Fixed an issue where the Pan tool's cursor could show up as a missing icon ([#2013047](https://bugs.launchpad.net/pinta/+bug/2013047))
 - Fixed errors when saving a file that was opened with a missing or incorrect extension ([#2013050](https://bugs.launchpad.net/pinta/+bug/2013050))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Thanks to the following contributors who worked on this release:
 - Saving an image already saved in a format that supports multiple layers to a format that does not support layers will now explicitly prompt the user to flatten the image before saving, rather than silently flattening it (#909)
 
 ### Fixed
-- Twist effect applied locally based on selection instead of entire image
+- Twist effect applied locally based on selection instead of entire image (#1089)
 - Fixed issues where the system language settings on macOS did not properly take effect in Pinta ([#1976178](https://bugs.launchpad.net/pinta/+bug/1976178))
 - Fixed an issue where the Pan tool's cursor could show up as a missing icon ([#2013047](https://bugs.launchpad.net/pinta/+bug/2013047))
 - Fixed errors when saving a file that was opened with a missing or incorrect extension ([#2013050](https://bugs.launchpad.net/pinta/+bug/2013050))


### PR DESCRIPTION
At present, when we select a region and twist it, the calculations are done based on the whole image:

![badtwist](https://github.com/user-attachments/assets/014d62c0-bf98-4358-9dc3-fa89c36edb26)

With this change, the calculations will be done based on the selected region itself:

![goodtwist](https://github.com/user-attachments/assets/03fd73b5-1d25-4a42-97e8-6bf347d296e3)

