### PR TITLE
Update to gir.core 0.6.0-preview.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GirCore.Adw-1" Version="0.5.0" />
-    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.5.0" />
-    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.5.0" />
+    <PackageVersion Include="GirCore.Adw-1" Version="0.6.0-preview.1" />
+    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.6.0-preview.1" />
+    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.6.0-preview.1" />
     <!-- Note: at least 1.4.2-alpha3 is required for fixes to uninstalling addins, from https://github.com/mono/mono-addins/pull/198 -->
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />

--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -201,7 +201,7 @@ public sealed class EditActions
 
 		ImageSurface old = doc.Layers.CurrentUserLayer.Surface.Clone ();
 
-		Context g = new (doc.Layers.CurrentUserLayer.Surface);
+		using Context g = new (doc.Layers.CurrentUserLayer.Surface);
 
 		g.AppendPath (doc.Selection.SelectionPath);
 		g.FillRule = FillRule.EvenOdd;
@@ -247,7 +247,7 @@ public sealed class EditActions
 
 		ImageSurface old = doc.Layers.CurrentUserLayer.Surface.Clone ();
 
-		Context g = new (doc.Layers.CurrentUserLayer.Surface);
+		using Context g = new (doc.Layers.CurrentUserLayer.Surface);
 
 		g.AppendPath (doc.Selection.SelectionPath);
 		g.FillRule = FillRule.EvenOdd;
