### PR TITLE
Terse collection initialization syntax in `Pinta.Core`

### DIFF
--- a/Pinta.Core/Actions/AdjustmentsActions.cs
+++ b/Pinta.Core/Actions/AdjustmentsActions.cs
@@ -30,7 +30,7 @@ namespace Pinta.Core;
 
 public sealed class AdjustmentsActions
 {
-	public Collection<Command> Actions { get; } = new ();
+	public Collection<Command> Actions { get; } = [];
 
 	#region Public Methods
 	public void ToggleActionsSensitive (bool sensitive)

--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -133,16 +133,16 @@ public sealed class EditActions
 		menu.AppendSubmenu (Translations.GetString ("Palette"), palette_menu);
 
 		app.AddAccelAction (Undo, "<Primary>Z");
-		app.AddAccelAction (Redo, new[] { "<Primary><Shift>Z", "<Ctrl>Y" });
+		app.AddAccelAction (Redo, ["<Primary><Shift>Z", "<Ctrl>Y"]);
 		app.AddAccelAction (Cut, "<Primary>X");
 		app.AddAccelAction (Copy, "<Primary>C");
 		app.AddAccelAction (CopyMerged, "<Primary><Shift>C");
 		app.AddAccelAction (Paste, "<Primary>V");
 		app.AddAccelAction (PasteIntoNewLayer, "<Primary><Shift>V");
 		// Note: <Ctrl><Alt>V shortcut doesn't seem to work on Windows & macOS (bug 2047921). 
-		app.AddAccelAction (PasteIntoNewImage, new[] { "<Shift>V", "<Primary><Alt>V" });
+		app.AddAccelAction (PasteIntoNewImage, ["<Shift>V", "<Primary><Alt>V"]);
 		app.AddAccelAction (SelectAll, "<Primary>A");
-		app.AddAccelAction (Deselect, new[] { "<Primary><Shift>A", "<Ctrl>D" });
+		app.AddAccelAction (Deselect, ["<Primary><Shift>A", "<Ctrl>D"]);
 		app.AddAccelAction (EraseSelection, "Delete");
 		app.AddAccelAction (FillSelection, "BackSpace");
 		app.AddAccelAction (InvertSelection, "<Primary>I");

--- a/Pinta.Core/Actions/EffectsActions.cs
+++ b/Pinta.Core/Actions/EffectsActions.cs
@@ -31,8 +31,8 @@ namespace Pinta.Core;
 
 public sealed class EffectsActions
 {
-	public Dictionary<string, Gio.Menu> Menus { get; } = new ();
-	public Collection<Command> Actions { get; } = new ();
+	public Dictionary<string, Gio.Menu> Menus { get; } = [];
+	public Collection<Command> Actions { get; } = [];
 
 	private readonly ChromeManager chrome;
 	public EffectsActions (ChromeManager chrome)

--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -169,9 +169,9 @@ public sealed class ViewActions
 		Gio.Menu color_scheme_section = Gio.Menu.New ();
 		color_scheme_section.AppendSubmenu (Translations.GetString ("Color Scheme"), color_scheme_menu);
 
-		app.AddAccelAction (ZoomIn, new[] { "<Primary>plus", "<Primary>equal", "equal", "<Primary>KP_Add", "KP_Add" });
-		app.AddAccelAction (ZoomOut, new[] { "<Primary>minus", "<Primary>underscore", "minus", "<Primary>KP_Subtract", "KP_Subtract" });
-		app.AddAccelAction (ActualSize, new[] { "<Primary>0", "<Primary><Shift>A" });
+		app.AddAccelAction (ZoomIn, ["<Primary>plus", "<Primary>equal", "equal", "<Primary>KP_Add", "KP_Add"]);
+		app.AddAccelAction (ZoomOut, ["<Primary>minus", "<Primary>underscore", "minus", "<Primary>KP_Subtract", "KP_Subtract"]);
+		app.AddAccelAction (ActualSize, ["<Primary>0", "<Primary><Shift>A"]);
 		app.AddAccelAction (ZoomToWindow, "<Primary>B");
 		app.AddAccelAction (Fullscreen, "F11");
 		app.AddAction (EditCanvasGrid);

--- a/Pinta.Core/Actions/WindowActions.cs
+++ b/Pinta.Core/Actions/WindowActions.cs
@@ -105,7 +105,7 @@ public sealed class WindowActions
 
 		// We only assign accelerators up to Alt-9
 		if (idx < 9)
-			chrome.Application.SetAccelsForAction (action_id, new[] { $"<Alt>{idx + 1}" });
+			chrome.Application.SetAccelsForAction (action_id, [$"<Alt>{idx + 1}"]);
 	}
 
 	private void RebuildDocumentMenu ()

--- a/Pinta.Core/Algorithms/HistogramRGB.cs
+++ b/Pinta.Core/Algorithms/HistogramRGB.cs
@@ -22,7 +22,7 @@ public sealed class HistogramRgb : Histogram
 		: base (3, 256, rgb_visual_colors)
 	{ }
 
-	private static ImmutableArray<ColorBgra> CreateVisualColors () => ImmutableArray.CreateRange (new[] { ColorBgra.Blue, ColorBgra.Green, ColorBgra.Red });
+	private static ImmutableArray<ColorBgra> CreateVisualColors () => [ColorBgra.Blue, ColorBgra.Green, ColorBgra.Red];
 	private static readonly ImmutableArray<ColorBgra> rgb_visual_colors = CreateVisualColors ();
 
 	public override ColorBgra GetMeanColor ()

--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -432,7 +432,7 @@ public static class Utility
 	/// <summary>
 	/// Checks if all of the pixels in the row match the specified color.
 	/// </summary>
-	private static bool IsConstantRow (ImageSurface surf, Cairo.Color color, RectangleI rect, int y)
+	private static bool IsConstantRow (ImageSurface surf, Color color, RectangleI rect, int y)
 	{
 		for (int x = rect.Left; x < rect.Right; ++x)
 			if (!color.Equals (surf.GetColorBgra (new (x, y)).ToCairoColor ()))
@@ -444,7 +444,7 @@ public static class Utility
 	/// <summary>
 	/// Checks if all of the pixels in the column (within the bounds of the rectangle) match the specified color.
 	/// </summary>
-	private static bool IsConstantColumn (ImageSurface surf, Cairo.Color color, RectangleI rect, int x)
+	private static bool IsConstantColumn (ImageSurface surf, Color color, RectangleI rect, int x)
 	{
 		for (int y = rect.Top; y < rect.Bottom; ++y)
 			if (!color.Equals (surf.GetColorBgra (new (x, y)).ToCairoColor ()))

--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -458,7 +458,7 @@ public static class Utility
 		// Use the entire image bounds by default, or restrict to the provided search area.
 		RectangleI rect = searchArea ?? image.GetBounds ();
 		// Get the background color from the top-left pixel of the rectangle
-		Cairo.Color borderColor = image.GetColorBgra (new PointI (rect.Left, rect.Top)).ToCairoColor ();
+		Color borderColor = image.GetColorBgra (new PointI (rect.Left, rect.Top)).ToCairoColor ();
 
 		// Top down.
 		for (int y = rect.Top; y < rect.Bottom; ++y) {

--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -119,7 +119,7 @@ public static class Utility
 			throw new ArgumentException ($"{nameof (sampleCount)} != ({nameof (quality)} * {nameof (quality)})");
 
 		if (sampleCount == 1)
-			return new[] { PointD.Zero };
+			return [PointD.Zero];
 
 		var result = new PointD[sampleCount];
 		for (int i = 0; i < sampleCount; ++i) {
@@ -151,7 +151,7 @@ public static class Utility
 	// i = z * 3;
 	// (x / z) = ((x * masTable[i]) + masTable[i + 1]) >> masTable[i + 2)
 	private static readonly uint[] mas_table =
-	{
+	[
 		0x00000000, 0x00000000, 0,  // 0
 		0x00000001, 0x00000000, 0,  // 1
 		0x00000001, 0x00000000, 1,  // 2
@@ -408,7 +408,7 @@ public static class Utility
 		0x81848DA9, 0x00000000, 39, // 253
 		0x10204081, 0x10204081, 36, // 254
 		0x80808081, 0x00000000, 39, // 255
-	};
+	];
 
 	/// <summary>Gets the nearest step angle in radians.</summary>
 	/// 

--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -63,17 +63,17 @@ public static class Utility
 	/// array of bounding boxes.
 	/// </summary>
 	/// <param name="rects">The "region" you want to find a bounding box for.</param>
-	/// <param name="start">Index of the first rectangle in the array to examine.</param>
+	/// <param name="startIndex">Index of the first rectangle in the array to examine.</param>
 	/// <param name="length">Number of rectangles to examine, beginning at <b>startIndex</b>.</param>
 	/// <returns>A rectangle that surrounds the region.</returns>
-	public static RectangleI GetRegionBounds (ReadOnlySpan<RectangleI> rects, int start, int length)
+	public static RectangleI GetRegionBounds (ReadOnlySpan<RectangleI> rects, int startIndex, int length)
 	{
 		if (rects.Length == 0)
 			return RectangleI.Zero;
 
-		RectangleI unionsAggregate = rects[start];
+		RectangleI unionsAggregate = rects[startIndex];
 
-		for (int i = start + 1; i < start + length; ++i)
+		for (int i = startIndex + 1; i < startIndex + length; ++i)
 			unionsAggregate = unionsAggregate.Union (rects[i]);
 
 		return unionsAggregate;
@@ -151,7 +151,7 @@ public static class Utility
 	// i = z * 3;
 	// (x / z) = ((x * masTable[i]) + masTable[i + 1]) >> masTable[i + 2)
 	private static readonly uint[] mas_table =
-	[
+	{
 		0x00000000, 0x00000000, 0,  // 0
 		0x00000001, 0x00000000, 0,  // 1
 		0x00000001, 0x00000000, 1,  // 2
@@ -408,7 +408,7 @@ public static class Utility
 		0x81848DA9, 0x00000000, 39, // 253
 		0x10204081, 0x10204081, 36, // 254
 		0x80808081, 0x00000000, 39, // 255
-	];
+	};
 
 	/// <summary>Gets the nearest step angle in radians.</summary>
 	/// 
@@ -432,7 +432,7 @@ public static class Utility
 	/// <summary>
 	/// Checks if all of the pixels in the row match the specified color.
 	/// </summary>
-	private static bool IsConstantRow (ImageSurface surf, Color color, RectangleI rect, int y)
+	private static bool IsConstantRow (ImageSurface surf, Cairo.Color color, RectangleI rect, int y)
 	{
 		for (int x = rect.Left; x < rect.Right; ++x)
 			if (!color.Equals (surf.GetColorBgra (new (x, y)).ToCairoColor ()))
@@ -444,7 +444,7 @@ public static class Utility
 	/// <summary>
 	/// Checks if all of the pixels in the column (within the bounds of the rectangle) match the specified color.
 	/// </summary>
-	private static bool IsConstantColumn (ImageSurface surf, Color color, RectangleI rect, int x)
+	private static bool IsConstantColumn (ImageSurface surf, Cairo.Color color, RectangleI rect, int x)
 	{
 		for (int y = rect.Top; y < rect.Bottom; ++y)
 			if (!color.Equals (surf.GetColorBgra (new (x, y)).ToCairoColor ()))
@@ -458,7 +458,7 @@ public static class Utility
 		// Use the entire image bounds by default, or restrict to the provided search area.
 		RectangleI rect = searchArea ?? image.GetBounds ();
 		// Get the background color from the top-left pixel of the rectangle
-		Color borderColor = image.GetColorBgra (new PointI (rect.Left, rect.Top)).ToCairoColor ();
+		Cairo.Color borderColor = image.GetColorBgra (new PointI (rect.Left, rect.Top)).ToCairoColor ();
 
 		// Top down.
 		for (int y = rect.Top; y < rect.Bottom; ++y) {

--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -63,17 +63,17 @@ public static class Utility
 	/// array of bounding boxes.
 	/// </summary>
 	/// <param name="rects">The "region" you want to find a bounding box for.</param>
-	/// <param name="startIndex">Index of the first rectangle in the array to examine.</param>
+	/// <param name="start">Index of the first rectangle in the array to examine.</param>
 	/// <param name="length">Number of rectangles to examine, beginning at <b>startIndex</b>.</param>
 	/// <returns>A rectangle that surrounds the region.</returns>
-	public static RectangleI GetRegionBounds (ReadOnlySpan<RectangleI> rects, int startIndex, int length)
+	public static RectangleI GetRegionBounds (ReadOnlySpan<RectangleI> rects, int start, int length)
 	{
 		if (rects.Length == 0)
 			return RectangleI.Zero;
 
-		RectangleI unionsAggregate = rects[startIndex];
+		RectangleI unionsAggregate = rects[start];
 
-		for (int i = startIndex + 1; i < startIndex + length; ++i)
+		for (int i = start + 1; i < start + length; ++i)
 			unionsAggregate = unionsAggregate.Union (rects[i]);
 
 		return unionsAggregate;

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -91,7 +91,7 @@ internal sealed class AsyncEffectRenderer
 		initialCompletionSource.SetResult (
 			new (
 				WasCanceled: false,
-				Errors: Array.Empty<Exception> ()
+				Errors: []
 			)
 		);
 

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -138,7 +138,7 @@ internal sealed class AsyncEffectRenderer
 		ConcurrentQueue<RectangleI> targetTiles = new (
 			settings.EffectIsTileable
 			? settings.RenderBounds.ToRows () // If effect is tileable, render each row in parallel.
-			: new[] { settings.RenderBounds }); // If the effect isn't tileable, there is a single tile for the entire render bounds
+			: [settings.RenderBounds]); // If the effect isn't tileable, there is a single tile for the entire render bounds
 
 		queued_tiles = targetTiles;
 		tiles_count = targetTiles.Count;

--- a/Pinta.Core/Classes/AsyncEffectRenderer.cs
+++ b/Pinta.Core/Classes/AsyncEffectRenderer.cs
@@ -195,7 +195,7 @@ internal sealed class AsyncEffectRenderer
 
 					CompletionInfo completion = new (
 						WasCanceled: cancellationToken.IsCancellationRequested,
-						Errors: renderExceptions.ToArray ());
+						Errors: [.. renderExceptions]);
 
 					Completed?.Invoke (completion);
 

--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -115,7 +115,7 @@ public abstract class BaseTool
 	/// A list of handles that should be drawn on the canvas window.
 	/// </summary>
 	public virtual IEnumerable<IToolHandle> Handles
-		=> Enumerable.Empty<IToolHandle> ();
+		=> [];
 
 	/// <summary>
 	/// The shortcut key used to activate this tool in the toolbox.

--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -32,7 +32,7 @@ namespace Pinta.Core;
 public sealed class DocumentHistory
 {
 	private readonly Document document;
-	private readonly List<BaseHistoryItem> history = new ();
+	private readonly List<BaseHistoryItem> history = [];
 	private int clean_pointer = -1;
 
 	public event EventHandler<HistoryItemAddedEventArgs>? HistoryItemAdded;

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -10,7 +10,7 @@ public sealed class DocumentLayers
 {
 	private readonly ToolManager tools;
 	private readonly Document document;
-	private readonly List<UserLayer> user_layers = new ();
+	private readonly List<UserLayer> user_layers = [];
 
 	private int layer_name_int = 2;
 

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -42,7 +42,7 @@ public sealed class DocumentSelection
 
 	private Path? selection_path;
 
-	public List<List<IntPoint>> SelectionPolygons { get; set; } = new ();
+	public List<List<IntPoint>> SelectionPolygons { get; set; } = [];
 	public Clipper SelectionClipper { get; } = new ();
 
 	public PointD Origin { get; set; }
@@ -362,7 +362,7 @@ public sealed class DocumentSelection
 	/// </param>
 	public void Invert (Core.Size imageSize)
 	{
-		List<List<IntPoint>> resultingPolygons = new List<List<IntPoint>> ();
+		List<List<IntPoint>> resultingPolygons = [];
 
 		var documentPolygon = CreateRectanglePolygon (new RectangleD (0, 0, imageSize.Width, imageSize.Height));
 
@@ -387,14 +387,14 @@ public sealed class DocumentSelection
 	public void Offset (double delta)
 	{
 		// Remove any self-intersections from the selection polygons.
-		List<List<IntPoint>> simplePolygons = new ();
+		List<List<IntPoint>> simplePolygons = [];
 
 		SelectionClipper.AddPaths (SelectionPolygons, PolyType.ptSubject, true);
 		SelectionClipper.Execute (ClipType.ctUnion, simplePolygons, PolyFillType.pftNonZero, PolyFillType.pftNonZero);
 		SelectionClipper.Clear ();
 
 		// Expand or contract the selection by the specified amount.
-		List<List<IntPoint>> offsetPolygons = new ();
+		List<List<IntPoint>> offsetPolygons = [];
 
 		ClipperOffset clipperOffset = new ();
 		clipperOffset.AddPaths (simplePolygons, JoinType.jtMiter, EndType.etClosedPolygon);
@@ -416,13 +416,13 @@ public sealed class DocumentSelection
 		// the first corner again. It is important to note that the order of the
 		// corners being added (clockwise) and the first/last Point being the same
 		// should be kept this way; otherwise, problems could result.
-		List<IntPoint> newPolygon = new () {
+		List<IntPoint> newPolygon = [
 			new (corner1X, corner1Y),
 			new (corner2X, corner1Y),
 			new (corner2X, corner2Y),
 			new (corner1X, corner2Y),
 			new (corner1X, corner1Y)
-		};
+		];
 
 		return newPolygon;
 	}

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -113,7 +113,7 @@ public sealed class DocumentSelection
 		g.StrokePreserve ();
 
 		// Draw a black dashed line over the white line
-		g.SetDash (new double[] { 2 / scale, 4 / scale }, 0);
+		g.SetDash ([2 / scale, 4 / scale], 0);
 		g.SetSourceColor (new Cairo.Color (0, 0, 0));
 
 		g.Stroke ();

--- a/Pinta.Core/Classes/DocumentSelection.cs
+++ b/Pinta.Core/Classes/DocumentSelection.cs
@@ -126,7 +126,7 @@ public sealed class DocumentSelection
 	public DocumentSelection Clone ()
 	{
 		return new (owning_document) {
-			SelectionPolygons = SelectionPolygons.ToList (),
+			SelectionPolygons = [.. SelectionPolygons],
 			Origin = new PointD (Origin.X, Origin.Y),
 			End = new PointD (End.X, End.Y),
 			visible = visible,

--- a/Pinta.Core/Classes/Palette.cs
+++ b/Pinta.Core/Classes/Palette.cs
@@ -38,7 +38,7 @@ public sealed class Palette
 {
 	public event EventHandler? PaletteChanged;
 
-	private List<Color> colors = new ();
+	private List<Color> colors = [];
 
 	private void OnPaletteChanged ()
 	{

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -120,7 +120,7 @@ public sealed partial class TextEngine
 
 	public KeyValuePair<TextPosition, TextPosition>[] SelectionRegions {
 		get {
-			List<KeyValuePair<TextPosition, TextPosition>> regions = new ();
+			List<KeyValuePair<TextPosition, TextPosition>> regions = [];
 
 			TextPosition start = TextPosition.Min (current_pos, selection_start);
 			TextPosition end = TextPosition.Max (current_pos, selection_start);

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -90,7 +90,7 @@ public sealed partial class TextEngine
 	public TextEngine Clone ()
 	{
 		TextEngine clonedTE = new () {
-			lines = lines.ToList (),
+			lines = [.. lines],
 			State = State,
 			current_pos = current_pos,
 			selection_start = selection_start,
@@ -135,7 +135,7 @@ public sealed partial class TextEngine
 					p1 = new TextPosition (currentLinePos + 1, 0);
 			});
 
-			return regions.ToArray ();
+			return [.. regions];
 		}
 	}
 

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -60,7 +60,7 @@ public sealed partial class TextEngine
 	public event EventHandler? Modified;
 
 	public TextEngine ()
-		: this (new[] { string.Empty })
+		: this ([string.Empty])
 	{ }
 
 	public TextEngine (IEnumerable<string> lines)

--- a/Pinta.Core/Classes/SplineInterpolator.cs
+++ b/Pinta.Core/Classes/SplineInterpolator.cs
@@ -12,7 +12,7 @@ namespace Pinta.Core;
 
 public sealed class SplineInterpolator
 {
-	private readonly SortedList<double, double> points = new ();
+	private readonly SortedList<double, double> points = [];
 	private ImmutableArray<double> y2;
 
 	public int Count => points.Count;

--- a/Pinta.Core/Classes/UserLayer.cs
+++ b/Pinta.Core/Classes/UserLayer.cs
@@ -36,7 +36,7 @@ namespace Pinta.Core;
 public sealed class UserLayer : Layer
 {
 	//Special layers to be drawn on to keep things editable by drawing them separately from the UserLayers.
-	internal Collection<ReEditableLayer> ReEditableLayers { get; } = new ();
+	internal Collection<ReEditableLayer> ReEditableLayers { get; } = [];
 	public ReEditableLayer TextLayer { get; }
 
 	//Call the base class constructor and setup the engines.

--- a/Pinta.Core/Effects/UnaryPixelOps.cs
+++ b/Pinta.Core/Effects/UnaryPixelOps.cs
@@ -633,9 +633,9 @@ public static class UnaryPixelOps
 		public object Clone ()
 		{
 			Level copy = new Level (color_in_low, color_in_high, (float[]) gamma.Clone (), color_out_low, color_out_high) {
-				CurveB = CurveB.ToArray (),
-				CurveG = CurveG.ToArray (),
-				CurveR = CurveR.ToArray ()
+				CurveB = [.. CurveB],
+				CurveG = [.. CurveG],
+				CurveR = [.. CurveR]
 			};
 
 			return copy;

--- a/Pinta.Core/Effects/UnaryPixelOps.cs
+++ b/Pinta.Core/Effects/UnaryPixelOps.cs
@@ -567,7 +567,7 @@ public static class UnaryPixelOps
 		public Level () : this (
 			ColorBgra.Black,
 			ColorBgra.White,
-			new float[] { 1, 1, 1 },
+			[1, 1, 1],
 			ColorBgra.Black,
 			ColorBgra.White)
 		{ }

--- a/Pinta.Core/Effects/UserBlendOps.MasTable.cs
+++ b/Pinta.Core/Effects/UserBlendOps.MasTable.cs
@@ -56,7 +56,7 @@ partial class UserBlendOps
 	// (x / z) = ((x * masTable[i]) + masTable[i + 1]) >> masTable[i + 2)
 #pragma warning disable format
 	private static readonly uint[] mas_table =
-	{
+	[
 		0x00000000, 0x00000000, 0,  // 0
 		0x00000001, 0x00000000, 0,  // 1
 		0x00000001, 0x00000000, 1,  // 2
@@ -313,6 +313,6 @@ partial class UserBlendOps
 		0x81848DA9, 0x00000000, 39, // 253
 		0x10204081, 0x10204081, 36, // 254
 		0x80808081, 0x00000000, 39  // 255
-	};
+	];
 #pragma warning restore format
 }

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Patterns.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Patterns.cs
@@ -94,7 +94,7 @@ partial class CairoExtensions
 		// An empty cairo pattern, a pattern with no dashes, or a pattern with a single dash just draws a normal line.
 		// Cairo draws a normal line when the dash list is empty.
 		if (!IsValidDashPattern (dash_pattern)) {
-			dash_list = Array.Empty<double> ();
+			dash_list = [];
 			offset = 0.0;
 			return false;
 		}
@@ -215,7 +215,7 @@ partial class CairoExtensions
 				scans[i] = cairo_rect.ToRectangleI ();
 			}
 		} else {
-			scans = Array.Empty<RectangleI> ();
+			scans = [];
 		}
 
 		foreach (var rect in scans)
@@ -289,7 +289,7 @@ partial class CairoExtensions
 				scans[i] = cairo_rect.ToRectangleI ();
 			}
 		} else {
-			scans = Array.Empty<RectangleI> ();
+			scans = [];
 		}
 
 		foreach (var rect in scans)

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Patterns.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Patterns.cs
@@ -99,7 +99,7 @@ partial class CairoExtensions
 			return false;
 		}
 
-		List<double> dashes = new ();
+		List<double> dashes = [];
 
 		// Count the number of consecutive dashes / spaces.
 		// e.g. "---  - " produces { 3.0, 2.0, 1.0, 1.0 }

--- a/Pinta.Core/Extensions/GioExtensions.cs
+++ b/Pinta.Core/Extensions/GioExtensions.cs
@@ -89,6 +89,6 @@ public static class GioExtensions
 
 	public static void RemoveMultiple (this Gio.ListStore store, uint position, uint n_removals)
 	{
-		store.Splice (position, n_removals, Array.Empty<GObject.Object> (), 0);
+		store.Splice (position, n_removals, [], 0);
 	}
 }

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Application.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Application.cs
@@ -43,7 +43,7 @@ partial class GtkExtensions
 		Command action,
 		string accel)
 	{
-		app.AddAccelAction (action, new[] { accel });
+		app.AddAccelAction (action, [accel]);
 	}
 
 	public static void AddAccelAction (

--- a/Pinta.Core/Extensions/NativeImportResolver.cs
+++ b/Pinta.Core/Extensions/NativeImportResolver.cs
@@ -50,7 +50,7 @@ internal static class NativeImportResolver
 		}
 	};
 
-	private static readonly Dictionary<string, LibraryInfo> library_infos = new ();
+	private static readonly Dictionary<string, LibraryInfo> library_infos = [];
 
 	static NativeImportResolver ()
 	{

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -186,7 +186,7 @@ public static class OtherExtensions
 					break;
 			}
 
-			PointI[] points = pts.ToArray ();
+			PointI[] points = [.. pts];
 
 			var scans = CairoExtensions.GetScans (points);
 

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -109,8 +109,8 @@ public static class OtherExtensions
 		if (stencil.IsEmpty)
 			return Array.Empty<PointI[]> ();
 
-		List<IReadOnlyList<PointI>> polygons = new ();
-		List<PointI> pts = new ();
+		List<IReadOnlyList<PointI>> polygons = [];
+		List<PointI> pts = [];
 
 		PointI start = bounds.Location ().ToInt ();
 

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -107,7 +107,7 @@ public static class OtherExtensions
 		PointI translateOffset)
 	{
 		if (stencil.IsEmpty)
-			return Array.Empty<PointI[]> ();
+			return [];
 
 		List<IReadOnlyList<PointI>> polygons = [];
 		List<PointI> pts = [];

--- a/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/CompoundHistoryItem.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core;
 
 public class CompoundHistoryItem : BaseHistoryItem
 {
-	protected List<BaseHistoryItem> history_stack = new ();
+	protected List<BaseHistoryItem> history_stack = [];
 	private List<ImageSurface>? snapshots;
 
 	public CompoundHistoryItem () : base ()
@@ -63,7 +63,7 @@ public class CompoundHistoryItem : BaseHistoryItem
 
 	public void StartSnapshotOfImage ()
 	{
-		snapshots = new List<ImageSurface> ();
+		snapshots = [];
 		foreach (UserLayer item in PintaCore.Workspace.ActiveDocument.Layers.UserLayers) {
 			snapshots.Add (item.Surface.Clone ());
 		}

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -77,8 +77,8 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 		using Gio.OutputStream stream = file.Replace ();
 		try {
 			pb.SaveToStreamv (stream, fileType,
-					optionKeys: Array.Empty<string> (),
-					optionValues: Array.Empty<string> (),
+					optionKeys: [],
+					optionValues: [],
 					cancellable: null);
 		} finally {
 			stream.Close (null);

--- a/Pinta.Core/ImageFormats/JpegFormat.cs
+++ b/Pinta.Core/ImageFormats/JpegFormat.cs
@@ -65,7 +65,7 @@ public sealed class JpegFormat : GdkPixbufFormat
 
 		using var stream = file.Replace ();
 		try {
-			pb.SaveToStreamv (stream, fileType, new string[] { "quality" }, new string[] { level.ToString () }, null);
+			pb.SaveToStreamv (stream, fileType, ["quality"], [level.ToString ()], null);
 		} finally {
 			stream.Close (null);
 		}

--- a/Pinta.Core/Managers/EffectsManager.cs
+++ b/Pinta.Core/Managers/EffectsManager.cs
@@ -44,8 +44,8 @@ public sealed class EffectsManager
 		ChromeManager chromeManager,
 		LivePreviewManager livePreviewManager)
 	{
-		adjustments = new Dictionary<BaseEffect, Command> ();
-		effects = new Dictionary<BaseEffect, Command> ();
+		adjustments = [];
+		effects = [];
 
 		action_manager = actionManager;
 		chrome_manager = chromeManager;

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -53,8 +53,8 @@ public sealed class ImageConverterManager
 		OraFormat oraHandler = new ();
 		FormatDescriptor oraFormatDescriptor = new (
 			displayPrefix: "OpenRaster",
-			extensions: new[] { "ora", "ORA" },
-			mimes: new[] { "image/openraster" },
+			extensions: ["ora", "ORA"],
+			mimes: ["image/openraster"],
 			importer: oraHandler,
 			exporter: oraHandler,
 			supportsLayers: true);
@@ -63,8 +63,8 @@ public sealed class ImageConverterManager
 		NetpbmPortablePixmap netpbmPortablePixmap = new ();
 		FormatDescriptor netpbmPortablePixmapDescriptor = new (
 			displayPrefix: "Netpbm Portable Pixmap",
-			extensions: new[] { "ppm", "PPM" },
-			mimes: new[] { "image/x-portable-pixmap" }, // Not official, but conventional
+			extensions: ["ppm", "PPM"],
+			mimes: ["image/x-portable-pixmap"], // Not official, but conventional
 			importer: null,
 			exporter: netpbmPortablePixmap,
 			supportsLayers: false
@@ -78,10 +78,10 @@ public sealed class ImageConverterManager
 				throw new ArgumentException ($"{nameof (format)} has an empty name");
 
 		string formatNameUpperCase = formatName.ToUpperInvariant ();
-		var extensions = formatName switch {
-			"jpeg" => new string[] { "jpg", "jpeg", "JPG", "JPEG" },
-			"tiff" => new string[] { "tif", "tiff", "TIF", "TIFF" },
-			_ => new string[] { formatName, formatNameUpperCase },
+		string[] extensions = formatName switch {
+			"jpeg" => ["jpg", "jpeg", "JPG", "JPEG"],
+			"tiff" => ["tif", "tiff", "TIF", "TIFF"],
+			_ => [formatName, formatNameUpperCase],
 		};
 		GdkPixbufFormat importer = new (formatName);
 		IImageExporter? exporter;

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -97,7 +97,7 @@ public sealed class ImageConverterManager
 		FormatDescriptor formatDescriptor = new (
 			displayPrefix: formatNameUpperCase,
 			extensions: extensions,
-			mimes: format.GetMimeTypes () ?? Array.Empty<string> (),
+			mimes: format.GetMimeTypes () ?? [],
 			importer: importer,
 			exporter: exporter,
 			supportsLayers: false);

--- a/Pinta.Core/Managers/PaintBrushManager.cs
+++ b/Pinta.Core/Managers/PaintBrushManager.cs
@@ -37,7 +37,7 @@ public interface IPaintBrushService : IEnumerable<BasePaintBrush>
 
 public sealed class PaintBrushManager : IPaintBrushService
 {
-	private readonly List<BasePaintBrush> paint_brushes = new ();
+	private readonly List<BasePaintBrush> paint_brushes = [];
 
 	public event EventHandler<BrushEventArgs>? BrushAdded;
 	public event EventHandler<BrushEventArgs>? BrushRemoved;

--- a/Pinta.Core/Managers/PaletteFormatManager.cs
+++ b/Pinta.Core/Managers/PaletteFormatManager.cs
@@ -35,7 +35,7 @@ public sealed class PaletteFormatManager
 
 	public PaletteFormatManager ()
 	{
-		formats = new List<PaletteDescriptor> ();
+		formats = [];
 
 		PaintDotNetPalette pdnHandler = new PaintDotNetPalette ();
 		formats.Add (new PaletteDescriptor ("Paint.NET", ["txt", "TXT"], pdnHandler, pdnHandler));

--- a/Pinta.Core/Managers/PaletteFormatManager.cs
+++ b/Pinta.Core/Managers/PaletteFormatManager.cs
@@ -38,13 +38,13 @@ public sealed class PaletteFormatManager
 		formats = new List<PaletteDescriptor> ();
 
 		PaintDotNetPalette pdnHandler = new PaintDotNetPalette ();
-		formats.Add (new PaletteDescriptor ("Paint.NET", new string[] { "txt", "TXT" }, pdnHandler, pdnHandler));
+		formats.Add (new PaletteDescriptor ("Paint.NET", ["txt", "TXT"], pdnHandler, pdnHandler));
 
 		GimpPalette gimpHandler = new GimpPalette ();
-		formats.Add (new PaletteDescriptor ("GIMP", new string[] { "gpl", "GPL" }, gimpHandler, gimpHandler));
+		formats.Add (new PaletteDescriptor ("GIMP", ["gpl", "GPL"], gimpHandler, gimpHandler));
 
 		PaintShopProPalette pspHandler = new PaintShopProPalette ();
-		formats.Add (new PaletteDescriptor ("PaintShop Pro", new string[] { "pal", "PAL" }, pspHandler, pspHandler));
+		formats.Add (new PaletteDescriptor ("PaintShop Pro", ["pal", "PAL"], pspHandler, pspHandler));
 	}
 
 	public IEnumerable<PaletteDescriptor> Formats => formats;

--- a/Pinta.Core/Managers/ServiceManager.cs
+++ b/Pinta.Core/Managers/ServiceManager.cs
@@ -55,7 +55,7 @@ public interface IServiceManager : IServiceProvider
 
 public sealed class ServiceManager : IServiceManager
 {
-	private readonly Dictionary<Type, object> services = new ();
+	private readonly Dictionary<Type, object> services = [];
 
 	public T AddService<T> (T implementation) where T : class
 	{

--- a/Pinta.Core/Managers/SettingsManager.cs
+++ b/Pinta.Core/Managers/SettingsManager.cs
@@ -63,7 +63,7 @@ public sealed class SettingsManager : ISettingsService
 {
 	private const string SETTINGS_FILE = "settings.xml";
 
-	private readonly Dictionary<string, object> settings = new ();
+	private readonly Dictionary<string, object> settings = [];
 
 	/// <summary>
 	/// Handle this event to be given a chance to save settings to disk

--- a/Pinta.Core/Managers/SettingsManager.cs
+++ b/Pinta.Core/Managers/SettingsManager.cs
@@ -87,7 +87,7 @@ public sealed class SettingsManager : ISettingsService
 			return;
 		}
 
-		var nodes = document.Element ("settings")?.Elements ("setting") ?? Enumerable.Empty<XElement> (); ;
+		var nodes = document.Element ("settings")?.Elements ("setting") ?? [];
 
 		foreach (var node in nodes) {
 			if (node.Attribute ("name")?.Value is not string name)

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -169,7 +169,7 @@ public sealed class WorkspaceManager : IWorkspaceService
 		ChromeManager chromeManager,
 		ImageConverterManager imageFormats)
 	{
-		open_documents = new List<Document> ();
+		open_documents = [];
 		OpenDocuments = new ReadOnlyCollection<Document> (open_documents);
 		SelectionHandler = new SelectionModeHandler (systemManager);
 

--- a/Pinta.Core/PaletteFormats/GimpPalette.cs
+++ b/Pinta.Core/PaletteFormats/GimpPalette.cs
@@ -37,9 +37,9 @@ public sealed class GimpPalette : IPaletteLoader, IPaletteSaver
 {
 	public List<Color> Load (Gio.File file)
 	{
-		List<Color> colors = new List<Color> ();
-		using var stream = new GioStream (file.Read (null));
-		using var reader = new StreamReader (stream);
+		List<Color> colors = [];
+		using GioStream stream = new (file.Read (null));
+		using StreamReader reader = new (stream);
 		string? line = reader.ReadLine ();
 
 		if (line is null || !line.StartsWith ("GIMP"))
@@ -72,8 +72,8 @@ public sealed class GimpPalette : IPaletteLoader, IPaletteSaver
 
 	public void Save (IReadOnlyList<Color> colors, Gio.File file)
 	{
-		using var stream = new GioStream (file.Replace ());
-		using var writer = new StreamWriter (stream);
+		using GioStream stream = new (file.Replace ());
+		using StreamWriter writer = new (stream);
 
 		writer.WriteLine ("GIMP Palette");
 		writer.WriteLine ("Name: Pinta Created {0}", DateTime.Now.ToString (DateTimeFormatInfo.InvariantInfo.RFC1123Pattern));

--- a/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintDotNetPalette.cs
@@ -36,7 +36,7 @@ public sealed class PaintDotNetPalette : IPaletteLoader, IPaletteSaver
 {
 	public List<Color> Load (Gio.File file)
 	{
-		List<Color> colors = new List<Color> ();
+		List<Color> colors = [];
 		using var stream = new GioStream (file.Read (null));
 		using var reader = new StreamReader (stream);
 

--- a/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
+++ b/Pinta.Core/PaletteFormats/PaintShopProPalette.cs
@@ -46,7 +46,7 @@ public sealed class PaintShopProPalette : IPaletteLoader, IPaletteSaver
 		int numberOfColors = int.Parse (reader.ReadLine ()!); // NRT - Assumes valid formatted file
 		PintaCore.Palette.CurrentPalette.Resize (numberOfColors);
 
-		List<Color> colors = new ();
+		List<Color> colors = [];
 
 		while (!reader.EndOfStream) {
 

--- a/Pinta.Core/Widgets/ToolBarDropDownButton.cs
+++ b/Pinta.Core/Widgets/ToolBarDropDownButton.cs
@@ -21,7 +21,7 @@ public sealed class ToolBarDropDownButton : Gtk.MenuButton
 	{
 		show_label = showLabel;
 
-		items = new List<ToolBarItem> ();
+		items = [];
 		Items = new ReadOnlyCollection<ToolBarItem> (items);
 		AlwaysShowArrow = true;
 


### PR DESCRIPTION
I think this was removed because .NET 7 didn't support it, but now the official builds don't include .NET 7