### PR TITLE
Bundled data values and reduced variable re-assignment in `PerlinNoise` and effects that use it

### DIFF
--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -54,9 +54,15 @@ public sealed class CloudsEffect : BaseEffect
 	public override Task<bool> LaunchConfiguration ()
 		=> chrome.LaunchSimpleEffectDialog (this);
 
-	#region Algorithm Code Ported From PDN
+	// Algorithm Code Ported From PDN
 
-	private static void RenderClouds (ImageSurface surface, RectangleI rect, int scale, byte seed, double power, ColorGradient gradient)
+	private static void RenderClouds (
+		ImageSurface surface,
+		RectangleI rect,
+		int scale,
+		byte seed,
+		double power,
+		ColorGradient gradient)
 	{
 		int w = surface.Width;
 		int h = surface.Height;
@@ -72,7 +78,14 @@ public sealed class CloudsEffect : BaseEffect
 		}
 	}
 
-	private static ColorBgra GetFinalPixelColor (int scale, byte seed, double power, ColorGradient gradient, int w, int dy, int x)
+	private static ColorBgra GetFinalPixelColor (
+		int scale,
+		byte seed,
+		double power,
+		ColorGradient gradient,
+		int w,
+		int dy,
+		int x)
 	{
 		int dx = 2 * x - w;
 		double val = 0;
@@ -81,20 +94,22 @@ public sealed class CloudsEffect : BaseEffect
 
 		for (int i = 0; i < 12 && mult > 0.03 && div > 0; ++i) {
 
-			double dxr = 65536 + dx / (double) div;
-			double dyr = 65536 + dy / (double) div;
+			PointD dr = new (
+				X: 65536 + dx / (double) div,
+				Y: 65536 + dy / (double) div);
 
-			int dxd = (int) dxr;
-			int dyd = (int) dyr;
+			PointI dd = new (
+				X: (int) dr.X,
+				Y: (int) dr.Y);
 
-			dxr -= dxd;
-			dyr -= dyd;
+			dr = new (
+				X: dr.X - dd.X,
+				Y: dr.Y - dd.Y);
 
 			double noise = PerlinNoise.Compute (
-				unchecked((byte) dxd),
-				unchecked((byte) dyd),
-				dxr, //(double)dxr / div,
-				dyr, //(double)dyr / div,
+				unchecked((byte) dd.X),
+				unchecked((byte) dd.Y),
+				dr, //(double)dxr / div, (double)dyr / div
 				(byte) (seed ^ i)
 			);
 
@@ -149,7 +164,6 @@ public sealed class CloudsEffect : BaseEffect
 			g.BlendSurface (temp, r.Location (), (BlendMode) CloudsData.BlendOps[Data.BlendMode]);
 		}
 	}
-	#endregion
 
 	public sealed class CloudsData : EffectData
 	{

--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -72,7 +72,7 @@ public sealed class DentsEffect : BaseEffect
 		EffectData = new DentsData ();
 	}
 
-	public override void Render (ImageSurface src, ImageSurface dst, ReadOnlySpan<RectangleI> rois)
+	protected override void Render (ImageSurface src, ImageSurface dst, RectangleI roi)
 	{
 		Warp.Settings settings = Warp.CreateSettings (
 			Data,
@@ -81,14 +81,13 @@ public sealed class DentsEffect : BaseEffect
 
 		Span<ColorBgra> dst_data = dst.GetPixelData ();
 		ReadOnlySpan<ColorBgra> src_data = src.GetReadOnlyPixelData ();
-		foreach (RectangleI rect in rois)
-			foreach (var pixel in Tiling.GeneratePixelOffsets (rect, src.GetSize ()))
-				dst_data[pixel.memoryOffset] = Warp.GetPixelColor (
-					settings,
-					InverseTransform,
-					src,
-					src_data[pixel.memoryOffset],
-					pixel);
+		foreach (var pixel in Tiling.GeneratePixelOffsets (roi, src.GetSize ()))
+			dst_data[pixel.memoryOffset] = Warp.GetPixelColor (
+				settings,
+				InverseTransform,
+				src,
+				src_data[pixel.memoryOffset],
+				pixel);
 	}
 
 	// Algorithm code ported from PDN

--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -100,6 +100,7 @@ public sealed class DentsEffect : BaseEffect
 
 		double detail1 = dentsData.Roughness;
 		double detail2 = detail1;
+		double detail3 = 1.0 + (detail2 / 10.0);
 		double roughness = detail2;
 
 		double turbulence = dentsData.Tension;
@@ -110,8 +111,6 @@ public sealed class DentsEffect : BaseEffect
 		double refractionScale = dentsData.Refraction / 100.0 / scaleR;
 		double theta = RadiansAngle.MAX_RADIANS * turbulence / 10.0;
 		double effectiveRoughness = roughness / 100.0;
-
-		double detail3 = 1.0 + (detail2 / 10.0);
 
 		// We don't want the perlin noise frequency components exceeding the nyquist limit, so we will limit 'detail' appropriately
 		double maxDetail = Math.Floor (Math.Log (scaleR) / Math.Log (0.5));

--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -108,7 +108,7 @@ public sealed class DentsEffect : BaseEffect
 
 		double scaleR = 400.0 / settings.defaultRadius / dentsData.Scale;
 		double refractionScale = dentsData.Refraction / 100.0 / scaleR;
-		RadiansAngle theta = new (RadiansAngle.MAX_RADIANS * turbulence / 10.0);
+		double theta = RadiansAngle.MAX_RADIANS * turbulence / 10.0;
 		double effectiveRoughness = roughness / 100.0;
 
 		double detail3 = 1.0 + (detail2 / 10.0);
@@ -124,7 +124,7 @@ public sealed class DentsEffect : BaseEffect
 
 		PointD i = p.Scaled (scaleR);
 
-		RadiansAngle bumpAngle = new (theta.Radians * PerlinNoise.Compute (i, effectiveDetail, effectiveRoughness, seed));
+		RadiansAngle bumpAngle = new (theta * PerlinNoise.Compute (i, effectiveDetail, effectiveRoughness, seed));
 
 		return new (
 			X: p.X + (refractionScale * Math.Sin (-bumpAngle.Radians)),


### PR DESCRIPTION
The failure of the Mac x64 build seems unrelated