### PR TITLE
Customizable grid size

### DIFF
--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -72,7 +72,7 @@ public sealed class ViewActions
 		ActualSize = new Command ("ActualSize", Translations.GetString ("Normal Size"), null, Resources.StandardIcons.ZoomOriginal);
 		ToolBar = new ToggleCommand ("Toolbar", Translations.GetString ("Toolbar"), null, null);
 		ImageTabs = new ToggleCommand ("ImageTabs", Translations.GetString ("Image Tabs"), null, null);
-		EditCanvasGrid = new Command ("EditCanvasGrid", Translations.GetString ("Edit Grid"), null, Resources.Icons.ViewGrid);
+		EditCanvasGrid = new Command ("EditCanvasGrid", Translations.GetString ("Canvas Grid..."), null, Resources.Icons.ViewGrid);
 		StatusBar = new ToggleCommand ("Statusbar", Translations.GetString ("Status Bar"), null, null);
 		ToolBox = new ToggleCommand ("ToolBox", Translations.GetString ("Tool Box"), null, null);
 		Rulers = new ToggleCommand ("Rulers", Translations.GetString ("Rulers"), null, Resources.Icons.ViewRulers);

--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -39,7 +39,6 @@ public sealed class ViewActions
 	public Command ActualSize { get; }
 	public ToggleCommand ToolBar { get; }
 	public ToggleCommand ImageTabs { get; }
-	public ToggleCommand EnableCanvasGrid { get; }
 	public Command EditCanvasGrid { get; }
 	public ToggleCommand StatusBar { get; }
 	public ToggleCommand ToolBox { get; }
@@ -73,8 +72,7 @@ public sealed class ViewActions
 		ActualSize = new Command ("ActualSize", Translations.GetString ("Normal Size"), null, Resources.StandardIcons.ZoomOriginal);
 		ToolBar = new ToggleCommand ("Toolbar", Translations.GetString ("Toolbar"), null, null);
 		ImageTabs = new ToggleCommand ("ImageTabs", Translations.GetString ("Image Tabs"), null, null);
-		EnableCanvasGrid = new ToggleCommand ("EnableCanvasGrid", Translations.GetString ("Show Canvas Grid"), null, Resources.Icons.ViewGrid);
-		EditCanvasGrid = new Command ("EditCanvasGrid", Translations.GetString ("Edit Canvas Grid"), null, Resources.StandardIcons.ValueIncrease);
+		EditCanvasGrid = new Command ("EditCanvasGrid", Translations.GetString ("Edit Grid"), null, Resources.Icons.ViewGrid);
 		StatusBar = new ToggleCommand ("Statusbar", Translations.GetString ("Status Bar"), null, null);
 		ToolBox = new ToggleCommand ("ToolBox", Translations.GetString ("Tool Box"), null, null);
 		Rulers = new ToggleCommand ("Rulers", Translations.GetString ("Rulers"), null, Resources.Icons.ViewRulers);
@@ -135,12 +133,8 @@ public sealed class ViewActions
 		zoom_section.AppendItem (ZoomToWindow.CreateMenuItem ());
 		zoom_section.AppendItem (Fullscreen.CreateMenuItem ());
 
-		Gio.Menu grid_menu = Gio.Menu.New ();
-		grid_menu.AppendItem (EnableCanvasGrid.CreateMenuItem ());
-		grid_menu.AppendItem (EditCanvasGrid.CreateMenuItem ());
-
 		Gio.Menu grid_section = Gio.Menu.New ();
-		grid_section.AppendSubmenu (Translations.GetString ("Canvas Grid"), grid_menu);
+		grid_section.AppendItem (EditCanvasGrid.CreateMenuItem ());
 
 		Gio.Menu metric_menu = Gio.Menu.New ();
 		metric_menu.Append (Translations.GetString ("Pixels"), $"app.{RulerMetric.Name}(0)");
@@ -176,7 +170,6 @@ public sealed class ViewActions
 		app.AddAccelAction (ActualSize, new[] { "<Primary>0", "<Primary><Shift>A" });
 		app.AddAccelAction (ZoomToWindow, "<Primary>B");
 		app.AddAccelAction (Fullscreen, "F11");
-		app.AddAction (EnableCanvasGrid);
 		app.AddAction (EditCanvasGrid);
 		app.AddAction (RulerMetric);
 		app.AddAction (Rulers);
@@ -213,10 +206,6 @@ public sealed class ViewActions
 		ZoomComboBox.ComboBox.GetEntry ().AddController (focus_controller);
 
 		ActualSize.Activated += HandlePintaCoreActionsViewActualSizeActivated;
-
-		EnableCanvasGrid.Toggled += (_) => {
-			workspace.Invalidate ();
-		};
 
 		bool isFullscreen = false;
 

--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -39,7 +39,8 @@ public sealed class ViewActions
 	public Command ActualSize { get; }
 	public ToggleCommand ToolBar { get; }
 	public ToggleCommand ImageTabs { get; }
-	public ToggleCommand PixelGrid { get; }
+	public ToggleCommand EnableCanvasGrid { get; }
+	public Command EditCanvasGrid { get; }
 	public ToggleCommand StatusBar { get; }
 	public ToggleCommand ToolBox { get; }
 	public ToggleCommand Rulers { get; }
@@ -72,7 +73,8 @@ public sealed class ViewActions
 		ActualSize = new Command ("ActualSize", Translations.GetString ("Normal Size"), null, Resources.StandardIcons.ZoomOriginal);
 		ToolBar = new ToggleCommand ("Toolbar", Translations.GetString ("Toolbar"), null, null);
 		ImageTabs = new ToggleCommand ("ImageTabs", Translations.GetString ("Image Tabs"), null, null);
