### PR TITLE
More action handlers that use dialogs were made `async`

### DIFF
--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
@@ -210,6 +210,25 @@ partial class GtkExtensions
 		return completionSource.Task;
 	}
 
+	public static Task PresentAsync (this Gtk.Window window)
+	{
+		TaskCompletionSource completionSource = new ();
+
+		bool CloseRequestCallback (
+			Gtk.Window sender,
+			System.EventArgs args)
+		{
+			completionSource.SetResult ();
+			window.OnCloseRequest -= CloseRequestCallback;
+			return false; // Allow the dialog to close normally
+		}
+
+		window.OnCloseRequest += CloseRequestCallback;
+		window.Present ();
+
+		return completionSource.Task;
+	}
+
 	public static void SetDefaultResponse (
 		this Gtk.Dialog dialog,
 		Gtk.ResponseType response

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
@@ -75,25 +75,6 @@ partial class GtkExtensions
 		return result;
 	}
 
-	public static Task<Gtk.ResponseType> ShowAsync (this Gtk.NativeDialog dialog, bool dispose = false)
-	{
-		TaskCompletionSource<Gtk.ResponseType> completionSource = new ();
-
-		void ResponseCallback (
-			Gtk.NativeDialog sender,
-			Gtk.NativeDialog.ResponseSignalArgs args)
-		{
-			completionSource.SetResult ((Gtk.ResponseType) args.ResponseId);
-			dialog.OnResponse -= ResponseCallback;
-			if (dispose) dialog.Dispose ();
-		}
-
-		dialog.OnResponse += ResponseCallback;
-		dialog.Show ();
-
-		return completionSource.Task;
-	}
-
 	/// <summary>
 	/// Similar to gtk_dialog_run() in GTK3, this runs the dialog in a blocking manner with a nested event loop.
 	/// This can be useful for compatibility with old code that relies on this behaviour, but new code should be
@@ -172,7 +153,7 @@ partial class GtkExtensions
 	}
 
 	// TODO-GTK4 (bindings) - replace with adw_message_dialog_choose() once adwaita 1.3 is available, like in v0.4 of gir.core
-	public static Task<string> RunAsync (this Adw.MessageDialog dialog, bool dispose = false)
+	public static Task<string> RunAsync (this Adw.MessageDialog dialog)
 	{
 		TaskCompletionSource<string> completionSource = new ();
 
@@ -182,7 +163,6 @@ partial class GtkExtensions
 		{
 			completionSource.SetResult (args.Response);
 			dialog.OnResponse -= ResponseCallback;
-			if (dispose) dialog.Dispose ();
 		}
 
 		dialog.OnResponse += ResponseCallback;
@@ -191,7 +171,7 @@ partial class GtkExtensions
 		return completionSource.Task;
 	}
 
-	public static Task<Gtk.ResponseType> RunAsync (this Gtk.Dialog dialog, bool dispose = false)
+	public static Task<Gtk.ResponseType> RunAsync (this Gtk.Dialog dialog)
 	{
 		TaskCompletionSource<Gtk.ResponseType> completionSource = new ();
 
@@ -201,7 +181,6 @@ partial class GtkExtensions
 		{
 			completionSource.SetResult ((Gtk.ResponseType) args.ResponseId);
 			dialog.OnResponse -= ResponseCallback;
-			if (dispose) dialog.Dispose ();
 		}
 
 		dialog.OnResponse += ResponseCallback;

--- a/Pinta/Actions/Addins/AddinManagerAction.cs
+++ b/Pinta/Actions/Addins/AddinManagerAction.cs
@@ -55,10 +55,10 @@ internal sealed class AddinManagerAction : IActionHandler
 		addins.AddinManager.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
 		AddinSetupService service = new (Mono.Addins.AddinManager.Registry);
-		AddinManagerDialog dialog = new (chrome.MainWindow, service, system, chrome);
-		dialog.Show ();
+		using AddinManagerDialog dialog = new (chrome.MainWindow, service, system, chrome);
+		await dialog.PresentAsync ();
 	}
 }

--- a/Pinta/Actions/Help/AboutDialogAction.cs
+++ b/Pinta/Actions/Help/AboutDialogAction.cs
@@ -57,9 +57,9 @@ internal sealed class AboutDialogAction : IActionHandler
 		app.About.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
