### PR TITLE
Non-public methods in `LivePreviewManager` were made local

### DIFF
--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -43,21 +43,6 @@ public interface ILivePreview
 
 public sealed class LivePreviewManager : ILivePreview
 {
-	// NRT - These are set in Start(). This should be rewritten to be provably non-null.
-	bool live_preview_enabled;
-	Layer layer = null!;
-	BaseEffect effect = null!;
-	Cairo.Path? selection_path;
-
-	bool apply_live_preview_flag;
-	bool cancel_live_preview_flag;
-
-	Cairo.ImageSurface live_preview_surface = null!;
-	RectangleI render_bounds;
-	SimpleHistoryItem history_item = null!;
-
-	AsyncEffectRenderer renderer = null!;
-
 	private readonly WorkspaceManager workspace;
 	private readonly ToolManager tools;
 	private readonly SystemManager system;
@@ -68,7 +53,7 @@ public sealed class LivePreviewManager : ILivePreview
 		SystemManager systemManager,
 		ChromeManager chromeManager)
 	{
-		live_preview_enabled = false;
+		IsEnabled = false;
 
 		workspace = workspaceManager;
 		tools = toolManager;
@@ -76,13 +61,13 @@ public sealed class LivePreviewManager : ILivePreview
 		chrome = chromeManager;
 	}
 
-	public Cairo.ImageSurface LivePreviewSurface => live_preview_surface;
-	public RectangleI RenderBounds => render_bounds;
-	public bool IsEnabled => live_preview_enabled;
+	public Cairo.ImageSurface LivePreviewSurface { get; private set; } = null!;
+	public RectangleI RenderBounds { get; private set; }
+	public bool IsEnabled { get; private set; }
 
 	public async void Start (BaseEffect effect)
 	{
-		if (live_preview_enabled)
+		if (IsEnabled)
 			throw new InvalidOperationException ("LivePreviewManager.Start() called while live preview is already enabled.");
 
 		// Create live preview surface.
@@ -91,15 +76,14 @@ public sealed class LivePreviewManager : ILivePreview
 
 		var doc = workspace.ActiveDocument;
 
-		live_preview_enabled = true;
-		apply_live_preview_flag = false;
-		cancel_live_preview_flag = false;
+		IsEnabled = true;
+		bool apply_live_preview_flag = false;
+		bool cancel_live_preview_flag = false;
 
-		layer = doc.Layers.CurrentUserLayer;
-		this.effect = effect;
+		Layer layer = doc.Layers.CurrentUserLayer;
 
 		//TODO Use the current tool layer instead.
-		live_preview_surface = CairoExtensions.CreateImageSurface (
+		LivePreviewSurface = CairoExtensions.CreateImageSurface (
 			Cairo.Format.Argb32,
 			workspace.ImageSize.Width,
 			workspace.ImageSize.Height);
@@ -109,33 +93,34 @@ public sealed class LivePreviewManager : ILivePreview
 
 		DocumentSelection selection = doc.Selection;
 
-		selection_path = selection.Visible ? selection.SelectionPath : null;
-		render_bounds = (selection_path != null) ? selection_path.GetBounds () : live_preview_surface.GetBounds ();
-		render_bounds = workspace.ClampToImageSize (render_bounds);
+		Cairo.Path? selection_path = selection.Visible ? selection.SelectionPath : null;
+		RenderBounds = (selection_path != null) ? selection_path.GetBounds () : LivePreviewSurface.GetBounds ();
+		RenderBounds = workspace.ClampToImageSize (RenderBounds);
 
-		history_item = new SimpleHistoryItem (effect.Icon, effect.Name);
+		SimpleHistoryItem history_item = new (effect.Icon, effect.Name);
 		history_item.TakeSnapshotOfLayer (doc.Layers.CurrentUserLayerIndex);
 
 		// Paint the pre-effect layer surface into into the working surface.
-		Cairo.Context ctx = new (live_preview_surface);
+		Cairo.Context ctx = new (LivePreviewSurface);
 		layer.Draw (ctx, layer.Surface, 1);
-
-		if (effect.EffectData != null)
-			effect.EffectData.PropertyChanged += EffectData_PropertyChanged;
 
 		AsyncEffectRenderer.Settings settings = new (
 			threadCount: system.RenderThreads,
-			renderBounds: render_bounds,
+			renderBounds: RenderBounds,
 			effectIsTileable: effect.IsTileable,
 			updateMilliseconds: 100,
 			threadPriority: ThreadPriority.BelowNormal);
 
 		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "Start Live preview.");
 
-		renderer = new AsyncEffectRenderer (settings);
+		AsyncEffectRenderer renderer = new AsyncEffectRenderer (settings);
 		renderer.Updated += OnUpdate;
 		renderer.Completed += OnCompletion;
-		renderer.Start (effect, layer.Surface, live_preview_surface);
+
+		if (effect.EffectData != null)
+			effect.EffectData.PropertyChanged += EffectData_PropertyChanged;
+
+		renderer.Start (effect, layer.Surface, LivePreviewSurface);
 
 		if (effect.IsConfigurable) {
 
@@ -150,185 +135,187 @@ public sealed class LivePreviewManager : ILivePreview
 			chrome.MainWindowBusy = true;
 			Apply ();
 		}
-	}
 
-	// Method asks render task to complete, and then returns immediately. The cancel
-	// is not actually complete until the LivePreviewRenderCompleted event is fired.
-	void Cancel ()
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.Cancel()");
+		// === Methods
 
-		cancel_live_preview_flag = true;
+		// Method asks render task to complete, and then returns immediately. The cancel
+		// is not actually complete until the LivePreviewRenderCompleted event is fired.
+		void Cancel ()
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.Cancel()");
 
-		renderer?.Cancel ();
+			cancel_live_preview_flag = true;
 
-		// Show a busy cursor, and make the main window insensitive,
-		// until the cancel has completed.
-		chrome.MainWindowBusy = true;
+			renderer?.Cancel ();
 
