### PR TITLE
Tidying some dialog-related code

### DIFF
--- a/Pinta.Effects/Dialogs/Effects.AlignmentDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.AlignmentDialog.cs
@@ -124,10 +124,4 @@ public sealed class AlignmentDialog : Gtk.Dialog
 		bottom_center.SetActive (position == AlignPosition.BottomCenter);
 		bottom_right.SetActive (position == AlignPosition.BottomRight);
 	}
-
-	public void RunDialog ()
-	{
-		Present ();
-		OnResponse += (_, _) => Destroy ();
-	}
 }

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -29,16 +29,38 @@ internal sealed class EditCanvasGridAction : IActionHandler
 		view.EditCanvasGrid.Activated -= Activated;
 	}
 
+	private void HandleDialogUpdate (object? sender, CanvasGridSettingsDialog.Settings eventArgs)
+	{
+		canvas_grid.ShowGrid = eventArgs.ShowGrid;
+		canvas_grid.CellWidth = eventArgs.CellSize.Width;
+		canvas_grid.CellHeight = eventArgs.CellSize.Height;
+	}
+
 	private async void Activated (object sender, EventArgs e)
 	{
-		using CanvasGridSettingsDialog dialog = new (chrome, canvas_grid);
+		CanvasGridSettingsDialog.Settings initialSettings = new (
+			canvas_grid.ShowGrid,
+			new (
+				canvas_grid.CellWidth,
+				canvas_grid.CellHeight));
+
+		using CanvasGridSettingsDialog dialog = new (chrome, initialSettings);
+
 		try {
+			dialog.Updated += HandleDialogUpdate;
 			Gtk.ResponseType response = await dialog.RunAsync ();
-			if (response == Gtk.ResponseType.Ok)
+
+			if (response == Gtk.ResponseType.Ok) {
 				canvas_grid.SaveGridSettings ();
-			else
-				dialog.RevertChanges ();
+			} else {
+				// Revert the changes that the dialog made to the canvas grid.
+				canvas_grid.ShowGrid = initialSettings.ShowGrid;
+				canvas_grid.CellWidth = initialSettings.CellSize.Width;
+				canvas_grid.CellHeight = initialSettings.CellSize.Height;
+			}
+
 		} finally {
+			dialog.Updated -= HandleDialogUpdate;
 			dialog.Destroy ();
 		}
 	}

--- a/Pinta/Actions/View/EditCanvasGridAction.cs
+++ b/Pinta/Actions/View/EditCanvasGridAction.cs
@@ -32,12 +32,15 @@ internal sealed class EditCanvasGridAction : IActionHandler
 	private async void Activated (object sender, EventArgs e)
 	{
 		using CanvasGridSettingsDialog dialog = new (chrome, canvas_grid);
-		Gtk.ResponseType response = await dialog.RunAsync ();
-		dialog.Destroy ();
-		if (response == Gtk.ResponseType.Ok)
-			canvas_grid.SaveGridSettings ();
-		else
-			dialog.RevertChanges ();
+		try {
+			Gtk.ResponseType response = await dialog.RunAsync ();
+			if (response == Gtk.ResponseType.Ok)
+				canvas_grid.SaveGridSettings ();
+			else
+				dialog.RevertChanges ();
+		} finally {
+			dialog.Destroy ();
+		}
 	}
 }
 

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -16,9 +16,19 @@ public sealed class CanvasGridSettingsDialog : Dialog
 
 	internal CanvasGridSettingsDialog (ChromeManager chrome, Settings initialSettings)
 	{
-		show_grid_checkbox = CreateShowGridCheckbox (initialSettings.ShowGrid, SettingsChanged);
-		grid_width_spinner = CreateSpinner (initialSettings.CellSize.Width, SettingsChanged);
-		grid_height_spinner = CreateSpinner (initialSettings.CellSize.Height, SettingsChanged);
+		CheckButton showGridCheckBox = CheckButton.NewWithLabel (Translations.GetString ("Show Grid"));
+		showGridCheckBox.Active = initialSettings.ShowGrid;
+		showGridCheckBox.OnToggled += SettingsChanged;
+
+		SpinButton widthSpinner = SpinButton.NewWithRange (1, int.MaxValue, 1);
+		widthSpinner.Value = initialSettings.CellSize.Width;
+		widthSpinner.OnValueChanged += SettingsChanged;
+		widthSpinner.SetActivatesDefaultImmediate (true);
+
+		SpinButton heightSpinner = SpinButton.NewWithRange (1, int.MaxValue, 1);
+		heightSpinner.Value = initialSettings.CellSize.Height;
+		heightSpinner.OnValueChanged += SettingsChanged;
+		heightSpinner.SetActivatesDefaultImmediate (true);
 
 		Grid grid = new () {
 			RowSpacing = SPACING,
@@ -26,54 +36,49 @@ public sealed class CanvasGridSettingsDialog : Dialog
 			ColumnHomogeneous = false,
 		};
 
-		grid.Attach (show_grid_checkbox, 0, 0, 2, 1);
+		grid.Attach (showGridCheckBox, 0, 0, 2, 1);
 
 		grid.Attach (CreateLabel (Translations.GetString ("Width:"), Align.End), 0, 1, 1, 1);
-		grid.Attach (grid_width_spinner, 1, 1, 1, 1);
+		grid.Attach (widthSpinner, 1, 1, 1, 1);
 		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 1, 1, 1);
 
 		grid.Attach (CreateLabel (Translations.GetString ("Height:"), Align.End), 0, 2, 1, 1);