-		PixelGrid = new ToggleCommand ("PixelGrid", Translations.GetString ("Pixel Grid"), null, Resources.Icons.ViewGrid);
+		EnableCanvasGrid = new ToggleCommand ("EnableCanvasGrid", Translations.GetString ("Show Canvas Grid"), null, Resources.Icons.ViewGrid);
+		EditCanvasGrid = new Command ("EditCanvasGrid", Translations.GetString ("Edit Canvas Grid"), null, Resources.StandardIcons.ValueIncrease);
 		StatusBar = new ToggleCommand ("Statusbar", Translations.GetString ("Status Bar"), null, null);
 		ToolBox = new ToggleCommand ("ToolBox", Translations.GetString ("Tool Box"), null, null);
 		Rulers = new ToggleCommand ("Rulers", Translations.GetString ("Rulers"), null, Resources.Icons.ViewRulers);
@@ -133,6 +135,13 @@ public sealed class ViewActions
 		zoom_section.AppendItem (ZoomToWindow.CreateMenuItem ());
 		zoom_section.AppendItem (Fullscreen.CreateMenuItem ());
 
+		Gio.Menu grid_menu = Gio.Menu.New ();
+		grid_menu.AppendItem (EnableCanvasGrid.CreateMenuItem ());
+		grid_menu.AppendItem (EditCanvasGrid.CreateMenuItem ());
+
+		Gio.Menu grid_section = Gio.Menu.New ();
+		grid_section.AppendSubmenu (Translations.GetString ("Canvas Grid"), grid_menu);
+
 		Gio.Menu metric_menu = Gio.Menu.New ();
 		metric_menu.Append (Translations.GetString ("Pixels"), $"app.{RulerMetric.Name}(0)");
 		metric_menu.Append (Translations.GetString ("Inches"), $"app.{RulerMetric.Name}(1)");
@@ -142,7 +151,6 @@ public sealed class ViewActions
 		metric_section.AppendSubmenu (Translations.GetString ("Ruler Units"), metric_menu);
 
 		Gio.Menu show_hide_menu = Gio.Menu.New ();
-		show_hide_menu.AppendItem (PixelGrid.CreateMenuItem ());
 		show_hide_menu.AppendItem (Rulers.CreateMenuItem ());
 		show_hide_menu.AppendItem (StatusBar.CreateMenuItem ());
 		show_hide_menu.AppendItem (ToolBox.CreateMenuItem ());
@@ -168,8 +176,9 @@ public sealed class ViewActions
 		app.AddAccelAction (ActualSize, new[] { "<Primary>0", "<Primary><Shift>A" });
 		app.AddAccelAction (ZoomToWindow, "<Primary>B");
 		app.AddAccelAction (Fullscreen, "F11");
+		app.AddAction (EnableCanvasGrid);
+		app.AddAction (EditCanvasGrid);
 		app.AddAction (RulerMetric);
-		app.AddAction (PixelGrid);
 		app.AddAction (Rulers);
 		if (mainToolbarPresent) app.AddAction (ToolBar);
 		app.AddAction (StatusBar);
@@ -177,8 +186,8 @@ public sealed class ViewActions
 		app.AddAction (ImageTabs);
 		app.AddAction (ColorScheme);
 
-
 		menu.AppendSection (null, zoom_section);
+		menu.AppendSection (null, grid_section);
 		menu.AppendSection (null, metric_section);
 		menu.AppendSection (null, show_hide_section);
 		menu.AppendSection (null, color_scheme_section);
@@ -205,7 +214,7 @@ public sealed class ViewActions
 
 		ActualSize.Activated += HandlePintaCoreActionsViewActualSizeActivated;
 
