### PR TITLE
Add keyboard shortcut for changing the brush size or line width

### DIFF
--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -277,6 +277,7 @@ public abstract class BaseEditEngine
 		if (brush_width == null) {
 
 			brush_width = GtkExtensions.CreateToolBarSpinButton (1, 1e5, 1, settings.GetSetting (BRUSH_WIDTH_SETTING (toolPrefix), BaseTool.DEFAULT_BRUSH_WIDTH));
+			brush_width.TooltipText = Translations.GetString ("Change brush width. Shortcut keys: [ ]");
 
 			brush_width.OnValueChanged += (o, e) => {
 

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -489,6 +489,13 @@ public abstract class BaseEditEngine
 			case Gdk.Key.Right:
 				HandleRight (e);
 				return true;
+			case Gdk.Key.bracketleft:
+				if (BrushWidth > 1)
+					BrushWidth--;
+				return true;
+			case Gdk.Key.bracketright:
+				BrushWidth++;
+				return true;
 			default:
 				if (keyPressed.IsControlKey ()) {
 					// Redraw since the Ctrl key affects the hover cursor, etc

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -181,8 +181,7 @@ public abstract class BaseEditEngine
 
 	protected virtual void BrushMinusButtonClickedEvent (object? o, EventArgs args)
 	{
-		if (BrushWidth > 1)
-			BrushWidth--;
+		BrushWidth--;
 
 		//No need to store previous settings or redraw, as this is done in the Changed event handler.
 	}
@@ -490,8 +489,7 @@ public abstract class BaseEditEngine
 				HandleRight (e);
 				return true;
 			case Gdk.Key.bracketleft:
-				if (BrushWidth > 1)
-					BrushWidth--;
+				BrushWidth--;
 				return true;
 			case Gdk.Key.bracketright:
 				BrushWidth++;

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -45,6 +45,8 @@ public abstract class BaseBrushTool : BaseTool
 	protected BaseBrushTool (IServiceProvider services) : base (services)
 	{
 		Palette = services.GetService<IPaletteService> ();
+
+		BrushWidthSpinButton.TooltipText = Translations.GetString ("Change brush width. Shortcut keys: [ ]");
 	}
 
 	protected override bool ShowAntialiasingButton => true;

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -50,7 +50,7 @@ public abstract class BaseBrushTool : BaseTool
 	protected override bool ShowAntialiasingButton => true;
 
 	protected int BrushWidth {
-		get => brush_width?.GetValueAsInt() ?? DEFAULT_BRUSH_WIDTH;
+		get => brush_width?.GetValueAsInt () ?? DEFAULT_BRUSH_WIDTH;
 		set {
 			if (brush_width is not null)
 				brush_width.Value = value;
@@ -95,11 +95,9 @@ public abstract class BaseBrushTool : BaseTool
 	protected override bool OnKeyDown (Document document, ToolKeyEventArgs e)
 	{
 		Gdk.Key keyPressed = e.Key;
-		switch (keyPressed)
-		{
+		switch (keyPressed) {
 			case Gdk.Key.bracketleft:
-				if (BrushWidth > 1)
-					BrushWidth--;
+				BrushWidth--;
 				return true;
 			case Gdk.Key.bracketright:
 				BrushWidth++;

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -49,7 +49,13 @@ public abstract class BaseBrushTool : BaseTool
 
 	protected override bool ShowAntialiasingButton => true;
 
-	protected int BrushWidth => brush_width?.GetValueAsInt () ?? DEFAULT_BRUSH_WIDTH;
+	protected int BrushWidth {
+		get => brush_width?.GetValueAsInt() ?? DEFAULT_BRUSH_WIDTH;
+		set {
+			if (brush_width is not null)
+				brush_width.Value = value;
+		}
+	}
 
 	protected override void OnBuildToolBar (Box tb)
 	{
@@ -84,6 +90,23 @@ public abstract class BaseBrushTool : BaseTool
 		surface_modified = false;
 		undo_surface = null;
 		mouse_button = MouseButton.None;
+	}
+
+	protected override bool OnKeyDown (Document document, ToolKeyEventArgs e)
+	{
+		Gdk.Key keyPressed = e.Key;
+		switch (keyPressed)
+		{
+			case Gdk.Key.bracketleft:
+				if (BrushWidth > 1)
+					BrushWidth--;
+				return true;
+			case Gdk.Key.bracketright:
+				BrushWidth++;
+				return true;
+		}
+
+		return base.OnKeyDown (document, e);
 	}
 
 	protected override void OnSaveSettings (ISettingsService settings)


### PR DESCRIPTION
Implements issue #796. The square brackets ] and [ increase and decrease the brush size respectively. Applies to all tools that implement BaseBrushTool and ShapeTool.

I'm wondering if it's possible to add a tooltip to the + and - buttons on the brush size widget? As of right now there's no indication that the shortcuts exist.