-		if (renderer == null || !renderer.IsRendering)
-			HandleCancel ();
-	}
+			// Show a busy cursor, and make the main window insensitive,
+			// until the cancel has completed.
+			chrome.MainWindowBusy = true;
 
-	// Called from asynchronously from Renderer.OnCompletion ()
-	void HandleCancel ()
-	{
-		Debug.WriteLine ("LivePreviewManager.HandleCancel()");
+			if (renderer == null || !renderer.IsRendering)
+				HandleCancel ();
+		}
 
-		live_preview_enabled = false;
+		// Called from asynchronously from Renderer.OnCompletion ()
+		void HandleCancel ()
+		{
+			Debug.WriteLine ("LivePreviewManager.HandleCancel()");
 
-		live_preview_surface = null!;
+			IsEnabled = false;
 
-		workspace.Invalidate ();
+			LivePreviewSurface = null!;
 
-		CleanUp ();
-	}
+			workspace.Invalidate ();
 
-	void Apply ()
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
+			CleanUp ();
+		}
 
-		apply_live_preview_flag = true;
+		void Apply ()
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
 
-		if (!renderer.IsRendering) {
-			HandleApply ();
-		} else {
+			apply_live_preview_flag = true;
+
+			if (!renderer.IsRendering) {
+				HandleApply ();
+			} else {
+				IProgressDialog dialog = chrome.ProgressDialog;
+				dialog.Title = Translations.GetString ("Rendering Effect");
+				dialog.Text = effect.Name;
+				dialog.Progress = renderer.Progress;
+				dialog.Canceled += HandleProgressDialogCancel;
+				dialog.Show ();
+			}
+		}
+
+		void HandleProgressDialogCancel (object? o, EventArgs e)
+		{
+			Cancel ();
+		}
+
+		// Called from asynchronously from Renderer.OnCompletion ()
+		void HandleApply ()
+		{
+			Debug.WriteLine ("LivePreviewManager.HandleApply()");
+
+			Cairo.Context ctx = new (layer.Surface);
+			ctx.Save ();
+			workspace.ActiveDocument.Selection.Clip (ctx);
+
+			layer.DrawWithOperator (ctx, LivePreviewSurface, Cairo.Operator.Source);
+			ctx.Restore ();
+
+			workspace.ActiveDocument.History.PushNewItem (history_item);
+			history_item = null!;
+
+			IsEnabled = false;
+
+			workspace.Invalidate (); //TODO keep track of dirty bounds.
+			CleanUp ();
+		}
+
+		// Clean up resources when live preview is disabled.
+		void CleanUp ()
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.CleanUp()");
+
+			IsEnabled = false;
+
+			if (effect != null) {
+				if (effect.EffectData != null)
+					effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;
+				effect = null!;
+			}
+
+			LivePreviewSurface = null!;
+
+			if (renderer != null) {
+				renderer.Dispose ();
+				renderer = null!;
+			}
+
+			history_item = null!;
+
+			// Hide progress dialog and clean up events.
 			IProgressDialog dialog = chrome.ProgressDialog;
-			dialog.Title = Translations.GetString ("Rendering Effect");
-			dialog.Text = effect.Name;
-			dialog.Progress = renderer.Progress;
-			dialog.Canceled += HandleProgressDialogCancel;
-			dialog.Show ();
-		}
-	}
+			dialog.Hide ();
+			dialog.Canceled -= HandleProgressDialogCancel;
 
-	void HandleProgressDialogCancel (object? o, EventArgs e)
-	{
-		Cancel ();
-	}
-
-	// Called from asynchronously from Renderer.OnCompletion ()
-	void HandleApply ()
-	{
-		Debug.WriteLine ("LivePreviewManager.HandleApply()");
-
-		Cairo.Context ctx = new (layer.Surface);
-		ctx.Save ();
-		workspace.ActiveDocument.Selection.Clip (ctx);
-
-		layer.DrawWithOperator (ctx, live_preview_surface, Cairo.Operator.Source);
-		ctx.Restore ();
-
-		workspace.ActiveDocument.History.PushNewItem (history_item);
-		history_item = null!;
-
-		live_preview_enabled = false;
-
-		workspace.Invalidate (); //TODO keep track of dirty bounds.
-		CleanUp ();
-	}
-
-	// Clean up resources when live preview is disabled.
-	void CleanUp ()
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.CleanUp()");
-
-		live_preview_enabled = false;
-
-		if (effect != null) {
-			if (effect.EffectData != null)
-				effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;
-			effect = null!;
+			chrome.MainWindowBusy = false;
 		}
 
-		live_preview_surface = null!;
-
-		if (renderer != null) {
-			renderer.Dispose ();
-			renderer = null!;
+		void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
+		{
+			//TODO calculate bounds.
+			renderer!.Start (effect, layer.Surface, LivePreviewSurface);
 		}
 
-		history_item = null!;
-
-		// Hide progress dialog and clean up events.
-		IProgressDialog dialog = chrome.ProgressDialog;
-		dialog.Hide ();
-		dialog.Canceled -= HandleProgressDialogCancel;
-
-		chrome.MainWindowBusy = false;
-	}
-
-	void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
-	{
-		//TODO calculate bounds.
-		renderer.Start (effect, layer.Surface, live_preview_surface);
-	}
-
-	private void OnUpdate (
-		double progress,
-		RectangleI updatedBounds)
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnUpdate() progress: " + progress);
-		chrome.ProgressDialog.Progress = progress;
-		HandleUpdate (updatedBounds);
-	}
-
-	private void OnCompletion (
-		IReadOnlyList<Exception> exceptions,
-		CancellationToken cancellationToken)
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancellationToken.IsCancellationRequested);
-
-		if (!live_preview_enabled)
-			return;
-
-		if (cancel_live_preview_flag)
-			HandleCancel ();
-		else if (apply_live_preview_flag)
-			HandleApply ();
-	}
-
-	void HandleUpdate (RectangleI bounds)
-	{
-		double scale = workspace.Scale;
-		PointD offset = workspace.Offset;
-
-		// Transform bounds (Image -> Canvas -> Window)
-
-		// Calculate canvas bounds.
-		PointD bounds1 = new (
-			X: bounds.Left * scale,
-			Y: bounds.Top * scale);
-
-		PointD bounds2 = new (
-			X: (bounds.Right + 1) * scale,
-			Y: (bounds.Bottom + 1) * scale);
-
-		// TODO Figure out why when scale > 1 that I need add on an
-		// extra pixel of padding.
-		// I must being doing something wrong here.
-		if (scale > 1.0) {
-			//x1 = (bounds.Left-1) * scale;
-			bounds1 = bounds1 with { Y = (bounds.Top - 1) * scale };
-			//x2 = (bounds.Right+1) * scale;
-			//y2 = (bounds.Bottom+1) * scale;
+		void OnUpdate (
+			double progress,
+			RectangleI updatedBounds)
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnUpdate() progress: " + progress);
+			chrome.ProgressDialog.Progress = progress;
+			HandleUpdate (updatedBounds);
 		}
 
-		// Calculate window bounds.
-		bounds1 += offset;
-		bounds2 += offset;
+		void OnCompletion (
+			IReadOnlyList<Exception> exceptions,
+			CancellationToken cancellationToken)
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancellationToken.IsCancellationRequested);
 