-		PixelGrid.Toggled += (_) => {
+		EnableCanvasGrid.Toggled += (_) => {
 			workspace.Invalidate ();
 		};
 

--- a/Pinta.Core/Managers/CanvasGridManager.cs
+++ b/Pinta.Core/Managers/CanvasGridManager.cs
@@ -5,23 +5,33 @@ namespace Pinta.Core.Managers;
 
 public interface ICanvasGridService
 {
+	bool ShowGrid { get; set; }
 	int CellWidth { get; set; }
 	int CellHeight { get; set; }
 
-	public event EventHandler? SizeChanged;
+	public event EventHandler? SettingsChanged;
 }
 
 
 public sealed class CanvasGridManager : ICanvasGridService
 {
+	private bool show_grid = false;
 	private int cell_width = 1;
 	private int cell_height = 1;
+
+	public bool ShowGrid {
+		get => show_grid;
+		set {
+			show_grid = value;
+			SettingsChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
 
 	public int CellWidth {
 		get => cell_width;
 		set {
 			cell_width = value;
-			SizeChanged?.Invoke(this, EventArgs.Empty);
+			SettingsChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 
@@ -29,17 +39,17 @@ public sealed class CanvasGridManager : ICanvasGridService
 		get => cell_height;
 		set {
 			cell_height = value;
-			SizeChanged?.Invoke(this, EventArgs.Empty);
+			SettingsChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 
 	public CanvasGridManager (WorkspaceManager workspace)
 	{
 		// Invalidate the workspace if the grid is changed to redraw the grid
-		SizeChanged += (_, __) => {
+		SettingsChanged += (_, __) => {
 			workspace.Invalidate();
 		};
 	}
 
-	public event EventHandler? SizeChanged;
+	public event EventHandler? SettingsChanged;
 }

--- a/Pinta.Core/Managers/CanvasGridManager.cs
+++ b/Pinta.Core/Managers/CanvasGridManager.cs
@@ -35,6 +35,10 @@ public sealed class CanvasGridManager : ICanvasGridService
 
 	public CanvasGridManager ()
 	{
+		// Invalidate the workspace if the grid is changed to redraw the grid
+		SizeChanged += (_, __) => {
+			PintaCore.Workspace.Invalidate();
+		};
 	}
 
 	public event EventHandler? SizeChanged;

--- a/Pinta.Core/Managers/CanvasGridManager.cs
+++ b/Pinta.Core/Managers/CanvasGridManager.cs
@@ -33,11 +33,11 @@ public sealed class CanvasGridManager : ICanvasGridService
 		}
 	}
 
-	public CanvasGridManager ()
+	public CanvasGridManager (WorkspaceManager workspace)
 	{
 		// Invalidate the workspace if the grid is changed to redraw the grid
 		SizeChanged += (_, __) => {
-			PintaCore.Workspace.Invalidate();
+			workspace.Invalidate();
 		};
 	}
 

--- a/Pinta.Core/Managers/CanvasGridManager.cs
+++ b/Pinta.Core/Managers/CanvasGridManager.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Pinta.Core.Managers;
+namespace Pinta.Core;
 
 
 public interface ICanvasGridService

--- a/Pinta.Core/Managers/CanvasGridManager.cs
+++ b/Pinta.Core/Managers/CanvasGridManager.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Pinta.Core.Managers;
+
+
+public interface ICanvasGridService
+{
+	int CellWidth { get; set; }
+	int CellHeight { get; set; }
+
+	public event EventHandler? SizeChanged;
+}
+
+
+public sealed class CanvasGridManager : ICanvasGridService
+{
+	private int cell_width = 1;
+	private int cell_height = 1;
+
+	public int CellWidth {
+		get => cell_width;
+		set {
+			cell_width = value;
+			SizeChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	public int CellHeight {
+		get => cell_height;
+		set {
+			cell_height = value;
+			SizeChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	public CanvasGridManager ()
+	{
+	}
+
+	public event EventHandler? SizeChanged;
+}

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -24,8 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Pinta.Core.Managers;
-
 namespace Pinta.Core;
 
 public static class PintaCore

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using Pinta.Core.Managers;
+
 namespace Pinta.Core;
 
 public static class PintaCore
@@ -43,6 +45,7 @@ public static class PintaCore
 	public static SystemManager System { get; }
 	public static ToolManager Tools { get; }
 	public static WorkspaceManager Workspace { get; }
+	public static CanvasGridManager CanvasGrid { get; }
 
 	public const string ApplicationVersion = "2.2";
 
@@ -57,6 +60,7 @@ public static class PintaCore
 		PaintBrushManager paintBrushes = new ();
 		PaletteFormatManager paletteFormats = new ();
 		RecentFileManager recentFiles = new ();
+		CanvasGridManager canvasGrid = new ();
 
 		// --- Services that depend on other services
 
@@ -86,6 +90,7 @@ public static class PintaCore
 		services.AddService<IChromeService> (chrome);
 		services.AddService<ISystemService> (system);
 		services.AddService (effects);
+		services.AddService (canvasGrid);
 
 		// --- References to expose
 
@@ -103,6 +108,7 @@ public static class PintaCore
 		Palette = palette;
 		Chrome = chrome;
 		Effects = effects;
+		CanvasGrid = canvasGrid;
 
 		Services = services;
 	}

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -70,7 +70,7 @@ public static class PintaCore
 		ActionManager actions = new (chrome, imageFormats, paletteFormats, palette, recentFiles, system, tools, workspace);
 		LivePreviewManager livePreview = new (workspace, tools, system, chrome);
 		EffectsManager effects = new (actions, chrome, livePreview);
-		CanvasGridManager canvasGrid = new (workspace);
+		CanvasGridManager canvasGrid = new (workspace, settings);
 
 		// --- Service manager
 

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -60,7 +60,6 @@ public static class PintaCore
 		PaintBrushManager paintBrushes = new ();
 		PaletteFormatManager paletteFormats = new ();
 		RecentFileManager recentFiles = new ();
-		CanvasGridManager canvasGrid = new ();
 
 		// --- Services that depend on other services
 
@@ -71,6 +70,7 @@ public static class PintaCore
 		ActionManager actions = new (chrome, imageFormats, paletteFormats, palette, recentFiles, system, tools, workspace);
 		LivePreviewManager livePreview = new (workspace, tools, system, chrome);
 		EffectsManager effects = new (actions, chrome, livePreview);
+		CanvasGridManager canvasGrid = new (workspace);
 
 		// --- Service manager
 
@@ -90,7 +90,7 @@ public static class PintaCore
 		services.AddService<IChromeService> (chrome);
 		services.AddService<ISystemService> (system);
 		services.AddService (effects);
-		services.AddService (canvasGrid);
+		services.AddService<ICanvasGridService> (canvasGrid);
 
 		// --- References to expose
 

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -103,11 +103,26 @@ public sealed class CanvasRenderer
 			g.Restore ();
 		}
 
-		// If we are at least 200% and grid is requested, draw it
-		if (enable_grid && PintaCore.Actions.View.EnableCanvasGrid.Value && scale_factor.Ratio <= 0.5d)
+		// Draw the grid if it's enabled and we're zoomed in far enough
+		const int minGridLineDistance = 5;
+		if (enable_grid && PintaCore.Actions.View.EnableCanvasGrid.Value && GetMinGridLineDistance () >= minGridLineDistance)
 			RenderPixelGrid (dst, offset);
 
 		dst.MarkDirty ();
+	}
+
+	/// <summary>
+	/// Returns the minimum number of pixels that could be between the rendered grid lines.
+	/// </summary>
+	private int GetMinGridLineDistance ()
+	{
+		int cellHeight = PintaCore.CanvasGrid.CellHeight;
+		int cellWidth = PintaCore.CanvasGrid.CellWidth;
+
+		int minCanvasDistance = Math.Min (cellHeight, cellWidth);
+		double minRenderedDistance = minCanvasDistance / scale_factor.Ratio;
+
+		return (int) minRenderedDistance;
 	}
 
 	// Lazily create and cache these

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -18,7 +18,7 @@ public sealed class CanvasRenderer
 {
 	private static readonly Cairo.Pattern tranparent_pattern;
 
-	private readonly bool enable_pixel_grid;
+	private readonly bool enable_grid;
 	private readonly bool enable_live_preview;
 
 	private Size source_size;
@@ -30,9 +30,9 @@ public sealed class CanvasRenderer
 	private ImmutableArray<int>? s_2_d_lookup_x;
 	private ImmutableArray<int>? s_2_d_lookup_y;
 
-	public CanvasRenderer (bool enable_pixel_grid, bool enableLivePreview)
+	public CanvasRenderer (bool enableGrid, bool enableLivePreview)
 	{
-		this.enable_pixel_grid = enable_pixel_grid;
+		enable_grid = enableGrid;
 		enable_live_preview = enableLivePreview;
 	}
 
@@ -104,7 +104,7 @@ public sealed class CanvasRenderer
 		}
 
 		// If we are at least 200% and grid is requested, draw it
-		if (enable_pixel_grid && PintaCore.Actions.View.PixelGrid.Value && scale_factor.Ratio <= 0.5d)
+		if (enable_grid && PintaCore.Actions.View.EnableCanvasGrid.Value && scale_factor.Ratio <= 0.5d)
 			RenderPixelGrid (dst, offset);
 
 		dst.MarkDirty ();

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -132,7 +132,9 @@ public sealed class CanvasRenderer
 
 		var lookup_y = S2DLookupY;
 
-		for (int srcY = sTop; srcY <= sBottom; ++srcY) {
+		var gridHeight = PintaCore.CanvasGrid.CellHeight;
+
+		for (int srcY = sTop; srcY <= sBottom; srcY += gridHeight) {
 
 			int dstY = lookup_y[srcY];
 			int dstRow = dstY - offset.Y;
@@ -153,7 +155,9 @@ public sealed class CanvasRenderer
 
 		var lookup_x = S2DLookupX;
 
-		for (int srcX = sLeft; srcX <= sRight; ++srcX) {
+		var gridWidth = PintaCore.CanvasGrid.CellWidth;
+
+		for (int srcX = sLeft; srcX <= sRight; srcX += gridWidth) {
 
 			int dstX = lookup_x[srcX];
 			int dstCol = dstX - offset.X;

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasRenderer.cs
@@ -105,7 +105,7 @@ public sealed class CanvasRenderer
 
 		// Draw the grid if it's enabled and we're zoomed in far enough
 		const int minGridLineDistance = 5;
-		if (enable_grid && PintaCore.Actions.View.EnableCanvasGrid.Value && GetMinGridLineDistance () >= minGridLineDistance)
+		if (enable_grid && PintaCore.CanvasGrid.ShowGrid && GetMinGridLineDistance () >= minGridLineDistance)
 			RenderPixelGrid (dst, offset);
 
 		dst.MarkDirty ();

--- a/Pinta.Gui.Widgets/Widgets/Canvas/CanvasWindow.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/CanvasWindow.cs
@@ -53,7 +53,8 @@ public sealed class CanvasWindow : Gtk.Grid
 
 	public CanvasWindow (
 		WorkspaceManager workspace,
-		Document document)
+		Document document,
+		ICanvasGridService canvasGrid)
 	{
 		this.workspace = workspace;
 		this.document = document;
@@ -81,7 +82,7 @@ public sealed class CanvasWindow : Gtk.Grid
 		// The mouse handler in PintaCanvas grabs focus away from toolbar widgets.
 		Focusable = true;
 
-		Canvas = new PintaCanvas (this, document) { Name = "canvas" };
+		Canvas = new PintaCanvas (this, document, canvasGrid) { Name = "canvas" };
 
 		// Rulers
 		horizontal_ruler = new Ruler (Gtk.Orientation.Horizontal) { Metric = MetricType.Pixels };

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -40,12 +40,12 @@ public sealed class PintaCanvas : DrawingArea
 
 	public CanvasWindow CanvasWindow { get; }
 
-	public PintaCanvas (CanvasWindow window, Document document)
+	public PintaCanvas (CanvasWindow window, Document document, ICanvasGridService canvasGrid)
 	{
 		CanvasWindow = window;
 		this.document = document;
 
-		cr = new CanvasRenderer (true, true);
+		cr = new CanvasRenderer (canvasGrid, true);
 
 		// Keep the widget the same size as the canvas
 		document.Workspace.ViewSizeChanged += (_, _) => SetRequisition (document.Workspace.ViewSize);

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
@@ -66,7 +66,7 @@ public sealed class LayersListViewItem : GObject.Object
 			doc.Layers.SelectionLayer,
 		};
 
-		canvas_renderer ??= new CanvasRenderer (false, false);
+		canvas_renderer ??= new CanvasRenderer (null, false);
 		canvas_renderer.Initialize (doc.ImageSize, new Size (widthRequest, heightRequest));
 		canvas_renderer.Render (layers, surface, PointI.Zero);
 

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -27,6 +27,7 @@
 using System.Collections.Generic;
 using Pinta.Actions;
 using Pinta.Core;
+using Pinta.Core.Managers;
 
 namespace Pinta;
 
@@ -45,6 +46,7 @@ public sealed class ActionHandlers
 		SystemManager system = PintaCore.System;
 		ToolManager tools = PintaCore.Tools;
 		PaletteManager palette = PintaCore.Palette;
+		CanvasGridManager canvasGrid = PintaCore.CanvasGrid;
 		string applicationVersion = PintaCore.ApplicationVersion;
 
 		action_handlers = new ()
@@ -83,6 +85,7 @@ public sealed class ActionHandlers
 			new StatusBarToggledAction (actions.View, chrome),
 			new ToolBoxToggledAction (actions.View, chrome),
 			new ColorSchemeChangedAction (actions.View),
+			new EditCanvasGridAction(actions.View, chrome, canvasGrid),
 
 			// Window
 			new CloseAllDocumentsAction (actions, workspace),

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -27,7 +27,6 @@
 using System.Collections.Generic;
 using Pinta.Actions;
 using Pinta.Core;
-using Pinta.Core.Managers;
 
 namespace Pinta;
 

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -30,7 +30,7 @@ internal sealed class EditCanvasGridAction : IActionHandler
 		view.EditCanvasGrid.Activated -= Activated;
 	}
 
-	private void Activated(object sender, EventArgs e)
+	private void Activated (object sender, EventArgs e)
 	{
 		CanvasGridSettingsDialog dialog = new (chrome, canvasGrid);
 

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -35,7 +35,9 @@ internal sealed class EditCanvasGridAction : IActionHandler
 		CanvasGridSettingsDialog dialog = new (chrome, canvasGrid);
 
 		dialog.OnResponse += (_, args) => {
-			if (args.ResponseId != (int) Gtk.ResponseType.Ok) {
+			if (args.ResponseId == (int) Gtk.ResponseType.Ok) {
+				canvasGrid.SaveGridSettings ();
+			} else {
 				dialog.RevertChanges ();
 			}
 

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -16,7 +16,7 @@ internal sealed class EditCanvasGridAction : IActionHandler
 	{
 		this.view = view;
 		this.chrome = chrome;
-		canvas_grid = canvasGrid;
+		this.canvas_grid = canvasGrid;
 	}
 
 	void IActionHandler.Initialize ()

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -1,0 +1,93 @@
+using System;
+using Pinta.Core;
+using Gtk;
+using Pinta.Core.Managers;
+
+namespace Pinta.Actions;
+
+internal sealed class EditCanvasGridAction : IActionHandler
+{
+	private readonly ViewActions view;
+	private readonly ChromeManager chrome;
+	private readonly CanvasGridManager canvasGrid;
+
+	internal EditCanvasGridAction (
+		ViewActions view,
+		ChromeManager chrome,
+		CanvasGridManager canvasGrid)
+	{
+		this.view = view;
+		this.chrome = chrome;
+		this.canvasGrid = canvasGrid;
+	}
+
+	void IActionHandler.Initialize ()
+	{
+		view.EditCanvasGrid.Activated += Activated;
+	}
+
+	void IActionHandler.Uninitialize ()
+	{
+		view.EditCanvasGrid.Activated -= Activated;
+	}
+
+	private void Activated(object sender, EventArgs e)
+	{
+		Dialog dialog = new Dialog
+		{
+			Title = Translations.GetString("Grid Size"),
+			TransientFor = chrome.MainWindow,
+			Modal = true
+		};
+		dialog.AddCancelOkButtons();
+		dialog.SetDefaultResponse(ResponseType.Ok);
+
+		// Create a container box for arranging widgets vertically
+		var vbox = new Box { Spacing = 6 };
+		vbox.SetOrientation(Orientation.Vertical);
+
+		// Add Width SpinButton
+		var widthLabel = Label.New(Translations.GetString("Grid width:"));
+		widthLabel.Xalign = 0;
+		var widthSpinButton = SpinButton.NewWithRange(1, 256, 1);
+		widthSpinButton.Value = canvasGrid.CellWidth;
+
+		var widthBox = new Box { Spacing = 6 };
+		widthBox.SetOrientation(Orientation.Horizontal);
+		widthBox.Append(widthLabel);
+		widthBox.Append(widthSpinButton);
+
+		// Add Height SpinButton
+		var heightLabel = Label.New(Translations.GetString("Grid height:"));
+		heightLabel.Xalign = 0;
+		var heightSpinButton = SpinButton.NewWithRange(1, 256, 1);
+		heightSpinButton.Value = canvasGrid.CellHeight;
+
+		var heightBox = new Box { Spacing = 6 };
+		heightBox.SetOrientation(Orientation.Horizontal);
+		heightBox.Append(heightLabel);
+		heightBox.Append(heightSpinButton);
+
+		// Add both width and height boxes to the main vertical box
+		vbox.Append(widthBox);
+		vbox.Append(heightBox);
+
+		// Add the main vertical box to the dialog content area
+		var contentArea = dialog.GetContentAreaBox();
+		contentArea.SetAllMargins(12);
+		contentArea.Append(vbox);
+
+		dialog.OnResponse += (_, args) =>
+		{
+			if (args.ResponseId == (int)ResponseType.Ok)
+			{
+				canvasGrid.CellWidth = widthSpinButton.GetValueAsInt();
+				canvasGrid.CellHeight = heightSpinButton.GetValueAsInt();
+			}
+			dialog.Destroy();
+		};
+
+		dialog.Present();
+	}
+}
+

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -1,6 +1,5 @@
 using System;
 using Pinta.Core;
-using Pinta.Core.Managers;
 
 namespace Pinta.Actions;
 

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -1,6 +1,5 @@
 using System;
 using Pinta.Core;
-using Gtk;
 using Pinta.Core.Managers;
 
 namespace Pinta.Actions;
@@ -33,61 +32,17 @@ internal sealed class EditCanvasGridAction : IActionHandler
 
 	private void Activated(object sender, EventArgs e)
 	{
-		Dialog dialog = new Dialog
-		{
-			Title = Translations.GetString("Grid Size"),
-			TransientFor = chrome.MainWindow,
-			Modal = true
-		};
-		dialog.AddCancelOkButtons();
-		dialog.SetDefaultResponse(ResponseType.Ok);
+		CanvasGridSettingsDialog dialog = new (chrome, canvasGrid);
 
-		// Create a container box for arranging widgets vertically
-		var vbox = new Box { Spacing = 6 };
-		vbox.SetOrientation(Orientation.Vertical);
-
-		// Add Width SpinButton
-		var widthLabel = Label.New(Translations.GetString("Grid width:"));
-		widthLabel.Xalign = 0;
-		var widthSpinButton = SpinButton.NewWithRange(1, 256, 1);
-		widthSpinButton.Value = canvasGrid.CellWidth;
-
-		var widthBox = new Box { Spacing = 6 };
-		widthBox.SetOrientation(Orientation.Horizontal);
-		widthBox.Append(widthLabel);
-		widthBox.Append(widthSpinButton);
-
-		// Add Height SpinButton
-		var heightLabel = Label.New(Translations.GetString("Grid height:"));
-		heightLabel.Xalign = 0;
-		var heightSpinButton = SpinButton.NewWithRange(1, 256, 1);
-		heightSpinButton.Value = canvasGrid.CellHeight;
-
-		var heightBox = new Box { Spacing = 6 };
-		heightBox.SetOrientation(Orientation.Horizontal);
-		heightBox.Append(heightLabel);
-		heightBox.Append(heightSpinButton);
-
-		// Add both width and height boxes to the main vertical box
-		vbox.Append(widthBox);
-		vbox.Append(heightBox);
-
-		// Add the main vertical box to the dialog content area
-		var contentArea = dialog.GetContentAreaBox();
-		contentArea.SetAllMargins(12);
-		contentArea.Append(vbox);
-
-		dialog.OnResponse += (_, args) =>
-		{
-			if (args.ResponseId == (int)ResponseType.Ok)
-			{
-				canvasGrid.CellWidth = widthSpinButton.GetValueAsInt();
-				canvasGrid.CellHeight = heightSpinButton.GetValueAsInt();
+		dialog.OnResponse += (_, args) => {
+			if (args.ResponseId != (int) Gtk.ResponseType.Ok) {
+				dialog.RevertChanges ();
 			}
-			dialog.Destroy();
+
+			dialog.Destroy ();
 		};
 
-		dialog.Present();
+		dialog.Show ();
 	}
 }
 

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -8,7 +8,7 @@ internal sealed class EditCanvasGridAction : IActionHandler
 {
 	private readonly ViewActions view;
 	private readonly ChromeManager chrome;
-	private readonly CanvasGridManager canvasGrid;
+	private readonly CanvasGridManager canvas_grid;
 
 	internal EditCanvasGridAction (
 		ViewActions view,
@@ -17,7 +17,7 @@ internal sealed class EditCanvasGridAction : IActionHandler
 	{
 		this.view = view;
 		this.chrome = chrome;
-		this.canvasGrid = canvasGrid;
+		canvas_grid = canvasGrid;
 	}
 
 	void IActionHandler.Initialize ()
@@ -32,11 +32,11 @@ internal sealed class EditCanvasGridAction : IActionHandler
 
 	private void Activated (object sender, EventArgs e)
 	{
-		CanvasGridSettingsDialog dialog = new (chrome, canvasGrid);
+		CanvasGridSettingsDialog dialog = new (chrome, canvas_grid);
 
 		dialog.OnResponse += (_, args) => {
 			if (args.ResponseId == (int) Gtk.ResponseType.Ok) {
-				canvasGrid.SaveGridSettings ();
+				canvas_grid.SaveGridSettings ();
 			} else {
 				dialog.RevertChanges ();
 			}

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -1,7 +1,6 @@
 using System;
 using Gtk;
 using Pinta.Core;
-using Pinta.Core.Managers;
 
 namespace Pinta;
 

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -40,11 +40,11 @@ public sealed class CanvasGridSettingsDialog : Dialog
 
 		grid.Attach (show_grid_checkbox, 0, 0, 2, 1);
 
-		grid.Attach (CreateLabel ("Width:", Align.End), 0, 1, 1, 1);
+		grid.Attach (CreateLabel (Translations.GetString("Width:"), Align.End), 0, 1, 1, 1);
 		grid.Attach (grid_width_spinner, 1, 1, 1, 1);
 		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 1, 1, 1);
 
-		grid.Attach (CreateLabel ("Height:", Align.End), 0, 2, 1, 1);
+		grid.Attach (CreateLabel (Translations.GetString("Height:"), Align.End), 0, 2, 1, 1);
 		grid.Attach (grid_height_spinner, 1, 2, 1, 1);
 		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 2, 1, 1);
 
@@ -75,7 +75,7 @@ public sealed class CanvasGridSettingsDialog : Dialog
 
 	private static Label CreateLabel (string text, Align horizontalAlign)
 	{
-		Label result = Label.New (Translations.GetString (text));
+		Label result = Label.New (text);
 		result.Halign = horizontalAlign;
 		return result;
 	}

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -1,0 +1,110 @@
+using System;
+using Gtk;
+using Pinta.Core;
+using Pinta.Core.Managers;
+
+namespace Pinta;
+
+public sealed class CanvasGridSettingsDialog : Dialog
+{
+	private readonly CanvasGridManager canvas_grid;
+
+	private readonly bool initial_show_grid;
+	private readonly int initial_grid_width;
+	private readonly int initial_grid_height;
+
+	private readonly CheckButton show_grid_checkbox;
+	private readonly SpinButton grid_width_spinner;
+	private readonly SpinButton grid_height_spinner;
+
+	private const int Spacing = 6;
+
+	internal CanvasGridSettingsDialog (
+		ChromeManager chrome,
+		CanvasGridManager canvasGrid)
+	{
+		canvas_grid = canvasGrid;
+
+		initial_show_grid = canvas_grid.ShowGrid;
+		initial_grid_width = canvas_grid.CellWidth;
+		initial_grid_height = canvas_grid.CellHeight;
+
+		show_grid_checkbox = CreateShowGridCheckbox (initial_show_grid, SettingsChanged);
+		grid_width_spinner = CreateSpinner (initial_grid_width, SettingsChanged);
+		grid_height_spinner = CreateSpinner (initial_grid_height, SettingsChanged);
+
+		Grid grid = new () {
+			RowSpacing = Spacing,
+			ColumnSpacing = Spacing,
+			ColumnHomogeneous = false,
+		};
+
+		grid.Attach (show_grid_checkbox, 0, 0, 2, 1);
+
+		grid.Attach (CreateLabel ("Width:", Align.End), 0, 1, 1, 1);
+		grid.Attach (grid_width_spinner, 1, 1, 1, 1);
+		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 1, 1, 1);
+
+		grid.Attach (CreateLabel ("Height:", Align.End), 0, 2, 1, 1);
+		grid.Attach (grid_height_spinner, 1, 2, 1, 1);
+		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 2, 1, 1);
+
+		Box mainVbox = new () { Spacing = Spacing };
+		mainVbox.SetOrientation (Orientation.Vertical);
+		mainVbox.Append (grid);
+
+		Title = Translations.GetString ("Grid Settings");
+		TransientFor = chrome.MainWindow;
+		Modal = true;
+		IconName = Resources.Icons.ViewGrid;
+
+		this.AddCancelOkButtons ();
+		this.SetDefaultResponse (ResponseType.Ok);
+
+		Box contentArea = this.GetContentAreaBox ();
+		contentArea.SetAllMargins (12);
+		contentArea.Append (mainVbox);
+	}
+
+	private static CheckButton CreateShowGridCheckbox (bool active, GObject.SignalHandler<CheckButton> onValueChanged)
+	{
+		CheckButton result = CheckButton.NewWithLabel (Translations.GetString ("Show Grid"));
+		result.Active = active;
+		result.OnToggled += onValueChanged;
+		return result;
+	}
+
+	private static Label CreateLabel (string text, Align horizontalAlign)
+	{
+		Label result = Label.New (Translations.GetString (text));
+		result.Halign = horizontalAlign;
+		return result;
+	}
+
+	private static SpinButton CreateSpinner (int startValue, GObject.SignalHandler<SpinButton> onValueChanged)
+	{
+		SpinButton result = SpinButton.NewWithRange (1, int.MaxValue, 1);
+		result.Value = startValue;
+		result.OnValueChanged += onValueChanged;
+		result.SetActivatesDefaultImmediate (true);
+		return result;
+	}
+
+	private void SettingsChanged (object? sender, EventArgs e)
+	{
+		canvas_grid.ShowGrid = show_grid_checkbox.Active;
+		canvas_grid.CellWidth = grid_width_spinner.GetValueAsInt ();;
+		canvas_grid.CellHeight = grid_height_spinner.GetValueAsInt ();
+	}
+
+	/// <summary>
+	/// Reverts the changes that the dialog made to the canvas grid.
+	/// </summary>
+	public void RevertChanges ()
+	{
+		canvas_grid.ShowGrid = initial_show_grid;
+		canvas_grid.CellWidth = initial_grid_width;
+		canvas_grid.CellHeight = initial_grid_height;
+	}
+}
+

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -40,11 +40,11 @@ public sealed class CanvasGridSettingsDialog : Dialog
 
 		grid.Attach (show_grid_checkbox, 0, 0, 2, 1);
 
-		grid.Attach (CreateLabel (Translations.GetString("Width:"), Align.End), 0, 1, 1, 1);
+		grid.Attach (CreateLabel (Translations.GetString ("Width:"), Align.End), 0, 1, 1, 1);
 		grid.Attach (grid_width_spinner, 1, 1, 1, 1);
 		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 1, 1, 1);
 
-		grid.Attach (CreateLabel (Translations.GetString("Height:"), Align.End), 0, 2, 1, 1);
+		grid.Attach (CreateLabel (Translations.GetString ("Height:"), Align.End), 0, 2, 1, 1);
 		grid.Attach (grid_height_spinner, 1, 2, 1, 1);
 		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 2, 1, 1);
 

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -53,7 +53,7 @@ public sealed class CanvasGridSettingsDialog : Dialog
 		mainVbox.SetOrientation (Orientation.Vertical);
 		mainVbox.Append (grid);
 
-		Title = Translations.GetString ("Grid Settings");
+		Title = Translations.GetString ("Canvas Grid Settings");
 		TransientFor = chrome.MainWindow;
 		Modal = true;
 		IconName = Resources.Icons.ViewGrid;

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -93,7 +93,7 @@ public sealed class CanvasGridSettingsDialog : Dialog
 	private void SettingsChanged (object? sender, EventArgs e)
 	{
 		canvas_grid.ShowGrid = show_grid_checkbox.Active;
-		canvas_grid.CellWidth = grid_width_spinner.GetValueAsInt ();;
+		canvas_grid.CellWidth = grid_width_spinner.GetValueAsInt ();
 		canvas_grid.CellHeight = grid_height_spinner.GetValueAsInt ();
 	}
 

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -496,7 +496,6 @@ internal sealed class MainWindow
 		PintaCore.Actions.View.StatusBar.Value = PintaCore.Settings.GetSetting ("statusbar-shown", true);
 		PintaCore.Actions.View.ToolBox.Value = PintaCore.Settings.GetSetting ("toolbox-shown", true);
 		PintaCore.Actions.View.ImageTabs.Value = PintaCore.Settings.GetSetting ("image-tabs-shown", true);
-		PintaCore.Actions.View.EnableCanvasGrid.Value = PintaCore.Settings.GetSetting ("pixel-grid-shown", false);
 
 		string dialog_uri = PintaCore.Settings.GetSetting (LastDialogDirSettingKey, PintaCore.RecentFiles.DefaultDialogDirectory?.GetUri () ?? "");
 		PintaCore.RecentFiles.LastDialogDirectory = Gio.FileHelper.NewForUri (dialog_uri);
@@ -526,7 +525,6 @@ internal sealed class MainWindow
 		PintaCore.Settings.PutSetting ("toolbar-shown", PintaCore.Actions.View.ToolBar.Value);
 		PintaCore.Settings.PutSetting ("statusbar-shown", PintaCore.Actions.View.StatusBar.Value);
 		PintaCore.Settings.PutSetting ("toolbox-shown", PintaCore.Actions.View.ToolBox.Value);
-		PintaCore.Settings.PutSetting ("pixel-grid-shown", PintaCore.Actions.View.EnableCanvasGrid.Value);
 		PintaCore.Settings.PutSetting (LastDialogDirSettingKey, PintaCore.RecentFiles.LastDialogDirectory?.GetUri () ?? "");
 
 		if (PintaCore.Tools.CurrentTool is BaseTool tool)

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -496,7 +496,7 @@ internal sealed class MainWindow
 		PintaCore.Actions.View.StatusBar.Value = PintaCore.Settings.GetSetting ("statusbar-shown", true);
 		PintaCore.Actions.View.ToolBox.Value = PintaCore.Settings.GetSetting ("toolbox-shown", true);
 		PintaCore.Actions.View.ImageTabs.Value = PintaCore.Settings.GetSetting ("image-tabs-shown", true);
-		PintaCore.Actions.View.PixelGrid.Value = PintaCore.Settings.GetSetting ("pixel-grid-shown", false);
+		PintaCore.Actions.View.EnableCanvasGrid.Value = PintaCore.Settings.GetSetting ("pixel-grid-shown", false);
 
 		string dialog_uri = PintaCore.Settings.GetSetting (LastDialogDirSettingKey, PintaCore.RecentFiles.DefaultDialogDirectory?.GetUri () ?? "");
 		PintaCore.RecentFiles.LastDialogDirectory = Gio.FileHelper.NewForUri (dialog_uri);
@@ -526,7 +526,7 @@ internal sealed class MainWindow
 		PintaCore.Settings.PutSetting ("toolbar-shown", PintaCore.Actions.View.ToolBar.Value);
 		PintaCore.Settings.PutSetting ("statusbar-shown", PintaCore.Actions.View.StatusBar.Value);
 		PintaCore.Settings.PutSetting ("toolbox-shown", PintaCore.Actions.View.ToolBox.Value);
-		PintaCore.Settings.PutSetting ("pixel-grid-shown", PintaCore.Actions.View.PixelGrid.Value);
+		PintaCore.Settings.PutSetting ("pixel-grid-shown", PintaCore.Actions.View.EnableCanvasGrid.Value);
 		PintaCore.Settings.PutSetting (LastDialogDirSettingKey, PintaCore.RecentFiles.LastDialogDirectory?.GetUri () ?? "");
 
 		if (PintaCore.Tools.CurrentTool is BaseTool tool)

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -161,7 +161,7 @@ internal sealed class MainWindow
 		var notebook = canvas_pad.Notebook;
 		int selected_index = notebook.ActiveItemIndex;
 
-		CanvasWindow canvas = new (PintaCore.Workspace, doc) {
+		CanvasWindow canvas = new (PintaCore.Workspace, doc, PintaCore.CanvasGrid) {
 			RulersVisible = PintaCore.Actions.View.Rulers.Value,
 			RulerMetric = GetCurrentRulerMetric ()
 		};

--- a/tests/PintaBenchmarks/CanvasRendererBenchmarks.cs
+++ b/tests/PintaBenchmarks/CanvasRendererBenchmarks.cs
@@ -43,7 +43,7 @@ public class CanvasRendererBenchmarks
 	[Benchmark]
 	public void RenderOneToOne ()
 	{
-		var renderer = new CanvasRenderer (false, false);
+		var renderer = new CanvasRenderer (null, false);
 
 		renderer.Initialize (src_size, src_size);
 		renderer.Render (layers, dest_surface, PointI.Zero);
@@ -52,7 +52,7 @@ public class CanvasRendererBenchmarks
 	[Benchmark]
 	public void RenderManyOneToOne ()
 	{
-		var renderer = new CanvasRenderer (false, false);
+		var renderer = new CanvasRenderer (null, false);
 
 		renderer.Initialize (src_size, src_size);
 		renderer.Render (ten_laters, dest_surface, PointI.Zero);
@@ -61,7 +61,7 @@ public class CanvasRendererBenchmarks
 	[Benchmark]
 	public void RenderZoomIn ()
 	{
-		var renderer = new CanvasRenderer (false, false);
+		var renderer = new CanvasRenderer (null, false);
 
 		renderer.Initialize (src_size, dest_size_zoom_in);
 		renderer.Render (layers, dest_surface_zoom_in, PointI.Zero);
@@ -70,7 +70,7 @@ public class CanvasRendererBenchmarks
 	[Benchmark]
 	public void RenderManyZoomIn ()
 	{
-		var renderer = new CanvasRenderer (false, false);
+		var renderer = new CanvasRenderer (null, false);
 
 		renderer.Initialize (src_size, dest_size_zoom_in);
 		renderer.Render (ten_laters, dest_surface_zoom_in, PointI.Zero);
@@ -79,7 +79,7 @@ public class CanvasRendererBenchmarks
 	[Benchmark]
 	public void RenderZoomOut ()
 	{
-		var renderer = new CanvasRenderer (false, false);
+		var renderer = new CanvasRenderer (null, false);
 
 		renderer.Initialize (src_size, dest_size_zoom_out);
 		renderer.Render (layers, dest_surface_zoom_out, PointI.Zero);
@@ -88,7 +88,7 @@ public class CanvasRendererBenchmarks
 	[Benchmark]
 	public void RenderManyZoomOut ()
 	{
-		var renderer = new CanvasRenderer (false, false);
+		var renderer = new CanvasRenderer (null, false);
 
 		renderer.Initialize (src_size, dest_size_zoom_out);
 		renderer.Render (ten_laters, dest_surface_zoom_out, PointI.Zero);


### PR DESCRIPTION
This extends the current pixel grid to be more customizable by allowing the user to specify the grid size as described in #1028. The original functionality of the pixel grid is still available be setting the grid width and height to 1px.

https://github.com/user-attachments/assets/ccd5470e-9f90-473a-b528-ba03c5c5b4ad