-		grid.Attach (grid_height_spinner, 1, 2, 1, 1);
+		grid.Attach (heightSpinner, 1, 2, 1, 1);
 		grid.Attach (Label.New (Translations.GetString ("pixels")), 2, 2, 1, 1);
 
 		Box mainVbox = new () { Spacing = SPACING };
 		mainVbox.SetOrientation (Orientation.Vertical);
 		mainVbox.Append (grid);
 
+		// --- Initialization (Gtk.Box)
+
+		Box contentArea = this.GetContentAreaBox ();
+		contentArea.SetAllMargins (12);
+		contentArea.Append (mainVbox);
+
+		// --- Initialization (Gtk.Window)
+
 		Title = Translations.GetString ("Canvas Grid Settings");
 		TransientFor = chrome.MainWindow;
 		Modal = true;
 		IconName = Resources.Icons.ViewGrid;
 
+		// --- Initializaiton (Gtk.Dialog)
+
 		this.AddCancelOkButtons ();
 		this.SetDefaultResponse (ResponseType.Ok);
 
-		Box contentArea = this.GetContentAreaBox ();
-		contentArea.SetAllMargins (12);
-		contentArea.Append (mainVbox);
-	}
+		// --- References to keep
 
-	private static CheckButton CreateShowGridCheckbox (bool active, GObject.SignalHandler<CheckButton> onValueChanged)
-	{
-		CheckButton result = CheckButton.NewWithLabel (Translations.GetString ("Show Grid"));
-		result.Active = active;
-		result.OnToggled += onValueChanged;
-		return result;
+		show_grid_checkbox = showGridCheckBox;
+		grid_width_spinner = widthSpinner;
+		grid_height_spinner = heightSpinner;
 	}
 
 	private static Label CreateLabel (string text, Align horizontalAlign)
 	{
 		Label result = Label.New (text);
 		result.Halign = horizontalAlign;
-		return result;
-	}
-
-	private static SpinButton CreateSpinner (int startValue, GObject.SignalHandler<SpinButton> onValueChanged)
-	{
-		SpinButton result = SpinButton.NewWithRange (1, int.MaxValue, 1);
-		result.Value = startValue;
-		result.OnValueChanged += onValueChanged;
-		result.SetActivatesDefaultImmediate (true);
 		return result;
 	}
 

--- a/Pinta/Dialogs/CanvasGridSettingsDialog.cs
+++ b/Pinta/Dialogs/CanvasGridSettingsDialog.cs
@@ -63,7 +63,7 @@ public sealed class CanvasGridSettingsDialog : Dialog
 		Modal = true;
 		IconName = Resources.Icons.ViewGrid;
 
-		// --- Initializaiton (Gtk.Dialog)
+		// --- Initialization (Gtk.Dialog)
 
 		this.AddCancelOkButtons ();
 		this.SetDefaultResponse (ResponseType.Ok);


### PR DESCRIPTION
The changes to `EditCanvasGridAction`, specifically, are a demonstration that will help us start discussing a point.

I wanted to change some code in `StatusBarColorPaletteWidget` and `NewDocumentAction` so that their dialog code uses `async` and `await`. However, doing it the way I'm doing it with other dialogs means that I would be accessing its properties after it has been `Destroy`ed. That would work because the properties are custom, from the Pinta codebase, and in no way tied to the lifetime of the Gtk dialog in question. However, it doesn't feel that clean.

If we just need to read the values, I was thinking we could create specialized extension methods and using them instead of the generic dialog methods, something like:

```csharp
public static Task<NewImageInfo?> RunAsync (this NewImageDialog dialog) {
    Gtk.ResponseType response = dialog.RunAsync();
    if (response == Gtk.ResponseType.Ok)
        return new (NewImageSize, NewImageBackground);
    else
        return null;
}
```

It's also tricky because the dialog is still visible even after it's `Dispose`d, unless we `Destroy` it previously, which doesn't make a lot of sense to me. One possible way to address that is creating our own base dialog class with an overridden `Dispose` method, or perhaps even address it directly by making the appropriate changes to gir.core.

If we are not just reading its properties, but also calling a method with side effects, (see `dialog.RevertChanges()`), it's a bit trickier to do cleanly, but in this PR I'm proposing a temporary solution, although in my opinion this `RevertChanges` method, along with the `CanvasGridManager`, should be refactored out of the dialog, because a _dialog_ has no business changing the workspace, but rather should just be used for getting input from the user.