### PR TITLE
Several action handlers that use dialogs were made `async`

### DIFF
--- a/Pinta/Actions/Edit/OffsetSelectionAction.cs
+++ b/Pinta/Actions/Edit/OffsetSelectionAction.cs
@@ -57,32 +57,28 @@ internal sealed class OffsetSelectionAction : IActionHandler
 		edit.OffsetSelection.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
-		OffsetSelectionDialog dialog = new (chrome);
+		using OffsetSelectionDialog dialog = new (chrome);
 
-		dialog.OnResponse += (_, args) => {
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
-			if (args.ResponseId == (int) Gtk.ResponseType.Ok) {
+		dialog.Destroy ();
 
-				tools.Commit ();
+		if (response != Gtk.ResponseType.Ok) return;
 
-				Document document = workspace.ActiveDocument;
+		tools.Commit ();
 
-				document.Layers.ToolLayer.Clear ();
+		Document document = workspace.ActiveDocument;
 
-				SelectionHistoryItem historyItem = new (Resources.Icons.EditSelectionOffset, Translations.GetString ("Offset Selection"));
-				historyItem.TakeSnapshot ();
+		document.Layers.ToolLayer.Clear ();
 
-				document.Selection.Offset (dialog.Offset);
+		SelectionHistoryItem historyItem = new (Resources.Icons.EditSelectionOffset, Translations.GetString ("Offset Selection"));
+		historyItem.TakeSnapshot ();
 
-				document.History.PushNewItem (historyItem);
-				document.Workspace.Invalidate ();
-			}
+		document.Selection.Offset (dialog.Offset);
 
-			dialog.Destroy ();
-		};
-
-		dialog.Show ();
+		document.History.PushNewItem (historyItem);
+		document.Workspace.Invalidate ();
 	}
 }

--- a/Pinta/Actions/Edit/ResizePaletteAction.cs
+++ b/Pinta/Actions/Edit/ResizePaletteAction.cs
@@ -54,9 +54,9 @@ internal sealed class ResizePaletteAction : IActionHandler
 		edit.ResizePalette.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
-		SpinButtonEntryDialog dialog = new (
+		using SpinButtonEntryDialog dialog = new (
 			Translations.GetString ("Resize Palette"),
 			chrome.MainWindow,
 			Translations.GetString ("New palette size:"),
@@ -64,14 +64,12 @@ internal sealed class ResizePaletteAction : IActionHandler
 			96,
 			palette.CurrentPalette.Count);
 
-		dialog.OnResponse += (_, args) => {
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
-			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
-				palette.CurrentPalette.Resize (dialog.GetValue ());
+		dialog.Destroy ();
 
-			dialog.Destroy ();
-		};
+		if (response != Gtk.ResponseType.Ok) return;
 
-		dialog.Present ();
+		palette.CurrentPalette.Resize (dialog.GetValue ());
 	}
 }

--- a/Pinta/Actions/Image/ResizeCanvasAction.cs
+++ b/Pinta/Actions/Image/ResizeCanvasAction.cs
@@ -54,18 +54,12 @@ internal sealed class ResizeCanvasAction : IActionHandler
 		actions.Image.CanvasSize.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
-		ResizeCanvasDialog dialog = new (chrome, workspace);
-
-		dialog.OnResponse += (_, args) => {
-
-			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
-				dialog.SaveChanges ();
-
-			dialog.Destroy ();
-		};
-
-		dialog.Show ();
+		using ResizeCanvasDialog dialog = new (chrome, workspace);
+		Gtk.ResponseType response = await dialog.RunAsync ();
+		dialog.Destroy ();
+		if (response != Gtk.ResponseType.Ok) return;
+		dialog.SaveChanges ();
 	}
 }

--- a/Pinta/Actions/Image/ResizeImageAction.cs
+++ b/Pinta/Actions/Image/ResizeImageAction.cs
@@ -54,18 +54,12 @@ internal sealed class ResizeImageAction : IActionHandler
 		image.Resize.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
-		ResizeImageDialog dialog = new (chrome, workspace);
-
-		dialog.OnResponse += (_, args) => {
-
-			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
-				dialog.SaveChanges ();
-
-			dialog.Destroy ();
-		};
-
-		dialog.Show ();
+		using ResizeImageDialog dialog = new (chrome, workspace);
+		Gtk.ResponseType response = await dialog.RunAsync ();
+		dialog.Destroy ();
+		if (response != Gtk.ResponseType.Ok) return;
+		dialog.SaveChanges ();
 	}
 }

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -29,21 +29,15 @@ internal sealed class EditCanvasGridAction : IActionHandler
 		view.EditCanvasGrid.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
-		CanvasGridSettingsDialog dialog = new (chrome, canvas_grid);
-
-		dialog.OnResponse += (_, args) => {
-			if (args.ResponseId == (int) Gtk.ResponseType.Ok) {
-				canvas_grid.SaveGridSettings ();
-			} else {
-				dialog.RevertChanges ();
-			}
-
-			dialog.Destroy ();
-		};
-
-		dialog.Show ();
+		using CanvasGridSettingsDialog dialog = new (chrome, canvas_grid);
+		Gtk.ResponseType response = await dialog.RunAsync ();
+		dialog.Destroy ();
+		if (response == Gtk.ResponseType.Ok)
+			canvas_grid.SaveGridSettings ();
+		else
+			dialog.RevertChanges ();
 	}
 }
 


### PR DESCRIPTION
Not all of them. Only those for which fitting extension methods exist. The other ones require adding further extension methods to `GtkExtensions.Dialog.cs`, but that's for a future pull request