### PR TITLE
Terse collection initialization syntax in `Pinta.Effects`

### DIFF
--- a/Pinta.Effects/Adjustments/CurvesEffect.cs
+++ b/Pinta.Effects/Adjustments/CurvesEffect.cs
@@ -75,14 +75,14 @@ public sealed class CurvesEffect : BaseEffect
 		switch (Data.Mode) {
 			case ColorTransferMode.Rgb:
 				UnaryPixelOps.ChannelCurve cc = new UnaryPixelOps.ChannelCurve ();
-				transferCurves = new byte[][] { cc.CurveR, cc.CurveG, cc.CurveB };
+				transferCurves = [cc.CurveR, cc.CurveG, cc.CurveB];
 				entries = 256;
 				op = cc;
 				break;
 
 			case ColorTransferMode.Luminosity:
 				UnaryPixelOps.LuminosityCurve lc = new UnaryPixelOps.LuminosityCurve ();
-				transferCurves = new byte[][] { lc.Curve };
+				transferCurves = [lc.Curve];
 				entries = 256;
 				op = lc;
 				break;

--- a/Pinta.Effects/Adjustments/SepiaEffect.cs
+++ b/Pinta.Effects/Adjustments/SepiaEffect.cs
@@ -32,7 +32,7 @@ public sealed class SepiaEffect : BaseEffect
 		level = new UnaryPixelOps.Level (
 			ColorBgra.Black,
 			ColorBgra.White,
-			new[] { 1.2f, 1.0f, 0.8f },
+			[1.2f, 1.0f, 0.8f],
 			ColorBgra.Black,
 			ColorBgra.White);
 	}

--- a/Pinta.Effects/Algorithms/PerlinNoise.cs
+++ b/Pinta.Effects/Algorithms/PerlinNoise.cs
@@ -27,7 +27,7 @@ internal static class PerlinNoise
 	static PerlinNoise ()
 	{
 #pragma warning disable format
-		ReadOnlySpan<byte> permutationTable = stackalloc byte[] {
+		ReadOnlySpan<byte> permutationTable = [
 			151, 160, 137,  91,  90,  15, 131,  13, 201,  95,  96,  53, 194, 233,   7,
 			225, 140,  36, 103,  30,  69, 142,   8,  99,  37, 240,  21,  10,  23, 190,   6,
 			148, 247, 120, 234,  75,   0,  26, 197,  62,  94, 252, 219, 203, 117,  35,
@@ -46,7 +46,7 @@ internal static class PerlinNoise
 			199, 106, 157, 184,  84, 204, 176, 115, 121,  50,  45, 127,   4, 150,
 			254, 138, 236, 205,  93, 222, 114,  67,  29,  24,  72, 243, 141, 128,
 			195,  78,  66, 215,  61, 156, 180,
-		};
+		];
 #pragma warning restore format
 		var permutationsBuilder = ImmutableArray.CreateBuilder<int> (512);
 		permutationsBuilder.Count = 512;

--- a/Pinta.Effects/Classes/ColorGradient.cs
+++ b/Pinta.Effects/Classes/ColorGradient.cs
@@ -179,7 +179,7 @@ internal sealed class ColorGradient
 	}
 
 	private static IEnumerable<KeyValuePair<double, ColorBgra>> EmptyStops ()
-		=> Enumerable.Empty<KeyValuePair<double, ColorBgra>> ();
+		=> [];
 
 	/// <summary>
 	/// Creates gradient mapping based on start and end color,

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -576,7 +576,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 
 			g.Stroke ();
 
