### PR TITLE
Removed `PintaCore` references from `Document`, `DocumentWorkspace`, and `DocumentHistory`

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -74,7 +74,7 @@ public sealed class Document
 		Selection = new DocumentSelection (this);
 
 		Layers = new DocumentLayers (PintaCore.Tools, this);
-		Workspace = new DocumentWorkspace (this);
+		Workspace = new DocumentWorkspace (PintaCore.Actions, PintaCore.Tools, this);
 		IsDirty = false;
 		HasBeenSavedInSession = false;
 		ImageSize = size;

--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -34,7 +34,7 @@ public sealed class DocumentHistory
 	private readonly EditActions edit;
 
 	private readonly Document document;
-	
+
 	private readonly List<BaseHistoryItem> history = [];
 	private int clean_pointer = -1;
 
@@ -69,11 +69,10 @@ public sealed class DocumentHistory
 		for (var i = history.Count - 1; i >= 0; i--) {
 			var item = history[i];
 
-			if (item.State == HistoryItemState.Redo) {
+			if (item.State == HistoryItemState.Redo)
 				history.RemoveAt (i);
-			} else if (item.State == HistoryItemState.Undo) {
+			else if (item.State == HistoryItemState.Undo)
 				break;
-			}
 		}
 
 		history.Add (newItem);

--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -31,8 +31,10 @@ namespace Pinta.Core;
 
 public sealed class DocumentHistory
 {
-	private readonly Document document;
 	private readonly EditActions edit;
+
+	private readonly Document document;
+	
 	private readonly List<BaseHistoryItem> history = [];
 	private int clean_pointer = -1;
 
@@ -41,11 +43,11 @@ public sealed class DocumentHistory
 	public event EventHandler? ActionRedone;
 
 	internal DocumentHistory (
-		Document document,
-		EditActions edit)
+		EditActions edit,
+		Document document)
 	{
-		this.document = document;
 		this.edit = edit;
+		this.document = document;
 	}
 
 	public bool CanRedo => Pointer < history.Count - 1;

--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -32,6 +32,7 @@ namespace Pinta.Core;
 public sealed class DocumentHistory
 {
 	private readonly Document document;
+	private readonly EditActions edit;
 	private readonly List<BaseHistoryItem> history = [];
 	private int clean_pointer = -1;
 
@@ -39,9 +40,12 @@ public sealed class DocumentHistory
 	public event EventHandler? ActionUndone;
 	public event EventHandler? ActionRedone;
 
-	internal DocumentHistory (Document document)
+	internal DocumentHistory (
+		Document document,
+		EditActions edit)
 	{
 		this.document = document;
+		this.edit = edit;
 	}
 
 	public bool CanRedo => Pointer < history.Count - 1;
@@ -77,9 +81,9 @@ public sealed class DocumentHistory
 			document.IsDirty = true;
 
 		if (history.Count > 1)
-			PintaCore.Actions.Edit.Undo.Sensitive = true;
+			edit.Undo.Sensitive = true;
 
-		PintaCore.Actions.Edit.Redo.Sensitive = false;
+		edit.Redo.Sensitive = false;
 
 		HistoryItemAdded?.Invoke (this, new HistoryItemAddedEventArgs (newItem));
 	}
@@ -102,9 +106,9 @@ public sealed class DocumentHistory
 			document.IsDirty = false;
 
 		if (Pointer == 0)
-			PintaCore.Actions.Edit.Undo.Sensitive = false;
+			edit.Undo.Sensitive = false;
 
-		PintaCore.Actions.Edit.Redo.Sensitive = true;
+		edit.Redo.Sensitive = true;
 
 		ActionUndone?.Invoke (this, EventArgs.Empty);
 	}
@@ -121,7 +125,7 @@ public sealed class DocumentHistory
 		item.State = HistoryItemState.Undo;
 
 		if (Pointer == history.Count - 1)
-			PintaCore.Actions.Edit.Redo.Sensitive = false;
+			edit.Redo.Sensitive = false;
 
 		if (Pointer == clean_pointer)
 			document.IsDirty = false;
@@ -129,7 +133,7 @@ public sealed class DocumentHistory
 			document.IsDirty = true;
 
 		if (history.Count > 1)
-			PintaCore.Actions.Edit.Undo.Sensitive = true;
+			edit.Undo.Sensitive = true;
 
 		ActionRedone?.Invoke (this, EventArgs.Empty);
 	}
@@ -163,7 +167,7 @@ public sealed class DocumentHistory
 
 		document.IsDirty = false;
 
-		PintaCore.Actions.Edit.Redo.Sensitive = false;
-		PintaCore.Actions.Edit.Undo.Sensitive = false;
+		edit.Redo.Sensitive = false;
+		edit.Undo.Sensitive = false;
 	}
 }

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -52,7 +52,7 @@ public sealed class DocumentWorkspace
 
 		this.document = document;
 
-		History = new DocumentHistory (document, actions.Edit);
+		History = new DocumentHistory (actions.Edit, document);
 	}
 
 	#region Public Events

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -42,7 +42,7 @@ public sealed class DocumentWorkspace
 	internal DocumentWorkspace (Document document)
 	{
 		this.document = document;
-		History = new DocumentHistory (document);
+		History = new DocumentHistory (document, PintaCore.Actions.Edit);
 	}
 
 	#region Public Events

