### PR TITLE
Added utility methods to easily create stacks of widgets

### DIFF
--- a/Pinta.Core/Extensions/Gtk/BoxStyle.cs
+++ b/Pinta.Core/Extensions/Gtk/BoxStyle.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace Pinta.Core;
 
-public sealed class StackStyle
+public sealed class BoxStyle
 {
-	public static StackStyle Horizontal { get; } = new (Gtk.Orientation.Horizontal);
-	public static StackStyle Vertical { get; } = new (Gtk.Orientation.Vertical);
+	public static BoxStyle Horizontal { get; } = new (Gtk.Orientation.Horizontal);
+	public static BoxStyle Vertical { get; } = new (Gtk.Orientation.Vertical);
 
 	// --- Mandatory
 	public Gtk.Orientation Orientation { get; }
@@ -14,7 +14,7 @@ public sealed class StackStyle
 	public int? Spacing { get; }
 	public string? CssClass { get; }
 
-	public StackStyle (
+	public BoxStyle (
 		Gtk.Orientation orientation,
 		int? spacing = null,
 		string? cssClass = null)

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -54,6 +54,22 @@ public static class AdwaitaStyles
 
 partial class GtkExtensions
 {
+	// TODO: Add argument for styling options
+	public static Gtk.Box Stack (ReadOnlySpan<Gtk.Widget> children) // TODO: Add 'params' keyword when updated to C#13
+	{
+		Gtk.Box stack = new ();
+		stack.AppendMultiple (children);
+		return stack;
+	}
+
+	public static void AppendMultiple (
+		this Gtk.Box box,
+		ReadOnlySpan<Gtk.Widget> children) // TODO: Add 'params' keyword when updated to C#13
+	{
+		foreach (var child in children)
+			box.Append (child);
+	}
+
 	/// <summary>
 	/// In GTK4, toolbars are just a Box with a different CSS style class.
 	/// </summary>
@@ -108,10 +124,10 @@ partial class GtkExtensions
 	}
 
 	public static Gtk.SpinButton CreateToolBarSpinButton (
-	double min,
-	double max,
-	double step,
-	double init_value)
+		double min,
+		double max,
+		double step,
+		double init_value)
 	{
 		Gtk.SpinButton spin = Gtk.SpinButton.NewWithRange (min, max, step);
 		spin.FocusOnClick = false;
@@ -119,8 +135,8 @@ partial class GtkExtensions
 		// After a spin button is edited, return focus to the canvas so that
 		// tools can handle subsequent key events.
 		spin.OnValueChanged += (o, e) => {
-			if (PintaCore.Workspace.HasOpenDocuments)
-				PintaCore.Workspace.ActiveWorkspace.GrabFocusToCanvas ();
+			if (!PintaCore.Workspace.HasOpenDocuments) return;
+			PintaCore.Workspace.ActiveWorkspace.GrabFocusToCanvas ();
 		};
 		return spin;
 	}

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -54,11 +54,26 @@ public static class AdwaitaStyles
 
 partial class GtkExtensions
 {
-	// TODO: Add argument for styling options
-	public static Gtk.Box Stack (ReadOnlySpan<Gtk.Widget> children) // TODO: Add 'params' keyword when updated to C#13
+	public static Gtk.Box StackHorizontal (ReadOnlySpan<Gtk.Widget> children)
+		=> Stack (StackStyle.Horizontal, children);
+
+	public static Gtk.Box StackVertical (ReadOnlySpan<Gtk.Widget> children)
+		=> Stack (StackStyle.Vertical, children);
+
+	public static Gtk.Box Stack (
+		StackStyle style,
+		ReadOnlySpan<Gtk.Widget> children) // TODO: Add 'params' keyword when updated to C#13
 	{
 		Gtk.Box stack = new ();
+
+		// --- Mandatory
+		stack.SetOrientation (style.Orientation);
+
+		// --- Optional
+		if (style.Spacing.HasValue) stack.Spacing = style.Spacing.Value;
+
 		stack.AppendMultiple (children);
+
 		return stack;
 	}
 

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -54,13 +54,13 @@ public static class AdwaitaStyles
 
 partial class GtkExtensions
 {
-	public static Gtk.Box StackHorizontal (ReadOnlySpan<Gtk.Widget> children)
-		=> Stack (StackStyle.Horizontal, children);
+	public static Gtk.Box BoxHorizontal (ReadOnlySpan<Gtk.Widget> children)
+		=> Box (StackStyle.Horizontal, children);
 
-	public static Gtk.Box StackVertical (ReadOnlySpan<Gtk.Widget> children)
-		=> Stack (StackStyle.Vertical, children);
+	public static Gtk.Box BoxVertical (ReadOnlySpan<Gtk.Widget> children)
+		=> Box (StackStyle.Vertical, children);
 
-	public static Gtk.Box Stack (
+	public static Gtk.Box Box (
 		StackStyle style,
 		ReadOnlySpan<Gtk.Widget> children) // TODO: Add 'params' keyword when updated to C#13
 	{

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -55,13 +55,13 @@ public static class AdwaitaStyles
 partial class GtkExtensions
 {
 	public static Gtk.Box BoxHorizontal (ReadOnlySpan<Gtk.Widget> children)
-		=> Box (StackStyle.Horizontal, children);
+		=> Box (BoxStyle.Horizontal, children);
 
 	public static Gtk.Box BoxVertical (ReadOnlySpan<Gtk.Widget> children)
-		=> Box (StackStyle.Vertical, children);
+		=> Box (BoxStyle.Vertical, children);
 
 	public static Gtk.Box Box (
-		StackStyle style,
+		BoxStyle style,
 		ReadOnlySpan<Gtk.Widget> children) // TODO: Add 'params' keyword when updated to C#13
 	{
 		Gtk.Box stack = new ();

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -71,6 +71,7 @@ partial class GtkExtensions
 
 		// --- Optional
 		if (style.Spacing.HasValue) stack.Spacing = style.Spacing.Value;
+		if (style.CssClass is not null) stack.AddCssClass (style.CssClass);
 
 		stack.AppendMultiple (children);
 

--- a/Pinta.Core/Extensions/Gtk/StackStyle.cs
+++ b/Pinta.Core/Extensions/Gtk/StackStyle.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Pinta.Core;
+
+public sealed class StackStyle
+{
+	public static StackStyle Horizontal { get; } = new (Gtk.Orientation.Horizontal);
+	public static StackStyle Vertical { get; } = new (Gtk.Orientation.Vertical);
+
+	// --- Mandatory
+	public Gtk.Orientation Orientation { get; }
+
+	// --- Optional
+	public int? Spacing { get; }
+
+	public StackStyle (
+		Gtk.Orientation orientation,
+		int? spacing = null)
+	{
+		if (spacing.HasValue && spacing.Value < 0) throw new ArgumentOutOfRangeException (nameof (spacing));
+		Orientation = orientation;
+		Spacing = spacing;
+	}
+}

--- a/Pinta.Core/Extensions/Gtk/StackStyle.cs
+++ b/Pinta.Core/Extensions/Gtk/StackStyle.cs
@@ -12,13 +12,16 @@ public sealed class StackStyle
 
 	// --- Optional
 	public int? Spacing { get; }
+	public string? CssClass { get; }
 
 	public StackStyle (
 		Gtk.Orientation orientation,
-		int? spacing = null)
+		int? spacing = null,
+		string? cssClass = null)
 	{
 		if (spacing.HasValue && spacing.Value < 0) throw new ArgumentOutOfRangeException (nameof (spacing));
 		Orientation = orientation;
 		Spacing = spacing;
+		CssClass = cssClass;
 	}
 }

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -98,7 +98,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 
 		Gtk.GestureClick clickController = CreateCurvesClickController ();
 
-		StackStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
+		BoxStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
 		Gtk.Box boxAbove = GtkExtensions.Box (
 			horizontalSpaced,
 			[

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using Cairo;
 using Pinta.Core;
+using Pinta.Gui.Widgets;
 
 namespace Pinta.Effects;
 
@@ -98,18 +99,19 @@ public sealed class CurvesDialog : Gtk.Dialog
 
 		Gtk.GestureClick clickController = CreateCurvesClickController ();
 
-		Gtk.Box boxAbove = new () { Spacing = SPACING };
+		Gtk.Box boxAbove = GtkExtensions.Stack ([
+			Gtk.Label.New (Translations.GetString ("Transfer Map")),
+			comboMap,
+			labelPoint]);
 		boxAbove.SetOrientation (Gtk.Orientation.Horizontal);
-		boxAbove.Append (Gtk.Label.New (Translations.GetString ("Transfer Map")));
-		boxAbove.Append (comboMap);
-		boxAbove.Append (labelPoint);
+		boxAbove.Spacing = SPACING;
 
-		Gtk.Box boxBelow = new ();
+		Gtk.Box boxBelow = GtkExtensions.Stack ([
+			checkRed,
+			checkGreen,
+			checkBlue,
+			buttonReset]);
 		boxBelow.SetOrientation (Gtk.Orientation.Horizontal);
-		boxBelow.Prepend (checkBlue);
-		boxBelow.Prepend (checkGreen);
-		boxBelow.Prepend (checkRed);
-		boxBelow.Append (buttonReset);
 
 		Gtk.DrawingArea curvesDrawing = new () {
 			WidthRequest = 256,
@@ -124,10 +126,11 @@ public sealed class CurvesDialog : Gtk.Dialog
 		Gtk.Box content_area = this.GetContentAreaBox ();
 		content_area.SetAllMargins (12);
 		content_area.Spacing = SPACING;
-		content_area.Append (boxAbove);
-		content_area.Append (curvesDrawing);
-		content_area.Append (boxBelow);
-		content_area.Append (labelTip);
+		content_area.AppendMultiple ([
+			boxAbove,
+			curvesDrawing,
+			boxBelow,
+			labelTip]);
 
 		// --- Gtk.Window initialization
 
@@ -398,7 +401,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 		for (int i = 0; i < channels; i++) {
 			result[i] = new () {
 				{ 0, 0 },
-				{ SIZE - 1, SIZE - 1 }
+				{ SIZE - 1, SIZE - 1 },
 			};
 		}
 

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -99,7 +99,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 		Gtk.GestureClick clickController = CreateCurvesClickController ();
 
 		StackStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
-		Gtk.Box boxAbove = GtkExtensions.Stack (
+		Gtk.Box boxAbove = GtkExtensions.Box (
 			horizontalSpaced,
 			[
 				Gtk.Label.New (Translations.GetString ("Transfer Map")),
@@ -108,7 +108,7 @@ public sealed class CurvesDialog : Gtk.Dialog
 			]
 		);
 
-		Gtk.Box boxBelow = GtkExtensions.StackHorizontal ([
+		Gtk.Box boxBelow = GtkExtensions.BoxHorizontal ([
 			checkRed,
 			checkGreen,
 			checkBlue,

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -28,7 +28,6 @@ using System;
 using System.Collections.Generic;
 using Cairo;
 using Pinta.Core;
-using Pinta.Gui.Widgets;
 
 namespace Pinta.Effects;
 
@@ -99,19 +98,21 @@ public sealed class CurvesDialog : Gtk.Dialog
 
 		Gtk.GestureClick clickController = CreateCurvesClickController ();
 
-		Gtk.Box boxAbove = GtkExtensions.Stack ([
-			Gtk.Label.New (Translations.GetString ("Transfer Map")),
-			comboMap,
-			labelPoint]);
-		boxAbove.SetOrientation (Gtk.Orientation.Horizontal);
-		boxAbove.Spacing = SPACING;
+		StackStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
+		Gtk.Box boxAbove = GtkExtensions.Stack (
+			horizontalSpaced,
+			[
+				Gtk.Label.New (Translations.GetString ("Transfer Map")),
+				comboMap,
+				labelPoint
+			]
+		);
 
-		Gtk.Box boxBelow = GtkExtensions.Stack ([
+		Gtk.Box boxBelow = GtkExtensions.StackHorizontal ([
 			checkRed,
 			checkGreen,
 			checkBlue,
 			buttonReset]);
-		boxBelow.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.DrawingArea curvesDrawing = new () {
 			WidthRequest = 256,

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -111,7 +111,7 @@ public partial class LevelsDialog : Gtk.Dialog
 		Gtk.CheckButton checkBlue = new () { Label = Translations.GetString ("Blue"), Active = true };
 		checkBlue.OnToggled += HandleCheckBlueToggled;
 
-		Gtk.Box hboxChecks = GtkExtensions.Stack (
+		Gtk.Box hboxChecks = GtkExtensions.Box (
 			horizontalSpaced,
 			[
 				checkRed,
@@ -174,7 +174,7 @@ public partial class LevelsDialog : Gtk.Dialog
 		HistogramWidget histogramInput = new () { WidthRequest = 130, FlipHorizontal = true };
 		HistogramWidget histogramOutput = new () { WidthRequest = 130 };
 
-		Gtk.Box vboxInput = GtkExtensions.Stack (
+		Gtk.Box vboxInput = GtkExtensions.Box (
 			verticalSpaced,
 			[
 				spinInHigh,
@@ -184,7 +184,7 @@ public partial class LevelsDialog : Gtk.Dialog
 			]
 		);
 
-		Gtk.Box hboxInput = GtkExtensions.Stack (
+		Gtk.Box hboxInput = GtkExtensions.Box (
 			horizontalSpaced,
 			[
 				vboxInput,
@@ -192,7 +192,7 @@ public partial class LevelsDialog : Gtk.Dialog
 			]
 		);
 
-		Gtk.Box vboxOutput = GtkExtensions.Stack (
+		Gtk.Box vboxOutput = GtkExtensions.Box (
 			verticalSpaced,
 			[
 				spinOutHigh,
@@ -204,7 +204,7 @@ public partial class LevelsDialog : Gtk.Dialog
 			]
 		);
 
-		Gtk.Box hboxOutput = GtkExtensions.Stack (
+		Gtk.Box hboxOutput = GtkExtensions.Box (
 			horizontalSpaced,
 			[
 				gradientOutput,
@@ -264,7 +264,7 @@ public partial class LevelsDialog : Gtk.Dialog
 		this.AddCancelOkButtons ();
 		this.SetDefaultResponse (Gtk.ResponseType.Ok);
 
-		Gtk.Box hboxLayout = GtkExtensions.Stack (
+		Gtk.Box hboxLayout = GtkExtensions.Box (
 			horizontalSpaced,
 			[
 				CreateLabelledWidget (histogram_input, Translations.GetString ("Input Histogram")),
@@ -290,7 +290,7 @@ public partial class LevelsDialog : Gtk.Dialog
 			Gtk.Label label_widget = Gtk.Label.New (label);
 			label_widget.Halign = Gtk.Align.Start;
 
-			Gtk.Box vbox = GtkExtensions.Stack (
+			Gtk.Box vbox = GtkExtensions.Box (
 				verticalSpaced,
 				[
 					label_widget,

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -97,7 +97,10 @@ public partial class LevelsDialog : Gtk.Dialog
 		IWorkspaceService workspace,
 		LevelsData effectData)
 	{
-		const int spacing = 6;
+		const int SPACING = 6;
+
+		StackStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
+		StackStyle verticalSpaced = new (Gtk.Orientation.Vertical, SPACING);
 
 		Gtk.CheckButton checkRed = new () { Label = Translations.GetString ("Red"), Active = true };
 		checkRed.OnToggled += HandleCheckRedToggled;
@@ -108,12 +111,14 @@ public partial class LevelsDialog : Gtk.Dialog
 		Gtk.CheckButton checkBlue = new () { Label = Translations.GetString ("Blue"), Active = true };
 		checkBlue.OnToggled += HandleCheckBlueToggled;
 
-		Gtk.Box hboxChecks = GtkExtensions.Stack ([
-			checkRed,
-			checkGreen,
-			checkBlue]);
-		hboxChecks.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxChecks.Spacing = spacing;
+		Gtk.Box hboxChecks = GtkExtensions.Stack (
+			horizontalSpaced,
+			[
+				checkRed,
+				checkGreen,
+				checkBlue
+			]
+		);
 
 		Gtk.SpinButton spinInLow = Gtk.SpinButton.NewWithRange (0, 254, 1);
 		spinInLow.OnValueChanged += HandleSpinInLowValueChanged;
@@ -169,35 +174,43 @@ public partial class LevelsDialog : Gtk.Dialog
 		HistogramWidget histogramInput = new () { WidthRequest = 130, FlipHorizontal = true };
 		HistogramWidget histogramOutput = new () { WidthRequest = 130 };
 
-		Gtk.Box vboxInput = GtkExtensions.Stack ([
-			spinInHigh,
-			colorPanelInHigh,
-			colorPanelInLow,
-			spinInLow]);
-		vboxInput.SetOrientation (Gtk.Orientation.Vertical);
-		vboxInput.Spacing = spacing;
+		Gtk.Box vboxInput = GtkExtensions.Stack (
+			verticalSpaced,
+			[
+				spinInHigh,
+				colorPanelInHigh,
+				colorPanelInLow,
+				spinInLow
+			]
+		);
 
-		Gtk.Box hboxInput = GtkExtensions.Stack ([
-			vboxInput,
-			gradientInput]);
-		hboxInput.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxInput.Spacing = spacing;
+		Gtk.Box hboxInput = GtkExtensions.Stack (
+			horizontalSpaced,
+			[
+				vboxInput,
+				gradientInput
+			]
+		);
 
-		Gtk.Box vboxOutput = GtkExtensions.Stack ([
-			spinOutHigh,
-			colorPanelOutHigh,
-			spinOutGamma,
-			colorPanelOutMid,
-			colorPanelOutLow,
-			spinOutLow]);
-		vboxOutput.SetOrientation (Gtk.Orientation.Vertical);
-		vboxOutput.Spacing = spacing;
+		Gtk.Box vboxOutput = GtkExtensions.Stack (
+			verticalSpaced,
+			[
+				spinOutHigh,
+				colorPanelOutHigh,
+				spinOutGamma,
+				colorPanelOutMid,
+				colorPanelOutLow,
+				spinOutLow
+			]
+		);
 
-		Gtk.Box hboxOutput = GtkExtensions.Stack ([
-			gradientOutput,
-			vboxOutput]);
-		hboxOutput.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxOutput.Spacing = spacing;
+		Gtk.Box hboxOutput = GtkExtensions.Stack (
+			horizontalSpaced,
+			[
+				gradientOutput,
+				vboxOutput
+			]
+		);
 
 		// --- References to keep
 
@@ -251,14 +264,16 @@ public partial class LevelsDialog : Gtk.Dialog
 		this.AddCancelOkButtons ();
 		this.SetDefaultResponse (Gtk.ResponseType.Ok);
 
-		Gtk.Box hboxLayout = GtkExtensions.Stack ([
-			CreateLabelledWidget (histogram_input, Translations.GetString ("Input Histogram")),
-			CreateLabelledWidget (hboxInput, Translations.GetString ("Input")),
-			CreateLabelledWidget (hboxOutput, Translations.GetString ("Output")),
-			CreateLabelledWidget (histogram_output, Translations.GetString ("Output Histogram"))]);
-		hboxLayout.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxLayout.SetAllMargins (spacing);
-		hboxLayout.Spacing = spacing;
+		Gtk.Box hboxLayout = GtkExtensions.Stack (
+			horizontalSpaced,
+			[
+				CreateLabelledWidget (histogram_input, Translations.GetString ("Input Histogram")),
+				CreateLabelledWidget (hboxInput, Translations.GetString ("Input")),
+				CreateLabelledWidget (hboxOutput, Translations.GetString ("Output")),
+				CreateLabelledWidget (histogram_output, Translations.GetString ("Output Histogram"))
+			]
+		);
+		hboxLayout.SetAllMargins (SPACING);
 
 		Gtk.Box contentArea = this.GetContentAreaBox ();
 		contentArea.Append (hboxLayout);
@@ -267,7 +282,7 @@ public partial class LevelsDialog : Gtk.Dialog
 		Reset ();
 		UpdateLevels ();
 
-		static Gtk.Box CreateLabelledWidget (Gtk.Widget widget, string label)
+		Gtk.Box CreateLabelledWidget (Gtk.Widget widget, string label)
 		{
 			widget.Vexpand = true;
 			widget.Valign = Gtk.Align.Fill;
@@ -275,11 +290,13 @@ public partial class LevelsDialog : Gtk.Dialog
 			Gtk.Label label_widget = Gtk.Label.New (label);
 			label_widget.Halign = Gtk.Align.Start;
 
-			Gtk.Box vbox = GtkExtensions.Stack ([
-				label_widget,
-				widget]);
-			vbox.SetOrientation (Gtk.Orientation.Vertical);
-			vbox.Spacing = spacing;
+			Gtk.Box vbox = GtkExtensions.Stack (
+				verticalSpaced,
+				[
+					label_widget,
+					widget
+				]
+			);
 
 			return vbox;
 		}

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -108,11 +108,12 @@ public partial class LevelsDialog : Gtk.Dialog
 		Gtk.CheckButton checkBlue = new () { Label = Translations.GetString ("Blue"), Active = true };
 		checkBlue.OnToggled += HandleCheckBlueToggled;
 
-		Gtk.Box hboxChecks = new () { Spacing = spacing };
+		Gtk.Box hboxChecks = GtkExtensions.Stack ([
+			checkRed,
+			checkGreen,
+			checkBlue]);
 		hboxChecks.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxChecks.Append (checkRed);
-		hboxChecks.Append (checkGreen);
-		hboxChecks.Append (checkBlue);
+		hboxChecks.Spacing = spacing;
 
 		Gtk.SpinButton spinInLow = Gtk.SpinButton.NewWithRange (0, 254, 1);
 		spinInLow.OnValueChanged += HandleSpinInLowValueChanged;
@@ -168,31 +169,35 @@ public partial class LevelsDialog : Gtk.Dialog
 		HistogramWidget histogramInput = new () { WidthRequest = 130, FlipHorizontal = true };
 		HistogramWidget histogramOutput = new () { WidthRequest = 130 };
 
-		Gtk.Box vboxInput = new () { Spacing = spacing };
+		Gtk.Box vboxInput = GtkExtensions.Stack ([
+			spinInHigh,
+			colorPanelInHigh,
+			colorPanelInLow,
+			spinInLow]);
 		vboxInput.SetOrientation (Gtk.Orientation.Vertical);
-		vboxInput.Append (spinInHigh);
-		vboxInput.Append (colorPanelInHigh);
-		vboxInput.Append (colorPanelInLow);
-		vboxInput.Append (spinInLow);
+		vboxInput.Spacing = spacing;
 
-		Gtk.Box hboxInput = new () { Spacing = spacing };
+		Gtk.Box hboxInput = GtkExtensions.Stack ([
+			vboxInput,
+			gradientInput]);
 		hboxInput.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxInput.Append (vboxInput);
-		hboxInput.Append (gradientInput);
+		hboxInput.Spacing = spacing;
 
-		Gtk.Box vboxOutput = new () { Spacing = spacing };
+		Gtk.Box vboxOutput = GtkExtensions.Stack ([
+			spinOutHigh,
+			colorPanelOutHigh,
+			spinOutGamma,
+			colorPanelOutMid,
+			colorPanelOutLow,
+			spinOutLow]);
 		vboxOutput.SetOrientation (Gtk.Orientation.Vertical);
-		vboxOutput.Append (spinOutHigh);
-		vboxOutput.Append (colorPanelOutHigh);
-		vboxOutput.Append (spinOutGamma);
-		vboxOutput.Append (colorPanelOutMid);
-		vboxOutput.Append (colorPanelOutLow);
-		vboxOutput.Append (spinOutLow);
+		vboxOutput.Spacing = spacing;
 
-		Gtk.Box hboxOutput = new () { Spacing = spacing };
+		Gtk.Box hboxOutput = GtkExtensions.Stack ([
+			gradientOutput,
+			vboxOutput]);
 		hboxOutput.SetOrientation (Gtk.Orientation.Horizontal);
-		hboxOutput.Append (gradientOutput);
-		hboxOutput.Append (vboxOutput);
+		hboxOutput.Spacing = spacing;
 
 		// --- References to keep
 
@@ -246,13 +251,14 @@ public partial class LevelsDialog : Gtk.Dialog
 		this.AddCancelOkButtons ();
 		this.SetDefaultResponse (Gtk.ResponseType.Ok);
 
-		Gtk.Box hboxLayout = new () { Spacing = spacing };
+		Gtk.Box hboxLayout = GtkExtensions.Stack ([
+			CreateLabelledWidget (histogram_input, Translations.GetString ("Input Histogram")),
+			CreateLabelledWidget (hboxInput, Translations.GetString ("Input")),
+			CreateLabelledWidget (hboxOutput, Translations.GetString ("Output")),
+			CreateLabelledWidget (histogram_output, Translations.GetString ("Output Histogram"))]);
 		hboxLayout.SetOrientation (Gtk.Orientation.Horizontal);
 		hboxLayout.SetAllMargins (spacing);
-		hboxLayout.Append (CreateLabelledWidget (histogram_input, Translations.GetString ("Input Histogram")));
-		hboxLayout.Append (CreateLabelledWidget (hboxInput, Translations.GetString ("Input")));
-		hboxLayout.Append (CreateLabelledWidget (hboxOutput, Translations.GetString ("Output")));
-		hboxLayout.Append (CreateLabelledWidget (histogram_output, Translations.GetString ("Output Histogram")));
+		hboxLayout.Spacing = spacing;
 
 		Gtk.Box contentArea = this.GetContentAreaBox ();
 		contentArea.Append (hboxLayout);
@@ -269,10 +275,11 @@ public partial class LevelsDialog : Gtk.Dialog
 			Gtk.Label label_widget = Gtk.Label.New (label);
 			label_widget.Halign = Gtk.Align.Start;
 
-			Gtk.Box vbox = new () { Spacing = spacing };
+			Gtk.Box vbox = GtkExtensions.Stack ([
+				label_widget,
+				widget]);
 			vbox.SetOrientation (Gtk.Orientation.Vertical);
-			vbox.Append (label_widget);
-			vbox.Append (widget);
+			vbox.Spacing = spacing;
 
 			return vbox;
 		}
@@ -288,7 +295,7 @@ public partial class LevelsDialog : Gtk.Dialog
 
 	private void UpdateInputHistogram ()
 	{
-		var doc = workspace.ActiveDocument;
+		Document doc = workspace.ActiveDocument;
 
 		ImageSurface surface = doc.Layers.CurrentUserLayer.Surface;
 		RectangleI rect = doc.Selection.SelectionPath.GetBounds ();
@@ -367,10 +374,9 @@ public partial class LevelsDialog : Gtk.Dialog
 		int count = 0, total = 0;
 
 		for (int c = 0; c < 3; c++) {
-			if (mask[c]) {
-				total += before[c];
-				count++;
-			}
+			if (!mask[c]) continue;
+			total += before[c];
+			count++;
 		}
 
 		if (count > 0)
@@ -421,10 +427,9 @@ public partial class LevelsDialog : Gtk.Dialog
 		float total = 0;
 
 		for (int c = 0; c < 3; c++) {
-			if (mask[c]) {
-				total += Levels.GetGamma (c);
-				count++;
-			}
+			if (!mask[c]) continue;
+			total += Levels.GetGamma (c);
+			count++;
 		}
 
 		if (count > 0)

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -99,8 +99,8 @@ public partial class LevelsDialog : Gtk.Dialog
 	{
 		const int SPACING = 6;
 
-		StackStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
-		StackStyle verticalSpaced = new (Gtk.Orientation.Vertical, SPACING);
+		BoxStyle horizontalSpaced = new (Gtk.Orientation.Horizontal, SPACING);
+		BoxStyle verticalSpaced = new (Gtk.Orientation.Vertical, SPACING);
 
 		Gtk.CheckButton checkRed = new () { Label = Translations.GetString ("Red"), Active = true };
 		checkRed.OnToggled += HandleCheckRedToggled;

--- a/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
@@ -57,19 +57,25 @@ public sealed class PosterizeDialog : Gtk.Dialog
 		this.AddCancelOkButtons ();
 		this.SetDefaultResponse (Gtk.ResponseType.Ok);
 
-		red_spinbox = CreateChannelSpinBox (Translations.GetString ("Red"));
-		green_spinbox = CreateChannelSpinBox (Translations.GetString ("Green"));
-		blue_spinbox = CreateChannelSpinBox (Translations.GetString ("Blue"));
-		link_button = CreateLinkButton ();
+		HScaleSpinButtonWidget redSpinbox = CreateChannelSpinBox (Translations.GetString ("Red"));
+		HScaleSpinButtonWidget greenSpinbox = CreateChannelSpinBox (Translations.GetString ("Green"));
+		HScaleSpinButtonWidget blueSpinbox = CreateChannelSpinBox (Translations.GetString ("Blue"));
+		Gtk.CheckButton linkButton = CreateLinkButton ();
+
+		red_spinbox = redSpinbox;
+		green_spinbox = greenSpinbox;
+		blue_spinbox = blueSpinbox;
+		link_button = linkButton;
 
 		Gtk.Box content_area = this.GetContentAreaBox ();
 		content_area.WidthRequest = 400;
 		content_area.SetAllMargins (6);
 		content_area.Spacing = 6;
-		content_area.Append (red_spinbox);
-		content_area.Append (green_spinbox);
-		content_area.Append (blue_spinbox);
-		content_area.Append (link_button);
+		content_area.AppendMultiple ([
+			redSpinbox,
+			greenSpinbox,
+			blueSpinbox,
+			linkButton]);
 	}
 
 	private static Gtk.CheckButton CreateLinkButton ()

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -61,22 +61,26 @@ internal sealed class AddinInfoView : Adw.Bin
 
 		Gtk.Switch enableSwitch = CreateEnableSwitch ();
 
-		Gtk.Box hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, 6);
+		Gtk.Box hbox = GtkExtensions.Stack ([
+			enableSwitch,
+			installButton,
+			updateButton,
+			infoButton,
+			uninstallButton]);
+		hbox.SetOrientation (Gtk.Orientation.Horizontal);
+		hbox.Spacing = 6;
 		hbox.AddCssClass (AdwaitaStyles.Toolbar);
-		hbox.Append (enableSwitch);
-		hbox.Append (installButton);
-		hbox.Append (updateButton);
-		hbox.Append (infoButton);
-		hbox.Append (uninstallButton);
 
-		Gtk.Box contentBox = Gtk.Box.New (Gtk.Orientation.Vertical, 10);
+		Gtk.Box contentBox = GtkExtensions.Stack ([
+			titleLabel,
+			versionLabel,
+			sizeLabel,
+			repoLabel,
+			descriptionLabel,
+			hbox]);
+		contentBox.SetOrientation (Gtk.Orientation.Vertical);
+		contentBox.Spacing = 10;
 		contentBox.SetAllMargins (10);
-		contentBox.Append (titleLabel);
-		contentBox.Append (versionLabel);
-		contentBox.Append (sizeLabel);
-		contentBox.Append (repoLabel);
-		contentBox.Append (descriptionLabel);
-		contentBox.Append (hbox);
 
 		Adw.ViewStack viewStack = Adw.ViewStack.New ();
 		viewStack.Add (emptyPage);
@@ -118,12 +122,10 @@ internal sealed class AddinInfoView : Adw.Bin
 
 	private Gtk.Switch CreateEnableSwitch ()
 	{
-		Gtk.Switch result = new () {
-			Visible = false
-		};
+		Gtk.Switch result = new () { Visible = false };
 		result.OnNotify += (o, e) => {
-			if (e.Pspec.GetName () == "active")
-				HandleEnableSwitched ();
+			if (e.Pspec.GetName () != "active") return;
+			HandleEnableSwitched ();
 		};
 		return result;
 	}

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -61,25 +61,35 @@ internal sealed class AddinInfoView : Adw.Bin
 
 		Gtk.Switch enableSwitch = CreateEnableSwitch ();
 
-		Gtk.Box hbox = GtkExtensions.Stack ([
-			enableSwitch,
-			installButton,
-			updateButton,
-			infoButton,
-			uninstallButton]);
-		hbox.SetOrientation (Gtk.Orientation.Horizontal);
-		hbox.Spacing = 6;
+		StackStyle spacedHorizontal = new (
+			orientation: Gtk.Orientation.Horizontal,
+			spacing: 6);
+		Gtk.Box hbox = GtkExtensions.Stack (
+			spacedHorizontal,
+			[
+				enableSwitch,
+				installButton,
+				updateButton,
+				infoButton,
+				uninstallButton
+			]
+		);
 		hbox.AddCssClass (AdwaitaStyles.Toolbar);
 
-		Gtk.Box contentBox = GtkExtensions.Stack ([
-			titleLabel,
-			versionLabel,
-			sizeLabel,
-			repoLabel,
-			descriptionLabel,
-			hbox]);
-		contentBox.SetOrientation (Gtk.Orientation.Vertical);
-		contentBox.Spacing = 10;
+		StackStyle spacedVertical = new (
+			orientation: Gtk.Orientation.Vertical,
+			spacing: 10);
+		Gtk.Box contentBox = GtkExtensions.Stack (
+			spacedVertical,
+			[
+				titleLabel,
+				versionLabel,
+				sizeLabel,
+				repoLabel,
+				descriptionLabel,
+				hbox
+			]
+		);
 		contentBox.SetAllMargins (10);
 
 		Adw.ViewStack viewStack = Adw.ViewStack.New ();

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -61,7 +61,7 @@ internal sealed class AddinInfoView : Adw.Bin
 
 		Gtk.Switch enableSwitch = CreateEnableSwitch ();
 
-		StackStyle spacedHorizontal = new (
+		BoxStyle spacedHorizontal = new (
 			orientation: Gtk.Orientation.Horizontal,
 			spacing: 6,
 			cssClass: AdwaitaStyles.Toolbar);
@@ -76,7 +76,7 @@ internal sealed class AddinInfoView : Adw.Bin
 			]
 		);
 
-		StackStyle spacedVertical = new (
+		BoxStyle spacedVertical = new (
 			orientation: Gtk.Orientation.Vertical,
 			spacing: 10);
 		Gtk.Box contentBox = GtkExtensions.Box (

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -63,7 +63,8 @@ internal sealed class AddinInfoView : Adw.Bin
 
 		StackStyle spacedHorizontal = new (
 			orientation: Gtk.Orientation.Horizontal,
-			spacing: 6);
+			spacing: 6,
+			cssClass: AdwaitaStyles.Toolbar);
 		Gtk.Box hbox = GtkExtensions.Stack (
 			spacedHorizontal,
 			[
@@ -74,7 +75,6 @@ internal sealed class AddinInfoView : Adw.Bin
 				uninstallButton
 			]
 		);
-		hbox.AddCssClass (AdwaitaStyles.Toolbar);
 
 		StackStyle spacedVertical = new (
 			orientation: Gtk.Orientation.Vertical,

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -65,7 +65,7 @@ internal sealed class AddinInfoView : Adw.Bin
 			orientation: Gtk.Orientation.Horizontal,
 			spacing: 6,
 			cssClass: AdwaitaStyles.Toolbar);
-		Gtk.Box hbox = GtkExtensions.Stack (
+		Gtk.Box hbox = GtkExtensions.Box (
 			spacedHorizontal,
 			[
 				enableSwitch,
@@ -79,7 +79,7 @@ internal sealed class AddinInfoView : Adw.Bin
 		StackStyle spacedVertical = new (
 			orientation: Gtk.Orientation.Vertical,
 			spacing: 10);
-		Gtk.Box contentBox = GtkExtensions.Stack (
+		Gtk.Box contentBox = GtkExtensions.Box (
 			spacedVertical,
 			[
 				titleLabel,

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -181,7 +181,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			[
 				layoutGrid,
 				orientationVbox,
-				backgroundVbox
+				backgroundVbox,
 			]
 		);
 
@@ -207,7 +207,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			spacedHorizontal,
 			[
 				optionsVbox,
-				previewVbox
+				previewVbox,
 			]
 		);
 

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -201,7 +201,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			previewBox]);
 
 		BoxStyle spacedHorizontal = new (
-			orientation: Gtk.Orientation.Vertical,
+			orientation: Gtk.Orientation.Horizontal,
 			spacing: 10);
 		Gtk.Box mainHbox = GtkExtensions.Box (
 			spacedHorizontal,

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -80,14 +80,14 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label widthLabel = CreateWidthLabel ();
 		Gtk.Entry widthEntry = CreateLengthEntry ();
 		Gtk.Label widthUnitsLabel = CreateUnitsLabel ();
-		Gtk.Box widthHbox = GtkExtensions.StackHorizontal ([
+		Gtk.Box widthHbox = GtkExtensions.BoxHorizontal ([
 			widthEntry,
 			widthUnitsLabel]);
 
 		Gtk.Label heightLabel = CreateHeightLabel ();
 		Gtk.Entry heightEntry = CreateLengthEntry ();
 		Gtk.Label heightUnitsLabel = CreateUnitsLabel ();
-		Gtk.Box heightHbox = GtkExtensions.StackHorizontal ([
+		Gtk.Box heightHbox = GtkExtensions.BoxHorizontal ([
 			heightEntry,
 			heightUnitsLabel]);
 
@@ -96,18 +96,18 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		Gtk.CheckButton portraitRadio = CreatePortraitRadio ();
 		Gtk.Image portraitImage = CreateOrientationIcon (Resources.Icons.OrientationPortrait);
-		Gtk.Box portraitHbox = GtkExtensions.StackHorizontal ([
+		Gtk.Box portraitHbox = GtkExtensions.BoxHorizontal ([
 			portraitImage,
 			portraitRadio]);
 
 		Gtk.CheckButton landscapeRadio = CreateLandscapeRadio (portraitRadio);
 		Gtk.Image landscapeImage = CreateOrientationIcon (Resources.Icons.OrientationLandscape);
 
-		Gtk.Box landscapeHbox = GtkExtensions.StackHorizontal ([
+		Gtk.Box landscapeHbox = GtkExtensions.BoxHorizontal ([
 			landscapeImage,
 			landscapeRadio]);
 
-		Gtk.Box orientationVbox = GtkExtensions.StackVertical ([
+		Gtk.Box orientationVbox = GtkExtensions.BoxVertical ([
 			orientationLabel,
 			portraitHbox,
 			landscapeHbox]);
@@ -120,7 +120,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageWhite = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 		imageWhite.MarginEnd = 7;
 
-		Gtk.Box hboxWhite = GtkExtensions.StackHorizontal ([
+		Gtk.Box hboxWhite = GtkExtensions.BoxHorizontal ([
 			imageWhite,
 			whiteBackgroundRadio]);
 
@@ -130,7 +130,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, palette.SecondaryColor).ToPixbuf ());
 		imageBackground.MarginEnd = 7;
 
-		Gtk.Box hboxBackground = GtkExtensions.StackHorizontal ([
+		Gtk.Box hboxBackground = GtkExtensions.BoxHorizontal ([
 			imageBackground,
 			secondaryBackgroundRadio]);
 
@@ -140,7 +140,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageTransparent = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		imageTransparent.MarginEnd = 7;
 
-		Gtk.Box hboxTransparent = GtkExtensions.StackHorizontal ([
+		Gtk.Box hboxTransparent = GtkExtensions.BoxHorizontal ([
 			imageTransparent,
 			transparentBackgroundRadio]);
 
@@ -156,7 +156,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		}
 
 		var backgroundBoxItems = GenerateBackgroundBoxItems ().ToArray ();
-		Gtk.Box backgroundVbox = GtkExtensions.StackVertical (backgroundBoxItems);
+		Gtk.Box backgroundVbox = GtkExtensions.BoxVertical (backgroundBoxItems);
 		backgroundVbox.MarginTop = 4;
 
 		// Layout table for preset, width, and height
@@ -176,7 +176,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		StackStyle spacedVertical = new (
 			orientation: Gtk.Orientation.Vertical,
 			spacing: 10);
-		Gtk.Box optionsVbox = GtkExtensions.Stack (
+		Gtk.Box optionsVbox = GtkExtensions.Box (
 			spacedVertical,
 			[
 				layoutGrid,
@@ -196,14 +196,14 @@ public sealed class NewImageDialog : Gtk.Dialog
 			Halign = Gtk.Align.Fill,
 		};
 
-		Gtk.Box previewVbox = GtkExtensions.StackVertical ([
+		Gtk.Box previewVbox = GtkExtensions.BoxVertical ([
 			previewLabel,
 			previewBox]);
 
 		StackStyle spacedHorizontal = new (
 			orientation: Gtk.Orientation.Vertical,
 			spacing: 10);
-		Gtk.Box mainHbox = GtkExtensions.Stack (
+		Gtk.Box mainHbox = GtkExtensions.Box (
 			spacedHorizontal,
 			[
 				optionsVbox,

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -80,45 +80,37 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label widthLabel = CreateWidthLabel ();
 		Gtk.Entry widthEntry = CreateLengthEntry ();
 		Gtk.Label widthUnitsLabel = CreateUnitsLabel ();
-
-		Gtk.Box widthHbox = GtkExtensions.Stack ([
+		Gtk.Box widthHbox = GtkExtensions.StackHorizontal ([
 			widthEntry,
 			widthUnitsLabel]);
-		widthHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.Label heightLabel = CreateHeightLabel ();
 		Gtk.Entry heightEntry = CreateLengthEntry ();
 		Gtk.Label heightUnitsLabel = CreateUnitsLabel ();
-
-		Gtk.Box heightHbox = GtkExtensions.Stack ([
+		Gtk.Box heightHbox = GtkExtensions.StackHorizontal ([
 			heightEntry,
 			heightUnitsLabel]);
-		heightHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
 		// Orientation Radio options
 		Gtk.Label orientationLabel = CreateOrientationLabel ();
 
 		Gtk.CheckButton portraitRadio = CreatePortraitRadio ();
 		Gtk.Image portraitImage = CreateOrientationIcon (Resources.Icons.OrientationPortrait);
-
-		Gtk.Box portraitHbox = GtkExtensions.Stack ([
+		Gtk.Box portraitHbox = GtkExtensions.StackHorizontal ([
 			portraitImage,
 			portraitRadio]);
-		portraitHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.CheckButton landscapeRadio = CreateLandscapeRadio (portraitRadio);
 		Gtk.Image landscapeImage = CreateOrientationIcon (Resources.Icons.OrientationLandscape);
 
-		Gtk.Box landscapeHbox = GtkExtensions.Stack ([
+		Gtk.Box landscapeHbox = GtkExtensions.StackHorizontal ([
 			landscapeImage,
 			landscapeRadio]);
-		landscapeHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
-		Gtk.Box orientationVbox = GtkExtensions.Stack ([
+		Gtk.Box orientationVbox = GtkExtensions.StackVertical ([
 			orientationLabel,
 			portraitHbox,
 			landscapeHbox]);
-		orientationVbox.SetOrientation (Gtk.Orientation.Vertical);
 
 		// Background Color options
 		Gtk.Label backgroundLabel = CreateBackgroundLabel ();
@@ -128,10 +120,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageWhite = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 		imageWhite.MarginEnd = 7;
 
-		Gtk.Box hboxWhite = GtkExtensions.Stack ([
+		Gtk.Box hboxWhite = GtkExtensions.StackHorizontal ([
 			imageWhite,
 			whiteBackgroundRadio]);
-		hboxWhite.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.CheckButton secondaryBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
 		secondaryBackgroundRadio.SetGroup (whiteBackgroundRadio);
@@ -139,10 +130,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, palette.SecondaryColor).ToPixbuf ());
 		imageBackground.MarginEnd = 7;
 
-		Gtk.Box hboxBackground = GtkExtensions.Stack ([
+		Gtk.Box hboxBackground = GtkExtensions.StackHorizontal ([
 			imageBackground,
 			secondaryBackgroundRadio]);
-		hboxBackground.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.CheckButton transparentBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
 		transparentBackgroundRadio.SetGroup (secondaryBackgroundRadio);
@@ -150,10 +140,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageTransparent = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		imageTransparent.MarginEnd = 7;
 
-		Gtk.Box hboxTransparent = GtkExtensions.Stack ([
+		Gtk.Box hboxTransparent = GtkExtensions.StackHorizontal ([
 			imageTransparent,
 			transparentBackgroundRadio]);
-		hboxTransparent.SetOrientation (Gtk.Orientation.Horizontal);
 
 		IEnumerable<Gtk.Widget> GenerateBackgroundBoxItems ()
 		{
@@ -167,8 +156,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		}
 
 		var backgroundBoxItems = GenerateBackgroundBoxItems ().ToArray ();
-		Gtk.Box backgroundVbox = GtkExtensions.Stack (backgroundBoxItems);
-		backgroundVbox.SetOrientation (Gtk.Orientation.Vertical);
+		Gtk.Box backgroundVbox = GtkExtensions.StackVertical (backgroundBoxItems);
 		backgroundVbox.MarginTop = 4;
 
 		// Layout table for preset, width, and height
@@ -185,12 +173,17 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layoutGrid.Attach (heightHbox, 1, 2, 1, 1);
 
 		// Put all the options together
-		Gtk.Box optionsVbox = GtkExtensions.Stack ([
-			layoutGrid,
-			orientationVbox,
-			backgroundVbox]);
-		optionsVbox.SetOrientation (Gtk.Orientation.Vertical);
-		optionsVbox.Spacing = 10;
+		StackStyle spacedVertical = new (
+			orientation: Gtk.Orientation.Vertical,
+			spacing: 10);
+		Gtk.Box optionsVbox = GtkExtensions.Stack (
+			spacedVertical,
+			[
+				layoutGrid,
+				orientationVbox,
+				backgroundVbox
+			]
+		);
 
 		// Layout the preview + the options
 
@@ -203,16 +196,20 @@ public sealed class NewImageDialog : Gtk.Dialog
 			Halign = Gtk.Align.Fill,
 		};
 
-		Gtk.Box previewVbox = GtkExtensions.Stack ([
+		Gtk.Box previewVbox = GtkExtensions.StackVertical ([
 			previewLabel,
 			previewBox]);
-		previewVbox.SetOrientation (Gtk.Orientation.Vertical);
 
-		Gtk.Box mainHbox = GtkExtensions.Stack ([
-			optionsVbox,
-			previewVbox]);
-		mainHbox.SetOrientation (Gtk.Orientation.Horizontal);
-		mainHbox.Spacing = 10;
+		StackStyle spacedHorizontal = new (
+			orientation: Gtk.Orientation.Vertical,
+			spacing: 10);
+		Gtk.Box mainHbox = GtkExtensions.Stack (
+			spacedHorizontal,
+			[
+				optionsVbox,
+				previewVbox
+			]
+		);
 
 		Gtk.Box contentArea = this.GetContentAreaBox ();
 		contentArea.SetAllMargins (8);

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -414,14 +414,15 @@ public sealed class NewImageDialog : Gtk.Dialog
 	private Size SelectedPresetSize {
 		get {
 			string text = preset_dropdown_model.GetString (preset_dropdown.Selected)!;
+
 			if (text == Translations.GetString ("Clipboard") || text == Translations.GetString ("Custom"))
 				return Size.Empty;
 
 			string[] textParts = text.Split (' ');
-			int width = int.Parse (textParts[0]);
-			int height = int.Parse (textParts[2]);
 
-			return new (width, height);
+			return new (
+				int.Parse (textParts[0]),
+				int.Parse (textParts[2]));
 		}
 	}
 

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -173,7 +173,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layoutGrid.Attach (heightHbox, 1, 2, 1, 1);
 
 		// Put all the options together
-		StackStyle spacedVertical = new (
+		BoxStyle spacedVertical = new (
 			orientation: Gtk.Orientation.Vertical,
 			spacing: 10);
 		Gtk.Box optionsVbox = GtkExtensions.Box (
@@ -200,7 +200,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 			previewLabel,
 			previewBox]);
 
-		StackStyle spacedHorizontal = new (
+		BoxStyle spacedHorizontal = new (
 			orientation: Gtk.Orientation.Vertical,
 			spacing: 10);
 		Gtk.Box mainHbox = GtkExtensions.Box (

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -80,25 +80,45 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Label widthLabel = CreateWidthLabel ();
 		Gtk.Entry widthEntry = CreateLengthEntry ();
 		Gtk.Label widthUnitsLabel = CreateUnitsLabel ();
-		Gtk.Box widthHbox = CreateHorizontalBox (0, widthEntry, widthUnitsLabel);
+
+		Gtk.Box widthHbox = GtkExtensions.Stack ([
+			widthEntry,
+			widthUnitsLabel]);
+		widthHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.Label heightLabel = CreateHeightLabel ();
 		Gtk.Entry heightEntry = CreateLengthEntry ();
 		Gtk.Label heightUnitsLabel = CreateUnitsLabel ();
-		Gtk.Box heightHbox = CreateHorizontalBox (0, heightEntry, heightUnitsLabel);
+
+		Gtk.Box heightHbox = GtkExtensions.Stack ([
+			heightEntry,
+			heightUnitsLabel]);
+		heightHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
 		// Orientation Radio options
 		Gtk.Label orientationLabel = CreateOrientationLabel ();
 
 		Gtk.CheckButton portraitRadio = CreatePortraitRadio ();
 		Gtk.Image portraitImage = CreateOrientationIcon (Resources.Icons.OrientationPortrait);
-		Gtk.Box portraitHbox = CreateHorizontalBox (0, portraitImage, portraitRadio);
+
+		Gtk.Box portraitHbox = GtkExtensions.Stack ([
+			portraitImage,
+			portraitRadio]);
+		portraitHbox.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.CheckButton landscapeRadio = CreateLandscapeRadio (portraitRadio);
 		Gtk.Image landscapeImage = CreateOrientationIcon (Resources.Icons.OrientationLandscape);
-		Gtk.Box landscapeHbox = CreateHorizontalBox (0, landscapeImage, landscapeRadio);
 
-		Gtk.Box orientationVbox = CreateVerticalBox (0, orientationLabel, portraitHbox, landscapeHbox);
+		Gtk.Box landscapeHbox = GtkExtensions.Stack ([
+			landscapeImage,
+			landscapeRadio]);
+		landscapeHbox.SetOrientation (Gtk.Orientation.Horizontal);
+
+		Gtk.Box orientationVbox = GtkExtensions.Stack ([
+			orientationLabel,
+			portraitHbox,
+			landscapeHbox]);
+		orientationVbox.SetOrientation (Gtk.Orientation.Vertical);
 
 		// Background Color options
 		Gtk.Label backgroundLabel = CreateBackgroundLabel ();
@@ -108,7 +128,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageWhite = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, new Cairo.Color (1, 1, 1)).ToPixbuf ());
 		imageWhite.MarginEnd = 7;
 
-		Gtk.Box hboxWhite = CreateHorizontalBox (0, imageWhite, whiteBackgroundRadio);
+		Gtk.Box hboxWhite = GtkExtensions.Stack ([
+			imageWhite,
+			whiteBackgroundRadio]);
+		hboxWhite.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.CheckButton secondaryBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Background Color"));
 		secondaryBackgroundRadio.SetGroup (whiteBackgroundRadio);
@@ -116,7 +139,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageBackground = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateColorSwatch (16, palette.SecondaryColor).ToPixbuf ());
 		imageBackground.MarginEnd = 7;
 
-		Gtk.Box hboxBackground = CreateHorizontalBox (0, imageBackground, secondaryBackgroundRadio);
+		Gtk.Box hboxBackground = GtkExtensions.Stack ([
+			imageBackground,
+			secondaryBackgroundRadio]);
+		hboxBackground.SetOrientation (Gtk.Orientation.Horizontal);
 
 		Gtk.CheckButton transparentBackgroundRadio = Gtk.CheckButton.NewWithLabel (Translations.GetString ("Transparent"));
 		transparentBackgroundRadio.SetGroup (secondaryBackgroundRadio);
@@ -124,7 +150,10 @@ public sealed class NewImageDialog : Gtk.Dialog
 		Gtk.Image imageTransparent = Gtk.Image.NewFromPixbuf (CairoExtensions.CreateTransparentColorSwatch (16, true).ToPixbuf ());
 		imageTransparent.MarginEnd = 7;
 
-		Gtk.Box hboxTransparent = CreateHorizontalBox (0, imageTransparent, transparentBackgroundRadio);
+		Gtk.Box hboxTransparent = GtkExtensions.Stack ([
+			imageTransparent,
+			transparentBackgroundRadio]);
+		hboxTransparent.SetOrientation (Gtk.Orientation.Horizontal);
 
 		IEnumerable<Gtk.Widget> GenerateBackgroundBoxItems ()
 		{
@@ -137,7 +166,9 @@ public sealed class NewImageDialog : Gtk.Dialog
 			yield return hboxTransparent;
 		}
 
-		Gtk.Box backgroundVbox = CreateVerticalBox (0, GenerateBackgroundBoxItems ());
+		var backgroundBoxItems = GenerateBackgroundBoxItems ().ToArray ();
+		Gtk.Box backgroundVbox = GtkExtensions.Stack (backgroundBoxItems);
+		backgroundVbox.SetOrientation (Gtk.Orientation.Vertical);
 		backgroundVbox.MarginTop = 4;
 
 		// Layout table for preset, width, and height
@@ -154,7 +185,12 @@ public sealed class NewImageDialog : Gtk.Dialog
 		layoutGrid.Attach (heightHbox, 1, 2, 1, 1);
 
 		// Put all the options together
-		Gtk.Box optionsVbox = CreateVerticalBox (10, layoutGrid, orientationVbox, backgroundVbox);
+		Gtk.Box optionsVbox = GtkExtensions.Stack ([
+			layoutGrid,
+			orientationVbox,
+			backgroundVbox]);
+		optionsVbox.SetOrientation (Gtk.Orientation.Vertical);
+		optionsVbox.Spacing = 10;
 
 		// Layout the preview + the options
 
@@ -167,9 +203,16 @@ public sealed class NewImageDialog : Gtk.Dialog
 			Halign = Gtk.Align.Fill,
 		};
 
-		Gtk.Box previewVbox = CreateVerticalBox (0, previewLabel, previewBox);
+		Gtk.Box previewVbox = GtkExtensions.Stack ([
+			previewLabel,
+			previewBox]);
+		previewVbox.SetOrientation (Gtk.Orientation.Vertical);
 
-		Gtk.Box mainHbox = CreateHorizontalBox (10, optionsVbox, previewVbox);
+		Gtk.Box mainHbox = GtkExtensions.Stack ([
+			optionsVbox,
+			previewVbox]);
+		mainHbox.SetOrientation (Gtk.Orientation.Horizontal);
+		mainHbox.Spacing = 10;
 
 		Gtk.Box contentArea = this.GetContentAreaBox ();
 		contentArea.SetAllMargins (8);
@@ -231,48 +274,6 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		previewBox.Update (NewImageSize, NewImageBackground);
 	}
-
-	private static Gtk.Box CreateHorizontalBox (
-		int spacing,
-		Gtk.Widget w1,
-		Gtk.Widget w2)
-	{
-		Gtk.Box hbox = Gtk.Box.New (Gtk.Orientation.Horizontal, spacing);
-		hbox.Append (w1);
-		hbox.Append (w2);
-		return hbox;
-	}
-
-	private static Gtk.Box CreateVerticalBox (
-		int spacing,
-		Gtk.Widget w1,
-		Gtk.Widget w2)
-	{
-		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, spacing);
-		vbox.Append (w1);
-		vbox.Append (w2);
-		return vbox;
-	}
-
-	private static Gtk.Box CreateVerticalBox (
-		int spacing,
-		IEnumerable<Gtk.Widget> children)
-	{
-		Gtk.Box vbox = Gtk.Box.New (Gtk.Orientation.Vertical, spacing);
-
-		foreach (var child in children)
-			vbox.Append (child);
-
-		return vbox;
-	}
-
-	private static Gtk.Box CreateVerticalBox (
-		int spacing,
-		params Gtk.Widget[] children
-	)
-		=> CreateVerticalBox (
-			spacing,
-			(IEnumerable<Gtk.Widget>) children);
 
 	private static Gtk.Label CreateUnitsLabel ()
 	{


### PR DESCRIPTION
For a conservative version of these changes (only a `Stack` method, and all other configuration being applied later, separately), look at the first commit only.

For a more 'daring' version (an extra argument of a custom type, for configurong the style), look at the combined diff.