### PR TITLE
Categorized more methods in `GtkExtensions`

### DIFF
--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Application.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Application.cs
@@ -31,9 +31,13 @@ namespace Pinta.Core;
 
 partial class GtkExtensions
 {
-	public static void AddAction (
-		this Gtk.Application app,
-		Command action)
+	/// <summary>
+	/// Helper function to return the icon theme for the default display.
+	/// </summary>
+	public static Gtk.IconTheme GetDefaultIconTheme ()
+		=> Gtk.IconTheme.GetForDisplay (Gdk.Display.GetDefault ()!);
+
+	public static void AddAction (this Gtk.Application app, Command action)
 	{
 		app.AddAction (action.Action);
 	}

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Data.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Data.cs
@@ -1,0 +1,25 @@
+namespace Pinta.Core;
+
+partial class GtkExtensions
+{
+	/// <summary>
+	/// Find the index of a string in a Gtk.StringList.
+	/// </summary>
+	public static bool FindString (
+		this Gtk.StringList list,
+		string s,
+		out uint index)
+	{
+		for (uint i = 0, n = list.GetNItems (); i < n; ++i) {
+
+			if (list.GetString (i) != s)
+				continue;
+
+			index = i;
+			return true;
+		}
+
+		index = 0;
+		return false;
+	}
+}

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.External.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.External.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Pinta.Core;
+
+partial class GtkExtensions
+{
+	// TODO-GTK4 (bindings, unsubmitted) - need support for 'out' enum parameters.
+	[LibraryImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_accelerator_parse")]
+	[return: MarshalAs (UnmanagedType.Bool)]
+	private static partial bool AcceleratorParse (
+		[MarshalAs (UnmanagedType.LPUTF8Str)] string accelerator,
+		out uint accelerator_key,
+		out Gdk.ModifierType accelerator_mods);
+
+	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
+	[StructLayout (LayoutKind.Sequential)]
+	private struct GdkRGBA
+	{
+		public float Red;
+		public float Green;
+		public float Blue;
+		public float Alpha;
+	}
+
+	[LibraryImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_style_context_get_color")]
+	private static partial void StyleContextGetColor (IntPtr handle, out GdkRGBA color);
+
+	[LibraryImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_color_chooser_get_rgba")]
+	private static partial void ColorChooserGetRgba (
+		IntPtr handle,
+		out GdkRGBA color);
+
+	// Manual binding for GetPreeditString
+	// TODO-GTK4 (bindings) - missing from gir.core: "opaque record parameter 'attrs' with direction != in not yet supported"
+	[DllImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_im_context_get_preedit_string")]
+	private static extern void IMContextGetPreeditString (
+		IntPtr handle,
+		out GLib.Internal.NonNullableUtf8StringOwnedHandle str,
+		out Pango.Internal.AttrListOwnedHandle attrs,
+		out int cursor_pos);
+}

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Interaction.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Interaction.cs
@@ -1,0 +1,111 @@
+using GObject;
+
+namespace Pinta.Core;
+
+partial class GtkExtensions
+{
+	public sealed class SelectionChangedSignalArgs : SignalArgs
+	{
+		public uint Position => Args[1].GetUint ();
+		public uint NItems => Args[2].GetUint ();
+
+	}
+
+	/// <summary>
+	/// Convert from GetCurrentButton to the MouseButton enum.
+	/// </summary>
+	public static MouseButton GetCurrentMouseButton (this Gtk.GestureClick gesture)
+	{
+		uint button = gesture.GetCurrentButton ();
+		return button switch {
+			MOUSE_LEFT_BUTTON => MouseButton.Left,
+			MOUSE_MIDDLE_BUTTON => MouseButton.Middle,
+			MOUSE_RIGHT_BUTTON => MouseButton.Right,
+			_ => MouseButton.None
+		};
+	}
+
+	/// <summary>
+	/// Convert the "<Primary>" accelerator to the Ctrl or Command key, depending on the platform.
+	/// This was done automatically in GTK3, but does not happen in GTK4.
+	/// </summary>
+	private static string ConvertPrimaryKey (this SystemManager system, string accel) =>
+		accel.Replace ("<Primary>", system.OperatingSystem == OS.Mac ? "<Meta>" : "<Control>");
+
+	/// <summary>
+	/// Returns the platform-specific label for the "Primary" (Ctrl) key.
+	/// For example, this is the Cmd key on macOS.
+	/// </summary>
+	public static string CtrlLabel (this SystemManager system)
+	{
+		AcceleratorParse (
+			system.ConvertPrimaryKey ("<Primary>"),
+			out var key,
+			out var mods);
+
+		return Gtk.Functions.AcceleratorGetLabel (key, mods);
+	}
+
+	/// <summary>
+	/// Returns the platform-specific label for the Alt key.
+	/// For example, this is the Option key on macOS.
+	/// </summary>
+	public static string AltLabel ()
+	{
+		AcceleratorParse ("<Alt>", out var key, out var mods);
+		return Gtk.Functions.AcceleratorGetLabel (key, mods);
+	}
+
+	/// <summary>
+	/// Provides convenient access to the Gdk.Key of the key being pressed.
+	/// </summary>
+	public static Gdk.Key GetKey (this Gtk.EventControllerKey.KeyPressedSignalArgs args)
+		=> new Gdk.Key (args.Keyval);
+
+	/// <summary>
+	/// Provides convenient access to the Gdk.Key of the key being released.
+	/// </summary>
+	public static Gdk.Key GetKey (this Gtk.EventControllerKey.KeyReleasedSignalArgs args)
+		=> new Gdk.Key (args.Keyval);
+
+	private static readonly Signal<Gtk.Entry> EntryChangedSignal = new (
+		unmanagedName: "changed",
+		managedName: string.Empty
+	);
+
+	// TODO-GTK4 (bindings) - the Gtk.Editable::changed signal is not generated (https://github.com/gircore/gir.core/issues/831)
+	public static void OnChanged (this Gtk.Entry o, SignalHandler<Gtk.Entry> handler)
+	{
+		EntryChangedSignal.Connect (o, handler);
+	}
+
+	private static readonly Signal<Gtk.SingleSelection, SelectionChangedSignalArgs> SelectionChangedSignal = new (
+		unmanagedName: "selection-changed",
+		managedName: string.Empty
+	);
+
+	// TODO-GTK4 (bindings) - the Gtk.SelectionModel::selection-changed signal is not generated (https://github.com/gircore/gir.core/issues/831)
+	public static void OnSelectionChanged (
+		this Gtk.SingleSelection o,
+		SignalHandler<Gtk.SingleSelection, SelectionChangedSignalArgs> handler)
+	{
+		SelectionChangedSignal.Connect (o, handler);
+	}
+
+	public static void GetPreeditString (
+		this Gtk.IMContext context,
+		out string str,
+		out Pango.AttrList attrs,
+		out int cursor_pos)
+	{
+		IMContextGetPreeditString (
+			context.Handle.DangerousGetHandle (),
+			out var str_handle,
+			out var attrs_handle,
+			out cursor_pos);
+
+		str = str_handle.ConvertToString ();
+		str_handle.Dispose ();
+		attrs = new Pango.AttrList (attrs_handle);
+	}
+}

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.cs
@@ -24,211 +24,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using GObject;
-
 namespace Pinta.Core;
 
 public static partial class GtkExtensions
 {
-	private const string GtkLibraryName = "Gtk";
+	private const string GTK_LIBRARY_NAME = "Gtk";
 
-	static GtkExtensions ()
-	{
-		NativeImportResolver.RegisterLibrary (
-
-			library: GtkLibraryName,
-
-			windowsLibraryName: "libgtk-4-1.dll",
-			linuxLibraryName: "libgtk-4.so.1",
-			osxLibraryName: "libgtk-4.1.dylib"
-		);
-	}
-
-	public const uint MouseLeftButton = 1;
-	public const uint MouseMiddleButton = 2;
-	public const uint MouseRightButton = 3;
-
-	/// <summary>
-	/// Convert from GetCurrentButton to the MouseButton enum.
-	/// </summary>
-	public static MouseButton GetCurrentMouseButton (this Gtk.GestureClick gesture)
-	{
-		uint button = gesture.GetCurrentButton ();
-		return button switch {
-			MouseLeftButton => MouseButton.Left,
-			MouseMiddleButton => MouseButton.Middle,
-			MouseRightButton => MouseButton.Right,
-			_ => MouseButton.None
-		};
-	}
+	public const uint MOUSE_LEFT_BUTTON = 1;
+	public const uint MOUSE_MIDDLE_BUTTON = 2;
+	public const uint MOUSE_RIGHT_BUTTON = 3;
 
 	// TODO-GTK4 (bindings) - add pre-defined VariantType's to gir.core (https://github.com/gircore/gir.core/issues/843)
 	public static readonly GLib.VariantType IntVariantType = GLib.VariantType.New ("i");
 
-	/// <summary>
-	/// Convert the "<Primary>" accelerator to the Ctrl or Command key, depending on the platform.
-	/// This was done automatically in GTK3, but does not happen in GTK4.
-	/// </summary>
-	private static string ConvertPrimaryKey (this SystemManager system, string accel) =>
-		accel.Replace ("<Primary>", system.OperatingSystem == OS.Mac ? "<Meta>" : "<Control>");
-
-	/// <summary>
-	/// Returns the platform-specific label for the "Primary" (Ctrl) key.
-	/// For example, this is the Cmd key on macOS.
-	/// </summary>
-	public static string CtrlLabel (this SystemManager system)
+	static GtkExtensions ()
 	{
-		AcceleratorParse (
-			system.ConvertPrimaryKey ("<Primary>"),
-			out var key,
-			out var mods);
-
-		return Gtk.Functions.AcceleratorGetLabel (key, mods);
-	}
-
-	/// <summary>
-	/// Returns the platform-specific label for the Alt key.
-	/// For example, this is the Option key on macOS.
-	/// </summary>
-	public static string AltLabel ()
-	{
-		AcceleratorParse ("<Alt>", out var key, out var mods);
-		return Gtk.Functions.AcceleratorGetLabel (key, mods);
-	}
-
-	// TODO-GTK4 (bindings, unsubmitted) - need support for 'out' enum parameters.
-	[LibraryImport (GtkLibraryName, EntryPoint = "gtk_accelerator_parse")]
-	[return: MarshalAs (UnmanagedType.Bool)]
-	private static partial bool AcceleratorParse (
-		[MarshalAs (UnmanagedType.LPUTF8Str)] string accelerator,
-		out uint accelerator_key,
-		out Gdk.ModifierType accelerator_mods);
-
-	/// <summary>
-	/// Helper function to return the icon theme for the default display.
-	/// </summary>
-	public static Gtk.IconTheme GetDefaultIconTheme ()
-		=> Gtk.IconTheme.GetForDisplay (Gdk.Display.GetDefault ()!);
-
-	/// <summary>
-	/// Find the index of a string in a Gtk.StringList.
-	/// </summary>
-	public static bool FindString (this Gtk.StringList list, string s, out uint index)
-	{
-		for (uint i = 0, n = list.GetNItems (); i < n; ++i) {
-			if (list.GetString (i) == s) {
-				index = i;
-				return true;
-			}
-		}
-
-		index = 0;
-		return false;
-	}
-
-	/// <summary>
-	/// Provides convenient access to the Gdk.Key of the key being pressed.
-	/// </summary>
-	public static Gdk.Key GetKey (this Gtk.EventControllerKey.KeyPressedSignalArgs args)
-		=> new Gdk.Key (args.Keyval);
-
-	/// <summary>
-	/// Provides convenient access to the Gdk.Key of the key being released.
-	/// </summary>
-	public static Gdk.Key GetKey (this Gtk.EventControllerKey.KeyReleasedSignalArgs args)
-		=> new Gdk.Key (args.Keyval);
-
-	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
-	[StructLayout (LayoutKind.Sequential)]
-	private struct GdkRGBA
-	{
-		public float Red;
-		public float Green;
-		public float Blue;
-		public float Alpha;
-	}
-
-	[LibraryImport (GtkLibraryName, EntryPoint = "gtk_style_context_get_color")]
-	private static partial void StyleContextGetColor (IntPtr handle, out GdkRGBA color);
-
-	[LibraryImport (GtkLibraryName, EntryPoint = "gtk_color_chooser_get_rgba")]
-	private static partial void ColorChooserGetRgba (
-		IntPtr handle,
-		out GdkRGBA color);
-
-	private static readonly Signal<Gtk.Entry> EntryChangedSignal = new (
-		unmanagedName: "changed",
-		managedName: string.Empty
-	);
-
-	// TODO-GTK4 (bindings) - the Gtk.Editable::changed signal is not generated (https://github.com/gircore/gir.core/issues/831)
-	public static void OnChanged (
-		this Gtk.Entry o,
-		SignalHandler<Gtk.Entry> handler)
-	{
-		EntryChangedSignal.Connect (o, handler);
-	}
-
-	public sealed class SelectionChangedSignalArgs : SignalArgs
-	{
-		public uint Position => Args[1].GetUint ();
-		public uint NItems => Args[2].GetUint ();
-
-	}
-
-	private static readonly Signal<Gtk.SingleSelection, SelectionChangedSignalArgs> SelectionChangedSignal = new (
-		unmanagedName: "selection-changed",
-		managedName: string.Empty
-	);
-
-	// TODO-GTK4 (bindings) - the Gtk.SelectionModel::selection-changed signal is not generated (https://github.com/gircore/gir.core/issues/831)
-	public static void OnSelectionChanged (
-		this Gtk.SingleSelection o,
-		SignalHandler<Gtk.SingleSelection, SelectionChangedSignalArgs> handler)
-	{
-		SelectionChangedSignal.Connect (o, handler);
-	}
-
-	// Manual binding for GetPreeditString
-	// TODO-GTK4 (bindings) - missing from gir.core: "opaque record parameter 'attrs' with direction != in not yet supported"
-	[DllImport (GtkLibraryName, EntryPoint = "gtk_im_context_get_preedit_string")]
-	private static extern void IMContextGetPreeditString (
-		IntPtr handle,
-		out GLib.Internal.NonNullableUtf8StringOwnedHandle str,
-		out Pango.Internal.AttrListOwnedHandle attrs,
-		out int cursor_pos);
-
-	public static void GetPreeditString (
-		this Gtk.IMContext context,
-		out string str,
-		out Pango.AttrList attrs,
-		out int cursor_pos)
-	{
-		IMContextGetPreeditString (
-			context.Handle.DangerousGetHandle (),
-			out var str_handle,
-			out var attrs_handle,
-			out cursor_pos);
-
-		str = str_handle.ConvertToString ();
-		str_handle.Dispose ();
-		attrs = new Pango.AttrList (attrs_handle);
-	}
-
-	public static async Task LaunchUri (
-		this SystemManager system,
-		string uri)
-	{
-		// Workaround for macOS, which produces an "unsupported on current backend" error (https://gitlab.gnome.org/GNOME/gtk/-/issues/6788)
-		if (system.OperatingSystem == OS.Mac) {
-			var process = System.Diagnostics.Process.Start ("open", uri);
-			process.WaitForExit ();
-		} else {
-			Gtk.UriLauncher launcher = Gtk.UriLauncher.New (uri);
-			await launcher.LaunchAsync (PintaCore.Chrome.MainWindow);
-		}
+		NativeImportResolver.RegisterLibrary (
+			library: GTK_LIBRARY_NAME,
+			windowsLibraryName: "libgtk-4-1.dll",
+			linuxLibraryName: "libgtk-4.so.1",
+			osxLibraryName: "libgtk-4.1.dylib");
 	}
 }

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -11,6 +11,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Pinta.Core;
 
@@ -199,5 +201,17 @@ public static class OtherExtensions
 		}
 
 		return polygons;
+	}
+
+	public static async Task LaunchUri (this SystemManager system, string uri)
+	{
+		// Workaround for macOS, which produces an "unsupported on current backend" error (https://gitlab.gnome.org/GNOME/gtk/-/issues/6788)
+		if (system.OperatingSystem == OS.Mac) {
+			Process process = Process.Start ("open", uri);
+			process.WaitForExit ();
+		} else {
+			Gtk.UriLauncher launcher = Gtk.UriLauncher.New (uri);
+			await launcher.LaunchAsync (PintaCore.Chrome.MainWindow);
+		}
 	}
 }

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
@@ -26,7 +26,7 @@ public sealed class AnglePickerGraphic : Gtk.DrawingArea
 
 		// Handle click + drag.
 		var gesture = Gtk.GestureDrag.New ();
-		gesture.SetButton (GtkExtensions.MouseLeftButton);
+		gesture.SetButton (GtkExtensions.MOUSE_LEFT_BUTTON);
 
 		gesture.OnDragBegin += (_, args) => {
 			drag_start = new PointD (args.StartX, args.StartY);

--- a/Pinta.Gui.Widgets/Widgets/PointPickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/PointPickerGraphic.cs
@@ -48,7 +48,7 @@ public sealed class PointPickerGraphic : Gtk.DrawingArea
 
 		// Handle click + drag.
 		var drag_gesture = Gtk.GestureDrag.New ();
-		drag_gesture.SetButton (GtkExtensions.MouseLeftButton);
+		drag_gesture.SetButton (GtkExtensions.MOUSE_LEFT_BUTTON);
 
 		drag_gesture.OnDragBegin += (_, args) => {
 			drag_start = new PointD (args.StartX, args.StartY);

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -103,9 +103,9 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 				if (index < 0)
 					break;
 
-				if (button == GtkExtensions.MouseRightButton) {
+				if (button == GtkExtensions.MOUSE_RIGHT_BUTTON) {
 					PintaCore.Palette.SecondaryColor = PintaCore.Palette.CurrentPalette[index];
-				} else if (button == GtkExtensions.MouseLeftButton) {
+				} else if (button == GtkExtensions.MOUSE_LEFT_BUTTON) {
 					PintaCore.Palette.PrimaryColor = PintaCore.Palette.CurrentPalette[index];
 				} else {
 					var color = GetUserChosenColor ([PintaCore.Palette.CurrentPalette[index]], 0, Translations.GetString ("Choose Palette Color"))?[0];
@@ -122,9 +122,9 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 					break;
 
 				var recentColor = PintaCore.Palette.RecentlyUsedColors.ElementAt (recent_index);
-				if (button == GtkExtensions.MouseRightButton) {
+				if (button == GtkExtensions.MOUSE_RIGHT_BUTTON) {
 					PintaCore.Palette.SetColor (false, recentColor, false);
-				} else if (button == GtkExtensions.MouseLeftButton) {
+				} else if (button == GtkExtensions.MOUSE_LEFT_BUTTON) {
 					PintaCore.Palette.SetColor (true, recentColor, false);
 				}
 


### PR DESCRIPTION
To have the 'leading' file `GtkExtensions.cs` be as barebones as possible, and to more closely mirror what happens in `CairoExtensions`