-		// Convert to integer, carefully not to miss partially covered
-		// pixels by rounding incorrectly.
-		int x = (int) Math.Floor (bounds1.X);
-		int y = (int) Math.Floor (bounds1.Y);
-		RectangleI areaToInvalidate = new (
-			X: x,
-			Y: y,
-			Width: (int) Math.Ceiling (bounds2.X) - x,
-			Height: (int) Math.Ceiling (bounds2.Y) - y);
+			if (!IsEnabled)
+				return;
 
-		// Tell GTK to expose the drawing area.
-		workspace.ActiveWorkspace.InvalidateWindowRect (areaToInvalidate);
+			if (cancel_live_preview_flag)
+				HandleCancel ();
+			else if (apply_live_preview_flag)
+				HandleApply ();
+		}
+
+		void HandleUpdate (RectangleI bounds)
+		{
+			double scale = workspace.Scale;
+			PointD offset = workspace.Offset;
+
+			// Transform bounds (Image -> Canvas -> Window)
+
+			// Calculate canvas bounds.
+			PointD bounds1 = new (
+				X: bounds.Left * scale,
+				Y: bounds.Top * scale);
+
+			PointD bounds2 = new (
+				X: (bounds.Right + 1) * scale,
+				Y: (bounds.Bottom + 1) * scale);
+
+			// TODO Figure out why when scale > 1 that I need add on an
+			// extra pixel of padding.
+			// I must being doing something wrong here.
+			if (scale > 1.0) {
+				//x1 = (bounds.Left-1) * scale;
+				bounds1 = bounds1 with { Y = (bounds.Top - 1) * scale };
+				//x2 = (bounds.Right+1) * scale;
+				//y2 = (bounds.Bottom+1) * scale;
+			}
+
+			// Calculate window bounds.
+			bounds1 += offset;
+			bounds2 += offset;
+
+			// Convert to integer, carefully not to miss partially covered
+			// pixels by rounding incorrectly.
+			int x = (int) Math.Floor (bounds1.X);
+			int y = (int) Math.Floor (bounds1.Y);
+			RectangleI areaToInvalidate = new (
+				X: x,
+				Y: y,
+				Width: (int) Math.Ceiling (bounds2.X) - x,
+				Height: (int) Math.Ceiling (bounds2.Y) - y);
+
+			// Tell GTK to expose the drawing area.
+			workspace.ActiveWorkspace.InvalidateWindowRect (areaToInvalidate);
+		}
 	}
 }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -43,9 +43,6 @@ public interface ILivePreview
 
 public sealed class LivePreviewManager : ILivePreview
 {
-	bool apply_live_preview_flag;
-	bool cancel_live_preview_flag;
-
 	private readonly WorkspaceManager workspace;
 	private readonly ToolManager tools;
 	private readonly SystemManager system;
@@ -80,6 +77,8 @@ public sealed class LivePreviewManager : ILivePreview
 		var doc = workspace.ActiveDocument;
 
 		IsEnabled = true;
+		bool apply_live_preview_flag = false;
+		bool cancel_live_preview_flag = false;
 
 		Layer layer = doc.Layers.CurrentUserLayer;
 

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -43,6 +43,9 @@ public interface ILivePreview
 
 public sealed class LivePreviewManager : ILivePreview
 {
+	bool apply_live_preview_flag;
+	bool cancel_live_preview_flag;
+
 	private readonly WorkspaceManager workspace;
 	private readonly ToolManager tools;
 	private readonly SystemManager system;
@@ -77,8 +80,6 @@ public sealed class LivePreviewManager : ILivePreview
 		var doc = workspace.ActiveDocument;
 
 		IsEnabled = true;
-		bool apply_live_preview_flag = false;
-		bool cancel_live_preview_flag = false;
 
 		Layer layer = doc.Layers.CurrentUserLayer;
 

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -43,6 +43,21 @@ public interface ILivePreview
 
 public sealed class LivePreviewManager : ILivePreview
 {
+	// NRT - These are set in Start(). This should be rewritten to be provably non-null.
+	bool live_preview_enabled;
+	Layer layer = null!;
+	BaseEffect effect = null!;
+	Cairo.Path? selection_path;
+
+	bool apply_live_preview_flag;
+	bool cancel_live_preview_flag;
+
+	Cairo.ImageSurface live_preview_surface = null!;
+	RectangleI render_bounds;
+	SimpleHistoryItem history_item = null!;
+
+	AsyncEffectRenderer renderer = null!;
+
 	private readonly WorkspaceManager workspace;
 	private readonly ToolManager tools;
 	private readonly SystemManager system;
@@ -53,7 +68,7 @@ public sealed class LivePreviewManager : ILivePreview
 		SystemManager systemManager,
 		ChromeManager chromeManager)
 	{
-		IsEnabled = false;
+		live_preview_enabled = false;
 
 		workspace = workspaceManager;
 		tools = toolManager;
@@ -61,13 +76,13 @@ public sealed class LivePreviewManager : ILivePreview
 		chrome = chromeManager;
 	}
 
-	public Cairo.ImageSurface LivePreviewSurface { get; private set; } = null!;
-	public RectangleI RenderBounds { get; private set; }
-	public bool IsEnabled { get; private set; }
+	public Cairo.ImageSurface LivePreviewSurface => live_preview_surface;
+	public RectangleI RenderBounds => render_bounds;
+	public bool IsEnabled => live_preview_enabled;
 
 	public async void Start (BaseEffect effect)
 	{
-		if (IsEnabled)
+		if (live_preview_enabled)
 			throw new InvalidOperationException ("LivePreviewManager.Start() called while live preview is already enabled.");
 
 		// Create live preview surface.
@@ -76,14 +91,15 @@ public sealed class LivePreviewManager : ILivePreview
 
 		var doc = workspace.ActiveDocument;
 
-		IsEnabled = true;
-		bool apply_live_preview_flag = false;
-		bool cancel_live_preview_flag = false;
+		live_preview_enabled = true;
+		apply_live_preview_flag = false;
+		cancel_live_preview_flag = false;
 
-		Layer layer = doc.Layers.CurrentUserLayer;
+		layer = doc.Layers.CurrentUserLayer;
+		this.effect = effect;
 
 		//TODO Use the current tool layer instead.
-		LivePreviewSurface = CairoExtensions.CreateImageSurface (
+		live_preview_surface = CairoExtensions.CreateImageSurface (
 			Cairo.Format.Argb32,
 			workspace.ImageSize.Width,
 			workspace.ImageSize.Height);
@@ -93,34 +109,33 @@ public sealed class LivePreviewManager : ILivePreview
 
 		DocumentSelection selection = doc.Selection;
 
-		Cairo.Path? selection_path = selection.Visible ? selection.SelectionPath : null;
-		RenderBounds = (selection_path != null) ? selection_path.GetBounds () : LivePreviewSurface.GetBounds ();
-		RenderBounds = workspace.ClampToImageSize (RenderBounds);
+		selection_path = selection.Visible ? selection.SelectionPath : null;
+		render_bounds = (selection_path != null) ? selection_path.GetBounds () : live_preview_surface.GetBounds ();
+		render_bounds = workspace.ClampToImageSize (render_bounds);
 
-		SimpleHistoryItem history_item = new (effect.Icon, effect.Name);
+		history_item = new SimpleHistoryItem (effect.Icon, effect.Name);
 		history_item.TakeSnapshotOfLayer (doc.Layers.CurrentUserLayerIndex);
 
 		// Paint the pre-effect layer surface into into the working surface.
-		Cairo.Context ctx = new (LivePreviewSurface);
+		Cairo.Context ctx = new (live_preview_surface);
 		layer.Draw (ctx, layer.Surface, 1);
+
+		if (effect.EffectData != null)
+			effect.EffectData.PropertyChanged += EffectData_PropertyChanged;
 
 		AsyncEffectRenderer.Settings settings = new (
 			threadCount: system.RenderThreads,
-			renderBounds: RenderBounds,
+			renderBounds: render_bounds,
 			effectIsTileable: effect.IsTileable,
 			updateMilliseconds: 100,
 			threadPriority: ThreadPriority.BelowNormal);
 
 		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "Start Live preview.");
 
-		AsyncEffectRenderer renderer = new AsyncEffectRenderer (settings);
+		renderer = new AsyncEffectRenderer (settings);
 		renderer.Updated += OnUpdate;
 		renderer.Completed += OnCompletion;
-
-		if (effect.EffectData != null)
-			effect.EffectData.PropertyChanged += EffectData_PropertyChanged;
-
-		renderer.Start (effect, layer.Surface, LivePreviewSurface);
+		renderer.Start (effect, layer.Surface, live_preview_surface);
 
 		if (effect.IsConfigurable) {
 
@@ -135,187 +150,185 @@ public sealed class LivePreviewManager : ILivePreview
 			chrome.MainWindowBusy = true;
 			Apply ();
 		}
+	}
 
-		// === Methods
+	// Method asks render task to complete, and then returns immediately. The cancel
+	// is not actually complete until the LivePreviewRenderCompleted event is fired.
+	void Cancel ()
+	{
+		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.Cancel()");
 
-		// Method asks render task to complete, and then returns immediately. The cancel
-		// is not actually complete until the LivePreviewRenderCompleted event is fired.
-		void Cancel ()
-		{
-			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.Cancel()");
+		cancel_live_preview_flag = true;
 
-			cancel_live_preview_flag = true;
+		renderer?.Cancel ();
 
-			renderer?.Cancel ();
+		// Show a busy cursor, and make the main window insensitive,
+		// until the cancel has completed.
+		chrome.MainWindowBusy = true;
 
-			// Show a busy cursor, and make the main window insensitive,
-			// until the cancel has completed.
-			chrome.MainWindowBusy = true;
+		if (renderer == null || !renderer.IsRendering)
+			HandleCancel ();
+	}
 
-			if (renderer == null || !renderer.IsRendering)
-				HandleCancel ();
-		}
+	// Called from asynchronously from Renderer.OnCompletion ()
+	void HandleCancel ()
+	{
+		Debug.WriteLine ("LivePreviewManager.HandleCancel()");
 
-		// Called from asynchronously from Renderer.OnCompletion ()
-		void HandleCancel ()
-		{
-			Debug.WriteLine ("LivePreviewManager.HandleCancel()");
+		live_preview_enabled = false;
 
-			IsEnabled = false;
+		live_preview_surface = null!;
 
-			LivePreviewSurface = null!;
+		workspace.Invalidate ();
 
-			workspace.Invalidate ();
+		CleanUp ();
+	}
 
-			CleanUp ();
-		}
+	void Apply ()
+	{
+		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
 
-		void Apply ()
-		{
-			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
+		apply_live_preview_flag = true;
 
-			apply_live_preview_flag = true;
-
-			if (!renderer.IsRendering) {
-				HandleApply ();
-			} else {
-				IProgressDialog dialog = chrome.ProgressDialog;
-				dialog.Title = Translations.GetString ("Rendering Effect");
-				dialog.Text = effect.Name;
-				dialog.Progress = renderer.Progress;
-				dialog.Canceled += HandleProgressDialogCancel;
-				dialog.Show ();
-			}
-		}
-
-		void HandleProgressDialogCancel (object? o, EventArgs e)
-		{
-			Cancel ();
-		}
-
-		// Called from asynchronously from Renderer.OnCompletion ()
-		void HandleApply ()
-		{
-			Debug.WriteLine ("LivePreviewManager.HandleApply()");
-
-			Cairo.Context ctx = new (layer.Surface);
-			ctx.Save ();
-			workspace.ActiveDocument.Selection.Clip (ctx);
-
-			layer.DrawWithOperator (ctx, LivePreviewSurface, Cairo.Operator.Source);
-			ctx.Restore ();
-
-			workspace.ActiveDocument.History.PushNewItem (history_item);
-			history_item = null!;
-
-			IsEnabled = false;
-
-			workspace.Invalidate (); //TODO keep track of dirty bounds.
-			CleanUp ();
-		}
-
-		// Clean up resources when live preview is disabled.
-		void CleanUp ()
-		{
-			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.CleanUp()");
-
-			IsEnabled = false;
-
-			if (effect != null) {
-				if (effect.EffectData != null)
-					effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;
-				effect = null!;
-			}
-
-			LivePreviewSurface = null!;
-
-			if (renderer != null) {
-				renderer.Dispose ();
-				renderer = null!;
-			}
-
-			history_item = null!;
-
-			// Hide progress dialog and clean up events.
+		if (!renderer.IsRendering) {
+			HandleApply ();
+		} else {
 			IProgressDialog dialog = chrome.ProgressDialog;
-			dialog.Hide ();
-			dialog.Canceled -= HandleProgressDialogCancel;
+			dialog.Title = Translations.GetString ("Rendering Effect");
+			dialog.Text = effect.Name;
+			dialog.Progress = renderer.Progress;
+			dialog.Canceled += HandleProgressDialogCancel;
+			dialog.Show ();
+		}
+	}
 
-			chrome.MainWindowBusy = false;
+	void HandleProgressDialogCancel (object? o, EventArgs e)
+	{
+		Cancel ();
+	}
+
+	// Called from asynchronously from Renderer.OnCompletion ()
+	void HandleApply ()
+	{
+		Debug.WriteLine ("LivePreviewManager.HandleApply()");
+
+		Cairo.Context ctx = new (layer.Surface);
+		ctx.Save ();
+		workspace.ActiveDocument.Selection.Clip (ctx);
+
+		layer.DrawWithOperator (ctx, live_preview_surface, Cairo.Operator.Source);
+		ctx.Restore ();
+
+		workspace.ActiveDocument.History.PushNewItem (history_item);
+		history_item = null!;
+
+		live_preview_enabled = false;
+
+		workspace.Invalidate (); //TODO keep track of dirty bounds.
+		CleanUp ();
+	}
+
+	// Clean up resources when live preview is disabled.
+	void CleanUp ()
+	{
+		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.CleanUp()");
+
+		live_preview_enabled = false;
+
+		if (effect != null) {
+			if (effect.EffectData != null)
+				effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;
+			effect = null!;
 		}
 
-		void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
-		{
-			//TODO calculate bounds.
-			renderer!.Start (effect, layer.Surface, LivePreviewSurface);
+		live_preview_surface = null!;
+
+		if (renderer != null) {
+			renderer.Dispose ();
+			renderer = null!;
 		}
 
-		void OnUpdate (
-			double progress,
-			RectangleI updatedBounds)
-		{
-			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnUpdate() progress: " + progress);
-			chrome.ProgressDialog.Progress = progress;
-			HandleUpdate (updatedBounds);
+		history_item = null!;
+
+		// Hide progress dialog and clean up events.
+		IProgressDialog dialog = chrome.ProgressDialog;
+		dialog.Hide ();
+		dialog.Canceled -= HandleProgressDialogCancel;
+
+		chrome.MainWindowBusy = false;
+	}
+
+	void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
+	{
+		//TODO calculate bounds.
+		renderer.Start (effect, layer.Surface, live_preview_surface);
+	}
+
+	private void OnUpdate (
+		double progress,
+		RectangleI updatedBounds)
+	{
+		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnUpdate() progress: " + progress);
+		chrome.ProgressDialog.Progress = progress;
+		HandleUpdate (updatedBounds);
+	}
+
+	private void OnCompletion (
+		IReadOnlyList<Exception> exceptions,
+		CancellationToken cancellationToken)
+	{
+		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancellationToken.IsCancellationRequested);
+
+		if (!live_preview_enabled)
+			return;
+
+		if (cancel_live_preview_flag)
+			HandleCancel ();
+		else if (apply_live_preview_flag)
+			HandleApply ();
+	}
+
+	void HandleUpdate (RectangleI bounds)
+	{
+		double scale = workspace.Scale;
+		PointD offset = workspace.Offset;
+
+		// Transform bounds (Image -> Canvas -> Window)
+
+		// Calculate canvas bounds.
+		PointD bounds1 = new (
+			X: bounds.Left * scale,
+			Y: bounds.Top * scale);
+
+		PointD bounds2 = new (
+			X: (bounds.Right + 1) * scale,
+			Y: (bounds.Bottom + 1) * scale);
+
+		// TODO Figure out why when scale > 1 that I need add on an
+		// extra pixel of padding.
+		// I must being doing something wrong here.
+		if (scale > 1.0) {
+			//x1 = (bounds.Left-1) * scale;
+			bounds1 = bounds1 with { Y = (bounds.Top - 1) * scale };
+			//x2 = (bounds.Right+1) * scale;
+			//y2 = (bounds.Bottom+1) * scale;
 		}
 
-		void OnCompletion (
-			IReadOnlyList<Exception> exceptions,
-			CancellationToken cancellationToken)
-		{
-			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancellationToken.IsCancellationRequested);
+		// Calculate window bounds.
+		bounds1 += offset;
+		bounds2 += offset;
 
-			if (!IsEnabled)
-				return;
+		// Convert to integer, carefully not to miss partially covered
+		// pixels by rounding incorrectly.
+		int x = (int) Math.Floor (bounds1.X);
+		int y = (int) Math.Floor (bounds1.Y);
+		RectangleI areaToInvalidate = new (
+			X: x,
+			Y: y,
+			Width: (int) Math.Ceiling (bounds2.X) - x,
+			Height: (int) Math.Ceiling (bounds2.Y) - y);
 
-			if (cancel_live_preview_flag)
-				HandleCancel ();
-			else if (apply_live_preview_flag)
-				HandleApply ();
-		}
-
-		void HandleUpdate (RectangleI bounds)
-		{
-			double scale = workspace.Scale;
-			PointD offset = workspace.Offset;
-
-			// Transform bounds (Image -> Canvas -> Window)
-
-			// Calculate canvas bounds.
-			PointD bounds1 = new (
-				X: bounds.Left * scale,
-				Y: bounds.Top * scale);
-
-			PointD bounds2 = new (
-				X: (bounds.Right + 1) * scale,
-				Y: (bounds.Bottom + 1) * scale);
-
-			// TODO Figure out why when scale > 1 that I need add on an
-			// extra pixel of padding.
-			// I must being doing something wrong here.
-			if (scale > 1.0) {
-				//x1 = (bounds.Left-1) * scale;
-				bounds1 = bounds1 with { Y = (bounds.Top - 1) * scale };
-				//x2 = (bounds.Right+1) * scale;
-				//y2 = (bounds.Bottom+1) * scale;
-			}
-
-			// Calculate window bounds.
-			bounds1 += offset;
-			bounds2 += offset;
-
-			// Convert to integer, carefully not to miss partially covered
-			// pixels by rounding incorrectly.
-			int x = (int) Math.Floor (bounds1.X);
-			int y = (int) Math.Floor (bounds1.Y);
-			RectangleI areaToInvalidate = new (
-				X: x,
-				Y: y,
-				Width: (int) Math.Ceiling (bounds2.X) - x,
-				Height: (int) Math.Ceiling (bounds2.Y) - y);
-
-			// Tell GTK to expose the drawing area.
-			workspace.ActiveWorkspace.InvalidateWindowRect (areaToInvalidate);
-		}
+		// Tell GTK to expose the drawing area.
+		workspace.ActiveWorkspace.InvalidateWindowRect (areaToInvalidate);
 	}
 }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -43,17 +43,11 @@ public interface ILivePreview
 
 public sealed class LivePreviewManager : ILivePreview
 {
-	// NRT - These are set in Start(). This should be rewritten to be provably non-null.
-	bool live_preview_enabled;
 	Layer layer = null!;
-	BaseEffect effect = null!;
 	Cairo.Path? selection_path;
 
 	bool apply_live_preview_flag;
 	bool cancel_live_preview_flag;
-
-	Cairo.ImageSurface live_preview_surface = null!;
-	RectangleI render_bounds;
 	SimpleHistoryItem history_item = null!;
 
 	AsyncEffectRenderer renderer = null!;
@@ -68,7 +62,7 @@ public sealed class LivePreviewManager : ILivePreview
 		SystemManager systemManager,
 		ChromeManager chromeManager)
 	{
-		live_preview_enabled = false;
+		IsEnabled = false;
 
 		workspace = workspaceManager;
 		tools = toolManager;
@@ -76,13 +70,13 @@ public sealed class LivePreviewManager : ILivePreview
 		chrome = chromeManager;
 	}
 
-	public Cairo.ImageSurface LivePreviewSurface => live_preview_surface;
-	public RectangleI RenderBounds => render_bounds;
-	public bool IsEnabled => live_preview_enabled;
+	public Cairo.ImageSurface LivePreviewSurface { get; private set; } = null!;
+	public RectangleI RenderBounds { get; private set; }
+	public bool IsEnabled { get; private set; }
 
 	public async void Start (BaseEffect effect)
 	{
-		if (live_preview_enabled)
+		if (IsEnabled)
 			throw new InvalidOperationException ("LivePreviewManager.Start() called while live preview is already enabled.");
 
 		// Create live preview surface.
@@ -91,15 +85,14 @@ public sealed class LivePreviewManager : ILivePreview
 
 		var doc = workspace.ActiveDocument;
 
-		live_preview_enabled = true;
+		IsEnabled = true;
 		apply_live_preview_flag = false;
 		cancel_live_preview_flag = false;
 
 		layer = doc.Layers.CurrentUserLayer;
-		this.effect = effect;
 
 		//TODO Use the current tool layer instead.
-		live_preview_surface = CairoExtensions.CreateImageSurface (
+		LivePreviewSurface = CairoExtensions.CreateImageSurface (
 			Cairo.Format.Argb32,
 			workspace.ImageSize.Width,
 			workspace.ImageSize.Height);
@@ -110,14 +103,14 @@ public sealed class LivePreviewManager : ILivePreview
 		DocumentSelection selection = doc.Selection;
 
 		selection_path = selection.Visible ? selection.SelectionPath : null;
-		render_bounds = (selection_path != null) ? selection_path.GetBounds () : live_preview_surface.GetBounds ();
-		render_bounds = workspace.ClampToImageSize (render_bounds);
+		RenderBounds = (selection_path != null) ? selection_path.GetBounds () : LivePreviewSurface.GetBounds ();
+		RenderBounds = workspace.ClampToImageSize (RenderBounds);
 
 		history_item = new SimpleHistoryItem (effect.Icon, effect.Name);
 		history_item.TakeSnapshotOfLayer (doc.Layers.CurrentUserLayerIndex);
 
 		// Paint the pre-effect layer surface into into the working surface.
-		Cairo.Context ctx = new (live_preview_surface);
+		Cairo.Context ctx = new (LivePreviewSurface);
 		layer.Draw (ctx, layer.Surface, 1);
 
 		if (effect.EffectData != null)
@@ -125,7 +118,7 @@ public sealed class LivePreviewManager : ILivePreview
 
 		AsyncEffectRenderer.Settings settings = new (
 			threadCount: system.RenderThreads,
-			renderBounds: render_bounds,
+			renderBounds: RenderBounds,
 			effectIsTileable: effect.IsTileable,
 			updateMilliseconds: 100,
 			threadPriority: ThreadPriority.BelowNormal);
@@ -135,7 +128,7 @@ public sealed class LivePreviewManager : ILivePreview
 		renderer = new AsyncEffectRenderer (settings);
 		renderer.Updated += OnUpdate;
 		renderer.Completed += OnCompletion;
-		renderer.Start (effect, layer.Surface, live_preview_surface);
+		renderer.Start (effect, layer.Surface, LivePreviewSurface);
 
 		if (effect.IsConfigurable) {
 
@@ -150,185 +143,184 @@ public sealed class LivePreviewManager : ILivePreview
 			chrome.MainWindowBusy = true;
 			Apply ();
 		}
-	}
 
-	// Method asks render task to complete, and then returns immediately. The cancel
-	// is not actually complete until the LivePreviewRenderCompleted event is fired.
-	void Cancel ()
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.Cancel()");
+		// === Methods ===
 
-		cancel_live_preview_flag = true;
+		// Method asks render task to complete, and then returns immediately. The cancel
+		// is not actually complete until the LivePreviewRenderCompleted event is fired.
+		void Cancel ()
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.Cancel()");
 
-		renderer?.Cancel ();
+			cancel_live_preview_flag = true;
 
-		// Show a busy cursor, and make the main window insensitive,
-		// until the cancel has completed.
-		chrome.MainWindowBusy = true;
+			renderer?.Cancel ();
 
-		if (renderer == null || !renderer.IsRendering)
-			HandleCancel ();
-	}
+			// Show a busy cursor, and make the main window insensitive,
+			// until the cancel has completed.
+			chrome.MainWindowBusy = true;
 
-	// Called from asynchronously from Renderer.OnCompletion ()
-	void HandleCancel ()
-	{
-		Debug.WriteLine ("LivePreviewManager.HandleCancel()");
-
-		live_preview_enabled = false;
-
-		live_preview_surface = null!;
-
-		workspace.Invalidate ();
-
-		CleanUp ();
-	}
-
-	void Apply ()
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
-
-		apply_live_preview_flag = true;
-
-		if (!renderer.IsRendering) {
-			HandleApply ();
-		} else {
-			IProgressDialog dialog = chrome.ProgressDialog;
-			dialog.Title = Translations.GetString ("Rendering Effect");
-			dialog.Text = effect.Name;
-			dialog.Progress = renderer.Progress;
-			dialog.Canceled += HandleProgressDialogCancel;
-			dialog.Show ();
+			if (renderer == null || !renderer.IsRendering)
+				HandleCancel ();
 		}
-	}
 
-	void HandleProgressDialogCancel (object? o, EventArgs e)
-	{
-		Cancel ();
-	}
+		// Called from asynchronously from Renderer.OnCompletion ()
+		void HandleCancel ()
+		{
+			Debug.WriteLine ("LivePreviewManager.HandleCancel()");
 
-	// Called from asynchronously from Renderer.OnCompletion ()
-	void HandleApply ()
-	{
-		Debug.WriteLine ("LivePreviewManager.HandleApply()");
+			IsEnabled = false;
 
-		Cairo.Context ctx = new (layer.Surface);
-		ctx.Save ();
-		workspace.ActiveDocument.Selection.Clip (ctx);
+			LivePreviewSurface = null!;
 
-		layer.DrawWithOperator (ctx, live_preview_surface, Cairo.Operator.Source);
-		ctx.Restore ();
+			workspace.Invalidate ();
 
-		workspace.ActiveDocument.History.PushNewItem (history_item);
-		history_item = null!;
+			CleanUp ();
+		}
 
-		live_preview_enabled = false;
+		void Apply ()
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
 
-		workspace.Invalidate (); //TODO keep track of dirty bounds.
-		CleanUp ();
-	}
+			apply_live_preview_flag = true;
 
-	// Clean up resources when live preview is disabled.
-	void CleanUp ()
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.CleanUp()");
+			if (!renderer.IsRendering) {
+				HandleApply ();
+			} else {
+				IProgressDialog dialog = chrome.ProgressDialog;
+				dialog.Title = Translations.GetString ("Rendering Effect");
+				dialog.Text = effect.Name;
+				dialog.Progress = renderer.Progress;
+				dialog.Canceled += HandleProgressDialogCancel;
+				dialog.Show ();
+			}
+		}
 
