### PR TITLE
Added extra pre-defined gradient

### DIFF
--- a/Pinta.Effects/Effects/GradientHelper.cs
+++ b/Pinta.Effects/Effects/GradientHelper.cs
@@ -48,7 +48,7 @@ public enum PresetGradients
 	[Caption ("Lime Lemon")]
 	LimeLemon,
 
-	// Translators: Gradient with bright, high-energy, and otherworldly tones of purple and yellow, along with a dark red that gives off the appearance of burning
+	// Translators: Gradient with bright, high-energy, and otherworldly tones of blue, purple, and yellow, along with a dark red that gives off the appearance of burning
 	[Caption ("Martian Lava")]
 	MartianLava,
 

--- a/Pinta.Effects/Effects/GradientHelper.cs
+++ b/Pinta.Effects/Effects/GradientHelper.cs
@@ -48,6 +48,10 @@ public enum PresetGradients
 	[Caption ("Lime Lemon")]
 	LimeLemon,
 
+	// Translators: Gradient with bright, high-energy, and otherworldly tones of purple and yellow, along with a dark red that gives off the appearance of burning
+	[Caption ("Martian Lava")]
+	MartianLava,
+
 	// Translators: Gradient with different shades of brownish yellow
 	[Caption ("Piña Colada")]
 	PinaColada,
@@ -179,6 +183,18 @@ internal static class GradientHelper
 					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.25)] = ColorBgra.FromBgr (0, 128, 0),
 					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.50)] = ColorBgra.FromBgr (0, 255, 0),
 					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.75)] = ColorBgra.FromBgr (0, 255, 255),
+				}),
+
+			PresetGradients.MartianLava => ColorGradient.Create (
+				ColorBgra.FromBgr (26, 12, 70),
+				ColorBgra.FromBgr (93, 117, 228),
+				DefaultStartPosition,
+				DefaultEndPosition,
+				new Dictionary<double, ColorBgra> {
+					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.2)] = ColorBgra.FromBgr (103, 101, 213),
+					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.4)] = ColorBgra.FromBgr (25, 219, 200),
+					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.6)] = ColorBgra.FromBgr (124, 52, 59),
+					[Mathematics.Lerp (DefaultStartPosition, DefaultEndPosition, 0.8)] = ColorBgra.FromBgr (248, 133, 0),
 				}),
 
 			PresetGradients.PinaColada => ColorGradient.Create (


### PR DESCRIPTION
Specifically, this is the gradient that is generated when the helper method (`GradientHelper.CreateBaseGradientForEffect`) gets passed a random seed with a value of 0. Users might miss it if the implementation changes at some point.

![image](https://github.com/user-attachments/assets/ab55d8d2-c0e2-4b3c-801f-31d12be275c5)
