### PR TITLE
Modernized dialog for opening palette in `EditActions`

### DIFF
--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
@@ -31,6 +31,23 @@ namespace Pinta.Core;
 
 partial class GtkExtensions
 {
+	public static async Task<Gio.File?> OpenFileAsync (
+		this Gtk.FileDialog fileDialog,
+		Gtk.Window parent)
+	{
+		Gio.File? choice;
+		try {
+			choice = await fileDialog.OpenAsync (parent);
+		} catch (GLib.GException) {
+			// Docs: https://docs.gtk.org/gtk4/method.FileDialog.open_finish.html
+			// According to the documentation, an error is set if the user cancels
+			// TODO: filter by error code once gir.core allows for that
+			return null;
+		}
+
+		return choice;
+	}
+
 	public static async Task<IReadOnlyList<Gio.File>?> OpenFilesAsync (
 		this Gtk.FileDialog fileDialog,
 		Gtk.Window parent)


### PR DESCRIPTION
It is relatively straightforward.

On the other hand, migrating the part where the user saves the palette (and, more specifically, the renaming part) is a bit trickier. As far as I know, there is currently no way to know which filter the user chose. Maybe we could skip the renaming part?