--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -31,7 +31,10 @@ namespace Pinta.Core;
 public sealed class DocumentWorkspace
 {
 	private readonly Document document;
-	private Size view_size;
+
+	private readonly ActionManager actions;
+	private readonly ToolManager tools;
+
 	private enum ZoomType
 	{
 		ZoomIn,
@@ -39,10 +42,17 @@ public sealed class DocumentWorkspace
 		ZoomManually,
 	}
 
-	internal DocumentWorkspace (Document document)
+	internal DocumentWorkspace (
+		ActionManager actions,
+		ToolManager tools,
+		Document document)
 	{
+		this.actions = actions;
+		this.tools = tools;
+
 		this.document = document;
-		History = new DocumentHistory (document, PintaCore.Actions.Edit);
+
+		History = new DocumentHistory (document, actions.Edit);
 	}
 
 	#region Public Events
@@ -60,10 +70,8 @@ public sealed class DocumentWorkspace
 	public bool ImageViewFitsInWindow {
 		get {
 			Gtk.Viewport view = (Gtk.Viewport) Canvas.Parent!;
-
 			int window_x = view.GetAllocatedWidth ();
 			int window_y = view.GetAllocatedHeight ();
-
 			return ViewSize.Width <= window_x && ViewSize.Height <= window_y;
 		}
 	}
@@ -74,13 +82,12 @@ public sealed class DocumentWorkspace
 	public Size ViewSize {
 		get => view_size;
 		set {
-			if (view_size == value)
-				return;
-
+			if (view_size == value) return;
 			view_size = value;
 			OnViewSizeChanged ();
 		}
 	}
+	private Size view_size;
 
 	public DocumentHistory History { get; }
 
@@ -90,10 +97,8 @@ public sealed class DocumentWorkspace
 	public bool ImageFitsInWindow {
 		get {
 			Gtk.Viewport view = (Gtk.Viewport) Canvas.Parent!;
-
 			int window_x = view.GetAllocatedWidth ();
 			int window_y = view.GetAllocatedHeight ();
-
 			return document.ImageSize.Width <= window_x && document.ImageSize.Height <= window_y;
 		}
 	}
@@ -120,9 +125,9 @@ public sealed class DocumentWorkspace
 
 			Invalidate ();
 
-			if (PintaCore.Tools.CurrentTool?.CursorChangesOnZoom == true) {
+			if (tools.CurrentTool?.CursorChangesOnZoom == true) {
 				//The current tool's cursor changes when the zoom changes.
-				PintaCore.Tools.CurrentTool.SetCursor (PintaCore.Tools.CurrentTool.DefaultCursor);
+				tools.CurrentTool.SetCursor (tools.CurrentTool.DefaultCursor);
 			}
 		}
 	}
@@ -158,11 +163,11 @@ public sealed class DocumentWorkspace
 	/// </param>
 	public void Invalidate (RectangleI canvasRect)
 	{
-		var canvasTopLeft = new PointD (canvasRect.Left, canvasRect.Top);
-		var canvasBtmRight = new PointD (canvasRect.Right + 1, canvasRect.Bottom + 1);
+		PointD canvasTopLeft = new PointD (canvasRect.Left, canvasRect.Top);
+		PointD canvasBtmRight = new PointD (canvasRect.Right + 1, canvasRect.Bottom + 1);
 
-		var winTopLeft = CanvasPointToView (canvasTopLeft);
-		var winBtmRight = CanvasPointToView (canvasBtmRight);
+		PointD winTopLeft = CanvasPointToView (canvasTopLeft);
+		PointD winBtmRight = CanvasPointToView (canvasBtmRight);
 
 		RectangleI winRect = CairoExtensions.PointsToRectangle (winTopLeft, winBtmRight).ToInt ();
 
@@ -301,7 +306,7 @@ public sealed class DocumentWorkspace
 			? document.ImageSize.Width / rect.Width
 			: document.ImageSize.Height / rect.Height;
 
-		PintaCore.Actions.View.ZoomComboBox.ComboBox.GetEntry ().SetText (ViewActions.ToPercent (ratio));
+		actions.View.ZoomComboBox.ComboBox.GetEntry ().SetText (ViewActions.ToPercent (ratio));
 		GLib.MainContext.Default ().Iteration (false); //Force update of scrollbar upper before recenter
 
 		PointD newPoint = new (
@@ -333,12 +338,12 @@ public sealed class DocumentWorkspace
 			return; //Can't zoom in past a 1x1 px canvas
 
 
-		if (!ViewActions.TryParsePercent (PintaCore.Actions.View.ZoomComboBox.ComboBox.GetActiveText ()!, out var zoom))
+		if (!ViewActions.TryParsePercent (actions.View.ZoomComboBox.ComboBox.GetActiveText ()!, out var zoom))
 			zoom = Scale * 100;
 
 		zoom = Math.Min (zoom, 3600);
 
-		PintaCore.Actions.View.SuspendZoomUpdate ();
+		actions.View.SuspendZoomUpdate ();
 
 		Gtk.Viewport view = (Gtk.Viewport) Canvas.Parent!;
 
@@ -349,10 +354,10 @@ public sealed class DocumentWorkspace
 				view.Vadjustment!.Value + (view.Vadjustment.PageSize / 2.0));
 		}
 