@@ -302,7 +302,7 @@ public sealed class EditActions
 
 		ImageSurface dest = CairoExtensions.CreateImageSurface (Format.Argb32, rect.Width, rect.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.SetSourceSurface (src, -rect.X, -rect.Y);
 		g.Paint ();
@@ -324,7 +324,7 @@ public sealed class EditActions
 		// Copy it to a correctly sized surface 
 		ImageSurface dest = CairoExtensions.CreateImageSurface (Format.Argb32, rect.Width, rect.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.SetSourceSurface (src, -rect.X, -rect.Y);
 		g.Paint ();

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -217,7 +217,7 @@ public sealed class LayerActions
 			using Gio.FileInputStream fs = file.Read (null);
 			try {
 				GdkPixbuf.Pixbuf bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when an error is thrown
-				Cairo.Context context = new (layer.Surface);
+				using Cairo.Context context = new (layer.Surface);
 				context.DrawPixbuf (bg, PointD.Zero);
 			} finally {
 				fs.Close (null);

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -197,26 +197,10 @@ public sealed class Document
 		return g;
 	}
 
-	public Context CreateClippedContext (bool antialias)
-	{
-		Context g = new (Layers.CurrentUserLayer.Surface);
-		Selection.Clip (g);
-		g.Antialias = antialias ? Antialias.Subpixel : Antialias.None;
-		return g;
-	}
-
 	public Context CreateClippedToolContext ()
 	{
 		Context g = new (Layers.ToolLayer.Surface);
 		Selection.Clip (g);
-		return g;
-	}
-
-	public Context CreateClippedToolContext (bool antialias)
-	{
-		Context g = new (Layers.ToolLayer.Surface);
-		Selection.Clip (g);
-		g.Antialias = antialias ? Antialias.Subpixel : Antialias.None;
 		return g;
 	}
 
@@ -232,7 +216,7 @@ public sealed class Document
 
 		Layer layer = Layers.SelectionLayer;
 
-		Context g = new (Layers.CurrentUserLayer.Surface);
+		using Context g = new (Layers.CurrentUserLayer.Surface);
 		selection.Clip (g);
 		layer.DrawWithOperator (g, Operator.Source, opacity: 1.0, transform: true);
 
@@ -270,7 +254,7 @@ public sealed class Document
 			1,
 			1);
 
-		Context g = new (dst);
+		using Context g = new (dst);
 
 		foreach (var layer in Layers.GetLayersToPaint ()) {
 

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -206,7 +206,7 @@ public sealed class DocumentLayers
 		// {0} is the name of the source layer. Example: "Layer 3 copy".
 		UserLayer layer = CreateLayer (Translations.GetString ("{0} copy", source.Name));
 
-		Context g = new (layer.Surface);
+		using Context g = new (layer.Surface);
 		g.SetSourceSurface (source.Surface, 0, 0);
 		g.Paint ();
 
@@ -254,7 +254,7 @@ public sealed class DocumentLayers
 	{
 		ImageSurface surf = CairoExtensions.CreateImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
 
-		Context g = new (surf);
+		using Context g = new (surf);
 		document.Selection.Clip (g);
 
 		g.SetSourceSurface (user_layers[index].Surface, 0, 0);
@@ -271,7 +271,7 @@ public sealed class DocumentLayers
 		// Create a new image surface
 		ImageSurface surf = CairoExtensions.CreateImageSurface (Format.Argb32, document.ImageSize.Width, document.ImageSize.Height);
 
-		Context g = new (surf);
+		using Context g = new (surf);
 
 		if (clip_to_selection)
 			document.Selection.Clip (g);
@@ -350,7 +350,7 @@ public sealed class DocumentLayers
 		UserLayer dest = user_layers[CurrentUserLayerIndex - 1];
 
 		// Blend the layers
-		Context g = new (dest.Surface);
+		using Context g = new (dest.Surface);
 		source.Draw (g);
 
 		DeleteCurrentLayer ();

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -62,7 +62,7 @@ public sealed class DocumentSelection
 	public Path SelectionPath {
 		get {
 			if (selection_path == null) {
-				Context g = new (owning_document.Layers.CurrentUserLayer.Surface);
+				using Context g = new (owning_document.Layers.CurrentUserLayer.Surface);
 				selection_path = g.CreatePolygonPath (ConvertToPolygonSet (SelectionPolygons));
 			}
 

--- a/Pinta.Core/Classes/Layer.cs
+++ b/Pinta.Core/Classes/Layer.cs
@@ -97,7 +97,7 @@ public class Layer : ObservableObject
 			Surface.Width,
 			Surface.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.SetMatrix (CairoExtensions.CreateMatrix (-1, 0, 0, 1, Surface.Width, 0));
 		g.SetSourceSurface (Surface, 0, 0);
@@ -114,7 +114,7 @@ public class Layer : ObservableObject
 			Surface.Width,
 			Surface.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.SetMatrix (CairoExtensions.CreateMatrix (1, 0, 0, -1, 0, Surface.Height));
 		g.SetSourceSurface (Surface, 0, 0);
@@ -183,7 +183,7 @@ public class Layer : ObservableObject
 			new_size.Width,
 			new_size.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.Transform (xform);
 		g.SetSourceSurface (Surface, 0, 0);
@@ -215,7 +215,7 @@ public class Layer : ObservableObject
 			newSize.Width,
 			newSize.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.Scale (newSize.Width / (double) Surface.Width, newSize.Height / (double) Surface.Height);
 		g.SetSourceSurface (Surface, resamplingMode);
@@ -238,7 +238,7 @@ public class Layer : ObservableObject
 
 		PointD anchorPoint = GetAnchorPoint (delta, anchor);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		g.SetSourceSurface (Surface, anchorPoint.X, anchorPoint.Y);
 		g.Paint ();
@@ -267,7 +267,7 @@ public class Layer : ObservableObject
 			rect.Width,
 			rect.Height);
 
-		Context g = new (dest);
+		using Context g = new (dest);
 
 		// Move the selected content to the upper left
 		g.Translate (-rect.X, -rect.Y);

--- a/Pinta.Core/Extensions/CairoExtensions.cs
+++ b/Pinta.Core/Extensions/CairoExtensions.cs
@@ -628,7 +628,7 @@ namespace Pinta.Core
 				surf.Width,
 				surf.Height);
 
-			Context g = new (newsurf);
+			using Context g = new (newsurf);
 
 			g.SetSourceSurface (surf, 0, 0);
 			g.Paint ();
@@ -639,14 +639,14 @@ namespace Pinta.Core
 		public static Path Clone (this Path path)
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
-			Context g = new (doc.Layers.CurrentUserLayer.Surface);
+			using Context g = new (doc.Layers.CurrentUserLayer.Surface);
 			g.AppendPath (path);
 			return g.CopyPath ();
 		}
 
 		public static void Clear (this ImageSurface surface)
 		{
-			Context g = new (surface) { Operator = Operator.Clear };
+			using Context g = new (surface) { Operator = Operator.Clear };
 			g.Paint ();
 		}
 
@@ -689,7 +689,7 @@ namespace Pinta.Core
 		public static RectangleI GetBounds (this Path path)
 		{
 			Document doc = PintaCore.Workspace.ActiveDocument;
-			Context g = new (doc.Layers.CurrentUserLayer.Surface);
+			using Context g = new (doc.Layers.CurrentUserLayer.Surface);
 			g.AppendPath (path);
 			return g.PathExtents ().ToInt ();
 		}
@@ -1175,7 +1175,7 @@ namespace Pinta.Core
 			ImageSurface surface = CreateImageSurface (Format.Argb32, size, size);
 
 			// Draw the checkerboard
-			Context g = new (surface);
+			using Context g = new (surface);
 
 			// Fill white
 			g.FillRectangle (new RectangleD (0, 0, size, size), new Color (1, 1, 1));
@@ -1856,7 +1856,7 @@ namespace Pinta.Core
 			Color color)
 		{
 			ImageSurface surf = CreateImageSurface (Cairo.Format.Argb32, size, size);
-			Context g = new (surf);
+			using Context g = new (surf);
 
 			g.FillRectangle (new RectangleD (0, 0, size, size), color);
 			g.DrawRectangle (new RectangleD (0, 0, size, size), new Color (0, 0, 0), 1);
@@ -1867,7 +1867,7 @@ namespace Pinta.Core
 		public static ImageSurface CreateTransparentColorSwatch (int size, bool drawBorder)
 		{
 			ImageSurface surface = CreateTransparentBackgroundSurface (size);
-			Context g = new (surface);
+			using Context g = new (surface);
 
 			if (drawBorder)
 				g.DrawRectangle (new RectangleD (0, 0, size, size), new Color (0, 0, 0), 1);

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -140,7 +140,7 @@ public static class GdkExtensions
 		shapeY = imgToShapeY - iconBBox.Top;
 
 		var i = CairoExtensions.CreateImageSurface (Cairo.Format.Argb32, iconBBox.Width, iconBBox.Height);
-		var g = new Cairo.Context (i);
+		using Cairo.Context g = new (i);
 		// Don't show shape if shapeWidth less than 3,
 		if (shapeWidth > 3) {
 			int diam = Math.Max (1, shapeWidth - 2);

--- a/Pinta.Core/HistoryItems/PasteHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/PasteHistoryItem.cs
@@ -50,7 +50,7 @@ public sealed class PasteHistoryItem : BaseHistoryItem
 		doc.Layers.CreateSelectionLayer ();
 		doc.Layers.ShowSelectionLayer = true;
 
-		var g = new Cairo.Context (doc.Layers.SelectionLayer.Surface);
+		using Cairo.Context g = new (doc.Layers.SelectionLayer.Surface);
 		g.SetSourceSurface (paste_image, 0, 0);
 		g.Paint ();
 

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -49,7 +49,7 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 
 		Layer layer = newDocument.Layers.AddNewLayer (file.GetDisplayName ());
 
-		Cairo.Context g = new (layer.Surface);
+		using Cairo.Context g = new (layer.Surface);
 
 		g.DrawPixbuf (effectiveBuffer, PointD.Zero);
 

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -110,7 +110,7 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 				layer.BlendMode = StandardToBlendMode (GetAttribute (layerElement, "composite-op", "svg:src-over"));
 
 				Pixbuf pb = Pixbuf.NewFromFile (tmp_file)!; // NRT: only nullable when an error is thrown
-				Context g = new (layer.Surface);
+				using Context g = new (layer.Surface);
 				g.DrawPixbuf (pb, (PointD) position);
 
 				try {

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -74,7 +74,9 @@ public sealed class ImageConverterManager
 
 	private static FormatDescriptor CreateFormatDescriptor (PixbufFormat format)
 	{
-		string formatName = format.GetName ().ToLowerInvariant ();
+		string formatName = format.GetName ()?.ToLowerInvariant () ??
+				throw new ArgumentException ($"{nameof (format)} has an empty name");
+
 		string formatNameUpperCase = formatName.ToUpperInvariant ();
 		var extensions = formatName switch {
 			"jpeg" => new string[] { "jpg", "jpeg", "JPG", "JPEG" },
@@ -95,7 +97,7 @@ public sealed class ImageConverterManager
 		FormatDescriptor formatDescriptor = new (
 			displayPrefix: formatNameUpperCase,
 			extensions: extensions,
-			mimes: format.GetMimeTypes (),
+			mimes: format.GetMimeTypes () ?? Array.Empty<string> (),
 			importer: importer,
 			exporter: exporter,
 			supportsLayers: false);

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -110,7 +110,7 @@ public sealed class LivePreviewManager : ILivePreview
 		history_item.TakeSnapshotOfLayer (doc.Layers.CurrentUserLayerIndex);
 
 		// Paint the pre-effect layer surface into into the working surface.
-		Cairo.Context ctx = new (LivePreviewSurface);
+		using Cairo.Context ctx = new (LivePreviewSurface);
 		layer.Draw (ctx, layer.Surface, 1);
 
 		if (effect.EffectData != null)
@@ -206,7 +206,7 @@ public sealed class LivePreviewManager : ILivePreview
 		{
 			Debug.WriteLine ("LivePreviewManager.HandleApply()");
 
-			Cairo.Context ctx = new (layer.Surface);
+			using Cairo.Context ctx = new (layer.Surface);
 			ctx.Save ();
 			workspace.ActiveDocument.Selection.Clip (ctx);
 

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -145,7 +145,7 @@ public static class WorkspaceServiceExtensions
 		Layer background = doc.Layers.AddNewLayer (Translations.GetString ("Background"));
 
 		if (backgroundColor.A != 0) {
-			Context g = new (background.Surface);
+			using Context g = new (background.Surface);
 			g.SetSourceColor (backgroundColor);
 			g.Paint ();
 		}
@@ -300,7 +300,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 			new Size (image.Width, image.Height),
 			new Color (0, 0, 0, 0));
 
-		Context g = new (doc.Layers[0].Surface);
+		using Context g = new (doc.Layers[0].Surface);
 		g.SetSourceSurface (image, 0, 0);
 		g.Paint ();
 

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -483,6 +483,8 @@ public sealed class CurvesDialog : Gtk.Dialog
 		DrawGrid (g);
 		DrawControlPoints (g);
 
+		g.Dispose ();
+
 		return;
 
 		// Methods

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -603,7 +603,9 @@ public partial class LevelsDialog : Gtk.Dialog
 		if (args.NPress != 2) // double click
 			return;
 
-		ColorPanelWidget panel = (ColorPanelWidget) controller.GetWidget ();
+		ColorPanelWidget panel = (ColorPanelWidget?) controller.GetWidget () ??
+				throw new Exception ("Controller widget should be non-null");
+
 		var ccd = Gtk.ColorChooserDialog.New (Translations.GetString ("Choose Color"), chrome.MainWindow);
 		ccd.UseAlpha = true;
 		ccd.SetColor (panel.CairoColor);

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -138,7 +138,7 @@ public sealed class CloudsEffect : BaseEffect
 		// Have to lock because effect renderer is multithreaded
 		lock (render_lock) {
 
-			Context g = new (dst);
+			using Context g = new (dst);
 
 			// - Clear any previous render from the destination
 			// - Copy the source to the destination

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
@@ -131,6 +131,8 @@ public sealed class AnglePickerGraphic : Gtk.DrawingArea
 		g.DrawEllipse (settings.ellipseOutlineRect, settings.color, 1);
 		g.FillEllipse (settings.gripEllipseRect, settings.color);
 		g.DrawLine (settings.center, settings.endPoint, settings.color, 1);
+
+		g.Dispose ();
 	}
 
 	public event EventHandler? ValueChanged;

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -68,7 +68,7 @@ public sealed class CanvasRenderer
 		RectangleD r = new RectangleI (offset, dst.GetBounds ().Size).ToDouble ();
 		bool is_one_to_one = scale_factor.Ratio == 1;
 
-		Cairo.Context g = new (dst);
+		using Cairo.Context g = new (dst);
 
 		// Create the transparent checkerboard background
 		g.Translate (-offset.X, -offset.Y);

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -209,6 +209,10 @@ public sealed class PintaCanvas : DrawingArea
 			DrawHandles (g, PintaCore.Tools.CurrentTool.Handles);
 			g.Restore ();
 		}
+
+		// Explicitly dispose the context to avoid memory growth (bug #939).
+		// This can be the last reference to a temporary surface from the GTK widget.
+		context.Dispose ();
 	}
 
 	private static void DrawHandles (Cairo.Context cr, IEnumerable<IToolHandle> controls)

--- a/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
@@ -340,6 +340,8 @@ public sealed class ColorGradientWidget : Gtk.DrawingArea
 	{
 		DrawGradient (g);
 		DrawTriangles (g);
+
+		g.Dispose ();
 	}
 
 	private void OnValueChanged (int index)

--- a/Pinta.Gui.Widgets/Widgets/ColorPanelWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPanelWidget.cs
@@ -58,5 +58,7 @@ public sealed class ColorPanelWidget : DrawingArea
 	private void Draw (Context cr)
 	{
 		cr.FillRoundedRectangle (new RectangleD (0, 0, GetAllocatedWidth (), GetAllocatedHeight ()), 4, CairoColor);
+
+		cr.Dispose ();
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -162,5 +162,7 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 
 		for (int i = 0; i < channelCount; ++i)
 			DrawChannel (g, Histogram.GetVisualColor (i), i, max, mean[i]);
+
+		g.Dispose ();
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
@@ -213,5 +213,7 @@ public sealed class LayersListViewItemWidget : Gtk.Box
 		g.LineWidth = 1;
 
 		g.Stroke ();
+
+		g.Dispose ();
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/PointPickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/PointPickerGraphic.cs
@@ -156,6 +156,8 @@ public sealed class PointPickerGraphic : Gtk.DrawingArea
 
 		// Point
 		g.DrawEllipse (settings.pointMarker, settings.pointMarkerColor, 2);
+
+		g.Dispose ();
 	}
 
 	private RectangleI GetDrawBounds ()

--- a/Pinta.Gui.Widgets/Widgets/PointPickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/PointPickerGraphic.cs
@@ -77,7 +77,7 @@ public sealed class PointPickerGraphic : Gtk.DrawingArea
 
 		thumbnail = CairoExtensions.CreateImageSurface (Format.Argb32, bounds.Width, bounds.Height);
 
-		var g = new Context (thumbnail);
+		using Context g = new (thumbnail);
 		g.Scale (scalex, scaley);
 
 		foreach (var layer in doc.Layers.GetLayersToPaint ())

--- a/Pinta.Gui.Widgets/Widgets/Ruler.cs
+++ b/Pinta.Gui.Widgets/Widgets/Ruler.cs
@@ -324,6 +324,8 @@ public sealed class Ruler : DrawingArea
 		cr.Stroke ();
 
 		// TODO-GTK3 - cache the ticks
+
+		cr.Dispose ();
 	}
 
 	private static int GetFontSize (

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -156,6 +156,8 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 		for (int i = 0; i < palette.Count; i++)
 			g.FillRectangle (GetSwatchBounds (i), palette[i]);
+
+		g.Dispose ();
 	}
 
 	private void DrawSwapIcon (Context g, Color color)

--- a/Pinta.Resources/ResourceManager.cs
+++ b/Pinta.Resources/ResourceManager.cs
@@ -131,7 +131,7 @@ public static class ResourceLoader
 	private static Texture CreateMissingImage (int size)
 	{
 		var surf = new Cairo.ImageSurface (Cairo.Format.Argb32, size, size);
-		var g = new Cairo.Context (surf);
+		using Cairo.Context g = new (surf);
 		g.SetSourceRgb (1, 1, 1);
 		g.Rectangle (0, 0, size, size);
 		g.Fill ();

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -1151,7 +1151,7 @@ public abstract class BaseEditEngine
 
 		Document doc = workspace.ActiveDocument;
 
-		var g = new Context (l.Surface);
+		using Context g = new (l.Surface);
 		g.AppendPath (doc.Selection.SelectionPath);
 		g.FillRule = FillRule.EvenOdd;
 		g.Clip ();

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -101,7 +101,7 @@ public sealed class CloneStampTool : BaseBrushTool
 			return;
 		}
 
-		var g = document.CreateClippedToolContext ();
+		using Cairo.Context g = document.CreateClippedToolContext ();
 		g.Antialias = UseAntialiasing ? Cairo.Antialias.Subpixel : Cairo.Antialias.None;
 
 		g.MoveTo (last_point.Value.X, last_point.Value.Y);
@@ -124,7 +124,7 @@ public sealed class CloneStampTool : BaseBrushTool
 	{
 		painting = false;
 
-		var g = new Cairo.Context (document.Layers.CurrentUserLayer.Surface);
+		using Cairo.Context g = new (document.Layers.CurrentUserLayer.Surface);
 		g.SetSourceSurface (document.Layers.ToolLayer.Surface, 0, 0);
 		g.Paint ();
 

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -95,7 +95,7 @@ public sealed class EraserTool : BaseBrushTool
 		if (document.Workspace.PointInCanvas (new_pointd))
 			surface_modified = true;
 
-		var g = document.CreateClippedContext ();
+		using Context g = document.CreateClippedContext ();
 		var last_pointd = (PointD) last_point.Value;
 		switch (eraser_type) {
 			case EraserType.Normal:
@@ -144,7 +144,7 @@ public sealed class EraserTool : BaseBrushTool
 	{
 		var tmp_surface = CairoExtensions.CreateImageSurface (Format.Argb32, dest_rect.Width, dest_rect.Height);
 
-		var g = new Context (tmp_surface) { Operator = Operator.Source };
+		using Context g = new (tmp_surface) { Operator = Operator.Source };
 
 		g.SetSourceSurface (surf, -dest_rect.Left, -dest_rect.Top);
 		g.Rectangle (new RectangleD (0, 0, dest_rect.Width, dest_rect.Height));

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -112,7 +112,7 @@ public sealed class FreeformShapeTool : BaseBrushTool
 
 		document.Layers.ToolLayer.Clear ();
 
-		var g = document.CreateClippedToolContext ();
+		using Context g = document.CreateClippedToolContext ();
 		g.Antialias = UseAntialiasing ? Antialias.Subpixel : Antialias.None;
 
 		g.SetDashFromString (dash_pattern, BrushWidth);
@@ -156,7 +156,7 @@ public sealed class FreeformShapeTool : BaseBrushTool
 		document.Layers.ToolLayer.Clear ();
 		document.Layers.ToolLayer.Hidden = true;
 
-		Context g = document.CreateClippedContext ();
+		using Context g = document.CreateClippedContext ();
 		g.Antialias = UseAntialiasing ? Antialias.Subpixel : Antialias.None;
 
 		g.SetDashFromString (dash_pattern, BrushWidth);

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -125,7 +125,7 @@ public sealed class GradientTool : BaseTool
 
 		// Initialize the scratch layer with the (original) current layer, if any blending is required.
 		if (gr.AlphaOnly || (gr.AlphaBlending && (gr.StartColor.A != 255 || gr.EndColor.A != 255))) {
-			var g = new Context (scratch_layer);
+			using Context g = new (scratch_layer);
 			document.Selection.Clip (g);
 			g.SetSourceSurface (undo_surface!, 0, 0);
 			g.Operator = Operator.Source;
@@ -136,7 +136,7 @@ public sealed class GradientTool : BaseTool
 		gr.Render (scratch_layer, selection_bounds_array);
 
 		// Transfer the result back to the current layer.
-		var context = document.CreateClippedContext ();
+		using Context context = document.CreateClippedContext ();
 		context.SetSourceSurface (scratch_layer, 0, 0);
 		context.Operator = Operator.Source;
 		context.Paint ();

--- a/Pinta.Tools/Tools/LassoSelectTool.cs
+++ b/Pinta.Tools/Tools/LassoSelectTool.cs
@@ -90,7 +90,7 @@ public class LassoSelectTool : BaseTool
 
 		var surf = document.Layers.SelectionLayer.Surface;
 
-		var g = new Context (surf) {
+		using Context g = new (surf) {
 			Antialias = Antialias.Subpixel
 		};
 
@@ -120,7 +120,7 @@ public class LassoSelectTool : BaseTool
 	{
 		var surf = document.Layers.SelectionLayer.Surface;
 
-		var g = new Context (surf);
+		using Context g = new (surf);
 		if (path != null) {
 			g.AppendPath (path);
 			path = null;

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -85,20 +85,20 @@ public sealed class MoveSelectedTool : BaseTransformTool
 			document.Layers.SelectionLayer.Opacity = document.Layers.CurrentUserLayer.Opacity;
 			document.Layers.SelectionLayer.Hidden = document.Layers.CurrentUserLayer.Hidden;
 
-			var g = new Context (document.Layers.SelectionLayer.Surface);
-			g.AppendPath (document.Selection.SelectionPath);
-			g.FillRule = FillRule.EvenOdd;
-			g.SetSourceSurface (document.Layers.CurrentUserLayer.Surface, 0, 0);
-			g.Clip ();
-			g.Paint ();
+			using Context selection_ctx = new (document.Layers.SelectionLayer.Surface);
+			selection_ctx.AppendPath (document.Selection.SelectionPath);
+			selection_ctx.FillRule = FillRule.EvenOdd;
+			selection_ctx.SetSourceSurface (document.Layers.CurrentUserLayer.Surface, 0, 0);
+			selection_ctx.Clip ();
+			selection_ctx.Paint ();
 
 			var surf = document.Layers.CurrentUserLayer.Surface;
 
-			g = new Context (surf);
-			g.AppendPath (document.Selection.SelectionPath);
-			g.FillRule = FillRule.EvenOdd;
-			g.Operator = Cairo.Operator.Clear;
-			g.Fill ();
+			using Context surf_ctx = new (surf);
+			surf_ctx.AppendPath (document.Selection.SelectionPath);
+			surf_ctx.FillRule = FillRule.EvenOdd;
+			surf_ctx.Operator = Cairo.Operator.Clear;
+			surf_ctx.Fill ();
 		}
 
 		document.Workspace.Invalidate ();

--- a/Pinta.Tools/Tools/PaintBrushTool.cs
+++ b/Pinta.Tools/Tools/PaintBrushTool.cs
@@ -124,7 +124,7 @@ public sealed class PaintBrushTool : BaseBrushTool
 			surface_modified = true;
 
 		var surf = document.Layers.ToolLayer.Surface;
-		var g = document.CreateClippedToolContext ();
+		using Context g = document.CreateClippedToolContext ();
 
 		g.Antialias = UseAntialiasing ? Antialias.Subpixel : Antialias.None;
 		g.LineWidth = BrushWidth;
@@ -148,9 +148,9 @@ public sealed class PaintBrushTool : BaseBrushTool
 
 	protected override void OnMouseUp (Document document, ToolMouseEventArgs e)
 	{
-		var gDest = new Context (document.Layers.CurrentUserLayer.Surface);
+		using Context g = new (document.Layers.CurrentUserLayer.Surface);
 
-		document.Layers.ToolLayer.Draw (gDest);
+		document.Layers.ToolLayer.Draw (g);
 
 		document.Layers.ToolLayer.Hidden = true;
 

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -63,11 +63,11 @@ public sealed class PaintBucketTool : FloodTool
 	{
 		var surf = document.Layers.ToolLayer.Surface;
 
-		var g = new Context (surf) {
+		using Context tool_layer_ctx = new (surf) {
 			Operator = Operator.Source
 		};
-		g.SetSourceSurface (document.Layers.CurrentUserLayer.Surface, 0, 0);
-		g.Paint ();
+		tool_layer_ctx.SetSourceSurface (document.Layers.CurrentUserLayer.Surface, 0, 0);
+		tool_layer_ctx.Paint ();
 
 		var hist = new SimpleHistoryItem (Icon, Name);
 		hist.TakeSnapshotOfLayer (document.Layers.CurrentUserLayer);
@@ -91,10 +91,10 @@ public sealed class PaintBucketTool : FloodTool
 
 		// Transfer the temp layer to the real one,
 		// respecting any selection area
-		g = document.CreateClippedContext ();
-		g.Operator = Operator.Source;
-		g.SetSourceSurface (surf, 0, 0);
-		g.Paint ();
+		using Context layer_ctx = document.CreateClippedContext ();
+		layer_ctx.Operator = Operator.Source;
+		layer_ctx.SetSourceSurface (surf, 0, 0);
+		layer_ctx.Paint ();
 
 		document.Layers.ToolLayer.Clear ();
 		document.History.PushNewItem (hist);

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -126,7 +126,7 @@ public sealed class PencilTool : BaseTool
 		if (document.Workspace.PointInCanvas (e.PointDouble))
 			surface_modified = true;
 
-		var g = document.CreateClippedContext ();
+		using Context g = document.CreateClippedContext ();
 
 		g.Antialias = Antialias.None;
 

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -143,7 +143,7 @@ public class RecolorTool : BaseBrushTool
 
 		tmp_layer.MarkDirty ();
 
-		var g = document.CreateClippedContext ();
+		using Context g = document.CreateClippedContext ();
 		g.Antialias = UseAntialiasing ? Antialias.Subpixel : Antialias.None;
 
 		g.MoveTo (last_point.Value.X, last_point.Value.Y);

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -981,7 +981,7 @@ public sealed class TextTool : BaseTool
 			ClearTextLayer ();
 		}
 
-		Cairo.Context g = new (surf);
+		using Cairo.Context g = new (surf);
 
 		var options = new Cairo.FontOptions ();
 
@@ -1015,7 +1015,7 @@ public sealed class TextTool : BaseTool
 
 		//Fill in background
 		if (BackgroundFill) {
-			Cairo.Context g2 = new (surf);
+			using Cairo.Context g2 = new (surf);
 			selection?.Clip (g2);
 
 			g2.FillRectangle (CurrentTextLayout.GetLayoutBounds ().ToDouble (), palette.SecondaryColor);

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -154,7 +154,7 @@ public sealed class ZoomTool : BaseTool
 		document.Layers.ToolLayer.Clear ();
 		document.Layers.ToolLayer.Hidden = false;
 
-		var g = new Context (document.Layers.ToolLayer.Surface);
+		using Context g = new (document.Layers.ToolLayer.Surface);
 		var dirty = g.FillRectangle (r, new Cairo.Color (0.7, 0.8, 0.9, 0.4));
 
 		document.Workspace.Invalidate (last_dirty.ToInt ());

--- a/Pinta/Actions/Edit/PasteAction.cs
+++ b/Pinta/Actions/Edit/PasteAction.cs
@@ -179,7 +179,7 @@ internal sealed class PasteAction : IActionHandler
 								 Math.Max (doc.ImageSize.Height, cb_image.Height));
 		doc.Layers.ShowSelectionLayer = true;
 
-		Cairo.Context g = new (doc.Layers.SelectionLayer.Surface);
+		using Cairo.Context g = new (doc.Layers.SelectionLayer.Surface);
 		g.SetSourceSurface (cb_image, 0, 0);
 		g.Paint ();
 

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -617,6 +617,8 @@ public sealed class NewImageDialog : Gtk.Dialog
 			cr.DrawRectangle (new RectangleD (r.X - 1, r.Y - 1, r.Width + 2, r.Height + 2), new Cairo.Color (.5, .5, .5), 1);
 			cr.DrawRectangle (new RectangleD (r.X - 2, r.Y - 2, r.Width + 4, r.Height + 4), new Cairo.Color (.8, .8, .8), 1);
 			cr.DrawRectangle (new RectangleD (r.X - 3, r.Y - 3, r.Width + 6, r.Height + 6), new Cairo.Color (.9, .9, .9), 1);
+
+			cr.Dispose ();
 		}
 
 		private Size GetPreviewSizeForDraw () // Figure out the dimensions of the preview to draw

--- a/tests/Pinta.Core.Tests/Utilities.cs
+++ b/tests/Pinta.Core.Tests/Utilities.cs
@@ -103,7 +103,7 @@ internal static class Utilities
 		try {
 			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when error is thrown.
 			var surf = CairoExtensions.CreateImageSurface (Format.Argb32, bg.Width, bg.Height);
-			var context = new Cairo.Context (surf);
+			using var context = new Cairo.Context (surf);
 			context.DrawPixbuf (bg, PointD.Zero);
 			return surf;
 		} finally {

--- a/tests/Pinta.Effects.Tests/Utilities.cs
+++ b/tests/Pinta.Effects.Tests/Utilities.cs
@@ -35,7 +35,7 @@ internal static class Utilities
 		try {
 			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when error is thrown.
 			var surf = CairoExtensions.CreateImageSurface (Format.Argb32, bg.Width, bg.Height);
-			Context context = new (surf);
+			using Context context = new (surf);
 			context.DrawPixbuf (bg, 0, 0);
 			return surf;
 		} finally {

--- a/tests/PintaBenchmarks/Utilities/TestData.cs
+++ b/tests/PintaBenchmarks/Utilities/TestData.cs
@@ -19,7 +19,7 @@ internal class TestData
 		try {
 			var bg = GdkPixbuf.Pixbuf.NewFromStream (fs, cancellable: null)!; // NRT: only nullable when error is thrown.
 			var surf = CairoExtensions.CreateImageSurface (Format.Argb32, bg.Width, bg.Height);
-			var context = new Cairo.Context (surf);
+			using var context = new Cairo.Context (surf);
 			context.DrawPixbuf (bg, 0, 0);
 			return surf;
 		} finally {


### PR DESCRIPTION
- Fixed a few warnings from methods that now have nullable return values.
- Dispose Cairo contexts from Gtk.DrawingArea widgets to avoid memory growth
- Dispose all other temporary Cairo contexts.