-		live_preview_enabled = false;
+		void HandleProgressDialogCancel (object? o, EventArgs e)
+		{
+			Cancel ();
+		}
 
-		if (effect != null) {
+		// Called from asynchronously from Renderer.OnCompletion ()
+		void HandleApply ()
+		{
+			Debug.WriteLine ("LivePreviewManager.HandleApply()");
+
+			Cairo.Context ctx = new (layer.Surface);
+			ctx.Save ();
+			workspace.ActiveDocument.Selection.Clip (ctx);
+
+			layer.DrawWithOperator (ctx, LivePreviewSurface, Cairo.Operator.Source);
+			ctx.Restore ();
+
+			workspace.ActiveDocument.History.PushNewItem (history_item);
+			history_item = null!;
+
+			IsEnabled = false;
+
+			workspace.Invalidate (); //TODO keep track of dirty bounds.
+			CleanUp ();
+		}
+
+		// Clean up resources when live preview is disabled.
+		void CleanUp ()
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.CleanUp()");
+
+			IsEnabled = false;
+
 			if (effect.EffectData != null)
 				effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;
-			effect = null!;
+
+			LivePreviewSurface = null!;
+
+			if (renderer != null) {
+				renderer.Dispose ();
+				renderer = null!;
+			}
+
+			history_item = null!;
+
+			// Hide progress dialog and clean up events.
+			IProgressDialog dialog = chrome.ProgressDialog;
+			dialog.Hide ();
+			dialog.Canceled -= HandleProgressDialogCancel;
+
+			chrome.MainWindowBusy = false;
 		}
 
