### PR TITLE
ToolBoxWidget: Improve high DPI scenarios and improve layout flow.

### DIFF
--- a/Pinta.Core/Extensions/ToolBoxButton.cs
+++ b/Pinta.Core/Extensions/ToolBoxButton.cs
@@ -35,6 +35,19 @@ public sealed class ToolBoxButton : ToggleButton
 {
 	public BaseTool Tool { get; }
 
+	// Hello, this is a run-once "static" constructor, you may remember me from documentation such as https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/static-constructors
+	static ToolBoxButton ()
+	{
+		// Force icons to have a specific size regardless of size of the application canvas.
+		// Discussion #1374 where icons seems to be getting smaller when the screen gets bigger.
+		Gtk.CssProvider css = Gtk.CssProvider.New ();
+		css.LoadFromString (".ToolBoxButton { -gtk-icon-size: 2rem; }"); // Works well for high resolution and low resolution canvases across various DPI's
+		Gdk.Display? display = Gdk.Display.GetDefault () ?? null;
+		if (display is not null) {
+			Gtk.StyleContext.AddProviderForDisplay (display, css, 1);
+		}
+	}
+
 	public ToolBoxButton (BaseTool tool)
 	{
 		Tool = tool;
@@ -42,7 +55,8 @@ public sealed class ToolBoxButton : ToggleButton
 		Name = tool.Name;
 		CanFocus = false;
 
-		AddCssClass (AdwaitaStyles.Flat);
+
+		SetCssClasses (["ToolBoxButton", AdwaitaStyles.Flat]);
 
 		string shortcutText = "";
 		if (tool.ShortcutKey != Gdk.Key.Invalid) {

--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -12,13 +12,8 @@ public sealed class ToolBoxWidget : FlowBox
 		PintaCore.Tools.ToolRemoved += HandleToolRemoved;
 
 		SetOrientation (Orientation.Vertical);
-		ColumnSpacing = 0;
-		RowSpacing = 0;
-		Homogeneous = true;
-		MinChildrenPerLine = 6;
-		MaxChildrenPerLine = 1024; // If there is enough vertical space, only use one column
-		Vexpand = true;
-		Valign = Align.Start;
+		MinChildrenPerLine = 8; // Pinta 3 has 22 default tools, meaning a max of 3 columns regardless of size, smaller values don't lead to better use of visual space.
+		MaxChildrenPerLine = 1024; // Allow for single column if there's sufficient space to do so.
 	}
 
 	public void AddItem (ToolBoxButton item)


### PR DESCRIPTION
Related discussion #1365

In summary, I believe that there's no practical benefit of the current behaviour which allows for a single vertical toolbar, if the expense is that the toolbar itself begins to shrink too.

Based on the following scales below, I'd like to imagine that this change is an overall win, since having personally tested before and after this patch being applied, the overall space used ends up being about the same; but on larger monitors, there's less mouse movement as well as bigger icons.

Smallest possible window size in Windows:
![image](https://github.com/user-attachments/assets/d78e7c98-759f-4342-acec-1edcfc933a5d)

Arbitrarily larger:
![image](https://github.com/user-attachments/assets/26e3ffc8-972a-45b7-92b8-afab296fc573)

Larger still
![image](https://github.com/user-attachments/assets/19cc3e2e-ee81-4c5b-90d5-ba336e037a51)

Full screen 1440p 100% display scaling
![image](https://github.com/user-attachments/assets/9734ed20-418b-4ed6-af16-0dce754708c4)