-		Adw.AboutWindow dialog = Adw.AboutWindow.New ();
+		using Adw.AboutWindow dialog = Adw.AboutWindow.New ();
 		dialog.TransientFor = chrome.MainWindow;
 		dialog.Title = Translations.GetString ("About Pinta");
 		dialog.IconName = Icons.AboutPinta;
@@ -72,7 +72,7 @@ internal sealed class AboutDialogAction : IActionHandler
 		dialog.License = BuildLicenseText ();
 		dialog.Developers = authors;
 		dialog.TranslatorCredits = Translations.GetString ("translator-credits");
-		dialog.Present ();
+		await dialog.PresentAsync ();
 	}
 
 	private static string BuildCopyrightText ()
@@ -110,7 +110,7 @@ internal sealed class AboutDialogAction : IActionHandler
 		"@evgeniy-harchenko",
 		"@f-i-l-i-p",
 		"@khoidauminh",
-		"@Lehonti",
+		"Lehonti Ramos (@Lehonti)",
 		"@logiclrd",
 		"@Matthieu-LAURENT39",
 		"@potatoes1286",

--- a/Pinta/Actions/Layers/RotateZoomLayerAction.cs
+++ b/Pinta/Actions/Layers/RotateZoomLayerAction.cs
@@ -59,13 +59,13 @@ public sealed class RotateZoomLayerAction : IActionHandler
 		layers.RotateZoom.Activated -= Activated;
 	}
 
-	private void Activated (object sender, EventArgs e)
+	private async void Activated (object sender, EventArgs e)
 	{
 		// TODO - allow the layer to be zoomed in or out
 
 		RotateZoomData data = new ();
 
-		SimpleEffectDialog dialog = new (
+		using SimpleEffectDialog dialog = new (
 			chrome.MainWindow,
 			Translations.GetString ("Rotate / Zoom Layer"),
 			Resources.Icons.LayerRotateZoom,
@@ -81,15 +81,15 @@ public sealed class RotateZoomLayerAction : IActionHandler
 			workspace.Invalidate ();
 		};
 
-		dialog.OnResponse += (_, args) => {
-			ClearLivePreview ();
-			if (args.ResponseId == (int) Gtk.ResponseType.Ok && !data.IsDefault)
-				ApplyTransform (data);
+		Gtk.ResponseType response = await dialog.RunAsync ();
 
-			dialog.Destroy ();
-		};
+		dialog.Destroy ();
 
-		dialog.Present ();
+		ClearLivePreview ();
+
+		if (response != Gtk.ResponseType.Ok || data.IsDefault) return;
+
+		ApplyTransform (data);
 	}
 
 	private void ClearLivePreview ()

--- a/Pinta/Dialogs/ErrorDialog.cs
+++ b/Pinta/Dialogs/ErrorDialog.cs
@@ -32,20 +32,20 @@ namespace Pinta;
 
 internal static class ErrorDialog
 {
-	internal static Task ShowMessage (
+	internal static async Task ShowMessage (
 		Gtk.Window parent,
 		string message,
 		string body)
 	{
 		Console.Error.WriteLine ("Pinta: {0}\n{1}", message, body);
 
-		Adw.MessageDialog dialog = Adw.MessageDialog.New (parent, message, body);
+		using Adw.MessageDialog dialog = Adw.MessageDialog.New (parent, message, body);
 
 		dialog.AddResponse (nameof (ErrorDialogResponse.OK), Translations.GetString ("_OK"));
 		dialog.DefaultResponse = nameof (ErrorDialogResponse.OK);
 		dialog.CloseResponse = nameof (ErrorDialogResponse.OK);
 
-		return dialog.RunAsync (dispose: true);
+		await dialog.RunAsync ();
 	}
 
 	internal static async Task<ErrorDialogResponse> ShowError (


### PR DESCRIPTION
Some were not. For example, `CloseAllDocumentsAction.Activated` invokes the `Activate` method — which doesn't provide a task to await, and relies on its state after it's executed — directly. Clearly, handlers like these need further thought.

In the second commit, I removed the `dispose` parameter in dialog extension methods and removed one of them that had 0 references. I think that mixing declarations with and without `using` could be confusing, and it also makes it very easy to `Dispose()` of the window before calling `Destroy()`. Perhaps, if the argument is re-added in the future, it should mean to `Destroy()` _and_ `Dispose()` the dialog.