-		live_preview_surface = null!;
-
-		if (renderer != null) {
-			renderer.Dispose ();
-			renderer = null!;
+		void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
+		{
+			//TODO calculate bounds.
+			renderer!.Start (effect, layer.Surface, LivePreviewSurface);
 		}
 
-		history_item = null!;
-
-		// Hide progress dialog and clean up events.
-		IProgressDialog dialog = chrome.ProgressDialog;
-		dialog.Hide ();
-		dialog.Canceled -= HandleProgressDialogCancel;
-
-		chrome.MainWindowBusy = false;
-	}
-
-	void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
-	{
-		//TODO calculate bounds.
-		renderer.Start (effect, layer.Surface, live_preview_surface);
-	}
-
-	private void OnUpdate (
-		double progress,
-		RectangleI updatedBounds)
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnUpdate() progress: " + progress);
-		chrome.ProgressDialog.Progress = progress;
-		HandleUpdate (updatedBounds);
-	}
-
-	private void OnCompletion (
-		IReadOnlyList<Exception> exceptions,
-		CancellationToken cancellationToken)
-	{
-		Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancellationToken.IsCancellationRequested);
-
-		if (!live_preview_enabled)
-			return;
-
-		if (cancel_live_preview_flag)
-			HandleCancel ();
-		else if (apply_live_preview_flag)
-			HandleApply ();
-	}
-
-	void HandleUpdate (RectangleI bounds)
-	{
-		double scale = workspace.Scale;
-		PointD offset = workspace.Offset;
-
-		// Transform bounds (Image -> Canvas -> Window)
-
-		// Calculate canvas bounds.
-		PointD bounds1 = new (
-			X: bounds.Left * scale,
-			Y: bounds.Top * scale);
-
-		PointD bounds2 = new (
-			X: (bounds.Right + 1) * scale,
-			Y: (bounds.Bottom + 1) * scale);
-
-		// TODO Figure out why when scale > 1 that I need add on an
-		// extra pixel of padding.
-		// I must being doing something wrong here.
-		if (scale > 1.0) {
-			//x1 = (bounds.Left-1) * scale;
-			bounds1 = bounds1 with { Y = (bounds.Top - 1) * scale };
-			//x2 = (bounds.Right+1) * scale;
-			//y2 = (bounds.Bottom+1) * scale;
+		void OnUpdate (
+			double progress,
+			RectangleI updatedBounds)
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnUpdate() progress: " + progress);
+			chrome.ProgressDialog.Progress = progress;
+			HandleUpdate (updatedBounds);
 		}
 
-		// Calculate window bounds.
-		bounds1 += offset;
-		bounds2 += offset;
+		void OnCompletion (
+			IReadOnlyList<Exception> exceptions,
+			CancellationToken cancellationToken)
+		{
+			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " LivePreviewManager.OnCompletion() cancelled: " + cancellationToken.IsCancellationRequested);
 
-		// Convert to integer, carefully not to miss partially covered
-		// pixels by rounding incorrectly.
-		int x = (int) Math.Floor (bounds1.X);
-		int y = (int) Math.Floor (bounds1.Y);
-		RectangleI areaToInvalidate = new (
-			X: x,
-			Y: y,
-			Width: (int) Math.Ceiling (bounds2.X) - x,
-			Height: (int) Math.Ceiling (bounds2.Y) - y);
+			if (!IsEnabled)
+				return;
 
-		// Tell GTK to expose the drawing area.
-		workspace.ActiveWorkspace.InvalidateWindowRect (areaToInvalidate);
+			if (cancel_live_preview_flag)
+				HandleCancel ();
+			else if (apply_live_preview_flag)
+				HandleApply ();
+		}
+
+		void HandleUpdate (RectangleI bounds)
+		{
+			double scale = workspace.Scale;
+			PointD offset = workspace.Offset;
+
+			// Transform bounds (Image -> Canvas -> Window)
+
+			// Calculate canvas bounds.
+			PointD bounds1 = new (
+				X: bounds.Left * scale,
+				Y: bounds.Top * scale);
+
+			PointD bounds2 = new (
+				X: (bounds.Right + 1) * scale,
+				Y: (bounds.Bottom + 1) * scale);
+
+			// TODO Figure out why when scale > 1 that I need add on an
+			// extra pixel of padding.
+			// I must being doing something wrong here.
+			if (scale > 1.0) {
+				//x1 = (bounds.Left-1) * scale;
+				bounds1 = bounds1 with { Y = (bounds.Top - 1) * scale };
+				//x2 = (bounds.Right+1) * scale;
+				//y2 = (bounds.Bottom+1) * scale;
+			}
+
+			// Calculate window bounds.
+			bounds1 += offset;
+			bounds2 += offset;
+
+			// Convert to integer, carefully not to miss partially covered
+			// pixels by rounding incorrectly.
+			int x = (int) Math.Floor (bounds1.X);
+			int y = (int) Math.Floor (bounds1.Y);
+			RectangleI areaToInvalidate = new (
+				X: x,
+				Y: y,
+				Width: (int) Math.Ceiling (bounds2.X) - x,
+				Height: (int) Math.Ceiling (bounds2.Y) - y);
+
+			// Tell GTK to expose the drawing area.
+			workspace.ActiveWorkspace.InvalidateWindowRect (areaToInvalidate);
+		}
 	}
 }


### PR DESCRIPTION
The only public method is `Start`
.
This will help us refactor later, and identify the fields that are used for communication between renders. The goal is getting rid of them, because one render shouldn't have to know about other renders.