### PR TITLE
Point to Github Discussions instead of Google Group for techical help

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,9 +79,9 @@ For building on the command line:
 
 ## Getting help / contributing:
 
-- You can get technical help on the [Pinta Google Group](https://groups.google.com/group/pinta-project).
-- You can report bugs/issues on [Github](https://github.com/PintaProject/Pinta/issues).
-- You can make suggestions on [Github](https://github.com/PintaProject/Pinta/discussions/categories/ideas).
+- You can get [technical help](https://github.com/PintaProject/Pinta/discussions).
+- You can report [bugs/issues](https://github.com/PintaProject/Pinta/issues).
+- You can make [suggestions](https://github.com/PintaProject/Pinta/discussions/categories/ideas).
 - You can help [translate Pinta to your native language](https://hosted.weblate.org/engage/pinta/).
 - You can fork the project on [Github](https://github.com/PintaProject/Pinta).
 - You can get help in #pinta on irc.gnome.org.


### PR DESCRIPTION
Also slightly change the format of some items in the Getting help / contributing