-		var scroll_offset_x = center_point.Value.X - view.Hadjustment!.Value - Offset.X;
-		var scroll_offset_y = center_point.Value.Y - view.Vadjustment!.Value - Offset.Y;
+		double scroll_offset_x = center_point.Value.X - view.Hadjustment!.Value - Offset.X;
+		double scroll_offset_y = center_point.Value.Y - view.Vadjustment!.Value - Offset.Y;
 
-		var canvas_point = ViewPointToCanvas (center_point.Value);
+		PointD canvas_point = ViewPointToCanvas (center_point.Value);
 
 		if (zoomType == ZoomType.ZoomIn || zoomType == ZoomType.ZoomOut) {
 
@@ -367,7 +372,7 @@ public sealed class DocumentWorkspace
 					case ZoomType.ZoomIn:
 
 						if (zoomInList == Translations.GetString ("Window") || zoom_level <= zoom) {
-							PintaCore.Actions.View.ZoomComboBox.ComboBox.Active = i - 1;
+							actions.View.ZoomComboBox.ComboBox.Active = i - 1;
 							return true;
 						}
 
@@ -379,7 +384,7 @@ public sealed class DocumentWorkspace
 							return true;
 
 						if (zoom_level < zoom) {
-							PintaCore.Actions.View.ZoomComboBox.ComboBox.Active = i;
+							actions.View.ZoomComboBox.ComboBox.Active = i;
 							return true;
 						}
 
@@ -388,7 +393,7 @@ public sealed class DocumentWorkspace
 				return false;
 			}
 
-			foreach (string item in PintaCore.Actions.View.ZoomCollection) {
+			foreach (string item in actions.View.ZoomCollection) {
 
 				if (UpdateZoomLevel (item))
 					break;
@@ -397,7 +402,7 @@ public sealed class DocumentWorkspace
 			}
 		}
 
-		PintaCore.Actions.View.UpdateCanvasScale ();
+		actions.View.UpdateCanvasScale ();
 
 		// Quick fix : need to manually update Upper limit because the value is not changing after updating the canvas scale.
 		// TODO : I think there is an event need to be fired so that those values updated automatically.
@@ -407,11 +412,11 @@ public sealed class DocumentWorkspace
 		// Scroll so that the canvas position under 'center_point' is still the same after zooming.
 		// Note that the canvas widget might not have resized yet, so using Offset is important for taking
 		// the size difference into account.
-		var new_center_point = CanvasPointToView (canvas_point);
+		PointD new_center_point = CanvasPointToView (canvas_point);
 		view.Hadjustment.Value = new_center_point.X - scroll_offset_x - Offset.X;
 		view.Vadjustment.Value = new_center_point.Y - scroll_offset_y - Offset.Y;
 
-		PintaCore.Actions.View.ResumeZoomUpdate ();
+		actions.View.ResumeZoomUpdate ();
 	}
 	#endregion
 }

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -46,7 +46,13 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 
 		Size imageSize = new (effectiveBuffer.Width, effectiveBuffer.Height);
 
-		Document newDocument = new (imageSize, file, filetype);
+		Document newDocument = new (
+			PintaCore.Actions,
+			PintaCore.Tools,
+			PintaCore.Workspace,
+			imageSize,
+			file,
+			filetype);
 
 		Layer layer = newDocument.Layers.AddNewLayer (file.GetDisplayName ());
 

--- a/Pinta.Core/ImageFormats/OraFormat.cs
+++ b/Pinta.Core/ImageFormats/OraFormat.cs
@@ -58,7 +58,13 @@ public sealed class OraFormat : IImageImporter, IImageExporter
 			Height: int.Parse (imageElement.GetAttribute ("h"))
 		);
 
-		Document newDocument = new (imageSize, file, "ora");
+		Document newDocument = new (
+			PintaCore.Actions,
+			PintaCore.Tools,
+			PintaCore.Workspace,
+			imageSize,
+			file,
+			"ora");
 
 		XmlElement stackElement = (XmlElement) stackXml.GetElementsByTagName ("stack")[0]!;
 		XmlNodeList layerElements = stackElement.GetElementsByTagName ("layer");

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -138,7 +138,7 @@ public static class WorkspaceServiceExtensions
 		Size imageSize,
 		Color backgroundColor)
 	{
-		Document doc = new (imageSize);
+		Document doc = new (PintaCore.Actions, PintaCore.Tools, PintaCore.Workspace, imageSize);
 		doc.Workspace.ViewSize = imageSize;
 		workspace.ActivateDocument (doc, actions);
 


### PR DESCRIPTION
This comes at the cost of introducing `PintaCore` references into `GdkPixbufFormat` and `OraFormat`, but they should be easy to remove from there once the refactoring of the services is complete