### PR TITLE
Remove useless code

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -8,9 +8,6 @@ public sealed class ToolBoxWidget : FlowBox
 {
 	public ToolBoxWidget ()
 	{
-		HeightRequest = 375;
-		AddCssClass (AdwaitaStyles.Linked);
-
 		PintaCore.Tools.ToolAdded += HandleToolAdded;
 		PintaCore.Tools.ToolRemoved += HandleToolRemoved;
 
@@ -20,7 +17,7 @@ public sealed class ToolBoxWidget : FlowBox
 		Homogeneous = true;
 		MinChildrenPerLine = 6;
 		MaxChildrenPerLine = 1024; // If there is enough vertical space, only use one column
-		Vexpand = false;
+		Vexpand = true;
 		Valign = Align.Start;
 	}
 


### PR DESCRIPTION
The style class does nothing in this case.
The height request is also useless for the toolbox. There should be some height request some ware to allow the history undo and redo buttons to be always visible, but this is probably not the best place and is also insufficient.