### PR TITLE
Configure the compatibility version for addins

### DIFF
--- a/Pinta.Core/Classes/IExtension.cs
+++ b/Pinta.Core/Classes/IExtension.cs
@@ -1,6 +1,6 @@
 using Pinta.Core;
 
-[assembly: Mono.Addins.AddinRoot ("Pinta", PintaCore.ApplicationVersion, CompatVersion = PintaCore.ApplicationVersion)]
+[assembly: Mono.Addins.AddinRoot ("Pinta", PintaCore.ApplicationVersion, CompatVersion = PintaCore.AddinCompatVersion)]
 
 namespace Pinta.Core;
 

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -46,6 +46,12 @@ public static class PintaCore
 	public static CanvasGridManager CanvasGrid { get; }
 
 	public const string ApplicationVersion = "3.1";
+	/// <summary>
+	/// The oldest version of Pinta for which add-ins built against it will still
+	/// run in the current version.
+	/// This should be updated when there are ABI-breaking changes.
+	/// </summary>
+	public const string AddinCompatVersion = "3.0";
 
 	static PintaCore ()
 	{


### PR DESCRIPTION
This allows us to specify an older Pinta version that add-ins are still compatible with

Fixes: #1379