-			g.SetDash (Array.Empty<double> (), 0);
+			g.SetDash ([], 0);
 		}
 
 		void DrawControlPoints (Context g)

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -559,7 +559,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 
 		static void DrawGrid (Context g)
 		{
-			g.SetDash (new double[] { 4, 4 }, 2);
+			g.SetDash ([4, 4], 2);
 			g.LineWidth = 1;
 
 			for (int i = 1; i < 4; i++) {

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -53,7 +53,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 	private int? last_cpx;
 	private PointI last_mouse_pos = new (0, 0);
 	// Keys of existing control points which cannot be overwritten by a new control point.
-	private readonly HashSet<int> orig_cps = new ();
+	private readonly HashSet<int> orig_cps = [];
 
 	//control points for luminosity transfer mode
 	private SortedList<int, int>[] luminosity_cps = null!; // NRT - Set via code flow

--- a/Pinta.Effects/Effects/FeatherEffect.cs
+++ b/Pinta.Effects/Effects/FeatherEffect.cs
@@ -68,7 +68,7 @@ public sealed class FeatherEffect : BaseEffect
 				for (int x = roi.Left; x <= roi.Right; x++)
 					dst_row[x] = src_row[x];
 
-				Span<PointI> pixels = stackalloc PointI[] { PointI.Zero, PointI.Zero, PointI.Zero, PointI.Zero };
+				Span<PointI> pixels = [PointI.Zero, PointI.Zero, PointI.Zero, PointI.Zero];
 
 				// Collect a list of pixels that surround the object (border pixels)
 				for (int x = roi.Left; x <= roi.Right; x++) {

--- a/Pinta.Effects/Effects/FeatherEffect.cs
+++ b/Pinta.Effects/Effects/FeatherEffect.cs
@@ -47,7 +47,7 @@ public sealed class FeatherEffect : BaseEffect
 		int threads = system.RenderThreads;
 		int tolerance = Data.Tolerance;
 
-		ConcurrentBag<PointI> borderPixels = new ();
+		ConcurrentBag<PointI> borderPixels = [];
 		// Color in any pixel that the stencil says we need to fill
 		// First pass
 		// Clean up dest, then collect all border pixels

--- a/Pinta.Effects/Effects/InkSketchEffect.cs
+++ b/Pinta.Effects/Effects/InkSketchEffect.cs
@@ -52,13 +52,13 @@ public sealed class InkSketchEffect : BaseEffect
 
 	static InkSketchEffect ()
 	{
-		conv = ImmutableArray.Create (
-			ImmutableArray.Create (-1, -1, -1, -1, -1),
-			ImmutableArray.Create (-1, -1, -1, -1, -1),
-			ImmutableArray.Create (-1, -1, 30, -1, -1),
-			ImmutableArray.Create (-1, -1, -1, -1, -1),
-			ImmutableArray.Create (-1, -1, -5, -1, -1)
-		);
+		conv = [
+			[-1, -1, -1, -1, -1],
+			[-1, -1, -1, -1, -1],
+			[-1, -1, 30, -1, -1],
+			[-1, -1, -1, -1, -1],
+			[-1, -1, -5, -1, -1],
+		];
 	}
 
 	public override Task<bool> LaunchConfiguration ()

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -115,7 +115,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 			dst_data[pixel.memoryOffset] = GetPixelColor (settings, pixel.coordinates);
 
 		if (settings.invertColors)
-			invert_effect.Render (dst, dst, stackalloc[] { roi });
+			invert_effect.Render (dst, dst, [roi]);
 	}
 
 	private static ColorBgra GetPixelColor (MandelbrotSettings settings, PointI target)

--- a/Pinta.Effects/Effects/OutlineObjectEffect.cs
+++ b/Pinta.Effects/Effects/OutlineObjectEffect.cs
@@ -49,7 +49,7 @@ public sealed class OutlineObjectEffect : BaseEffect
 		ColorBgra primaryColor = palette.PrimaryColor.ToColorBgra ();
 		ColorBgra secondaryColor = palette.SecondaryColor.ToColorBgra ();
 
-		ConcurrentBag<PointI> borderPixels = new ();
+		ConcurrentBag<PointI> borderPixels = [];
 
 		// First pass
 		// Clean up dest, then collect all border pixels

--- a/Pinta.Effects/Effects/VoronoiDiagramEffect.cs
+++ b/Pinta.Effects/Effects/VoronoiDiagramEffect.cs
@@ -208,7 +208,7 @@ public sealed class VoronoiDiagramEffect : BaseEffect
 	private static IEnumerable<ColorBgra> CreateColors (int colorCount, RandomSeed colorsSeed)
 	{
 		Random randomColorizer = new (colorsSeed.Value);
-		HashSet<ColorBgra> uniquenessTracker = new ();
+		HashSet<ColorBgra> uniquenessTracker = [];
 		while (uniquenessTracker.Count < colorCount) {
 			ColorBgra candidateColor = randomColorizer.RandomColorBgra ();
 			if (uniquenessTracker.Contains (candidateColor)) continue;

--- a/Pinta.Effects/Utilities/PaletteHelper.cs
+++ b/Pinta.Effects/Utilities/PaletteHelper.cs
@@ -57,7 +57,7 @@ internal static class PaletteHelper
 
 		static Predefined ()
 		{
-			BlackWhite = ImmutableArray.CreateRange (new[] { ColorBgra.Black, ColorBgra.White });
+			BlackWhite = [ColorBgra.Black, ColorBgra.White];
 			old_ms_paint = new (() => EnumerateOldMsPaintColors ().ToImmutableArray ());
 			old_windows_16 = new (() => EnumerateOldWindows16Colors ().ToImmutableArray ());
 			old_windows_20 = new (() => EnumerateOldWindows20Colors ().ToImmutableArray ());


### PR DESCRIPTION
I think this was removed because .NET 7 didn't support it, but now the official builds don't include .NET 7