### PR TITLE
Simplified display of progress dialog

### DIFF
--- a/Pinta.Core/Managers/ChromeManager.cs
+++ b/Pinta.Core/Managers/ChromeManager.cs
@@ -212,7 +212,7 @@ public interface IProgressDialog
 	string Title { get; set; }
 	string Text { get; set; }
 	double Progress { get; set; }
-	event EventHandler<EventArgs> Canceled;
+	event EventHandler Canceled;
 }
 
 public delegate Task<ErrorDialogResponse> ErrorDialogHandler (Gtk.Window parent, string message, string body, string details);

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -111,8 +111,6 @@ public sealed class LivePreviewManager : ILivePreview
 		dialog.Progress = renderer.Progress;
 		dialog.Canceled += HandleProgressDialogCancel;
 
-		uint progress_timeout_id = 0;
-
 		try {
 			// Paint the pre-effect layer surface into into the working surface.
 			using Cairo.Context ctx = new (LivePreviewSurface);
@@ -142,15 +140,7 @@ public sealed class LivePreviewManager : ILivePreview
 
 			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
 
-			progress_timeout_id = GLib.Functions.TimeoutAdd (
-				0,
-				500,
-				() => {
-					dialog.Show ();
-					progress_timeout_id = 0;
-					return false;
-				}
-			);
+			dialog.Show ();
 
 			var result = await renderer.Finish (cancel: false);
 
@@ -189,9 +179,6 @@ public sealed class LivePreviewManager : ILivePreview
 			chrome.MainWindowBusy = false;
 
 			dialog.Canceled -= HandleProgressDialogCancel;
-
-			if (progress_timeout_id != 0)
-				GLib.Source.Remove (progress_timeout_id);
 
 			dialog.Hide ();
 		}

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -111,6 +111,8 @@ public sealed class LivePreviewManager : ILivePreview
 		dialog.Progress = renderer.Progress;
 		dialog.Canceled += HandleProgressDialogCancel;
 
+		uint progress_timeout_id = 0;
+
 		try {
 			// Paint the pre-effect layer surface into into the working surface.
 			using Cairo.Context ctx = new (LivePreviewSurface);
@@ -140,7 +142,15 @@ public sealed class LivePreviewManager : ILivePreview
 
 			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + "LivePreviewManager.Apply()");
 
-			dialog.Show ();
+			progress_timeout_id = GLib.Functions.TimeoutAdd (
+				0,
+				500,
+				() => {
+					dialog.Show ();
+					progress_timeout_id = 0;
+					return false;
+				}
+			);
 
 			var result = await renderer.Finish (cancel: false);
 
@@ -179,6 +189,9 @@ public sealed class LivePreviewManager : ILivePreview
 			chrome.MainWindowBusy = false;
 
 			dialog.Canceled -= HandleProgressDialogCancel;
+
+			if (progress_timeout_id != 0)
+				GLib.Source.Remove (progress_timeout_id);
 
 			dialog.Hide ();
 		}

--- a/Pinta/Dialogs/ProgressDialog.cs
+++ b/Pinta/Dialogs/ProgressDialog.cs
@@ -34,7 +34,7 @@ public sealed class ProgressDialog : Gtk.Dialog, IProgressDialog
 	private readonly Gtk.Label text_label;
 	private readonly Gtk.ProgressBar progress_bar;
 
-	public event EventHandler<EventArgs>? Canceled;
+	public event EventHandler? Canceled;
 
 	public ProgressDialog (ChromeManager chrome)
 	{
@@ -83,28 +83,5 @@ public sealed class ProgressDialog : Gtk.Dialog, IProgressDialog
 	public double Progress {
 		get => progress_bar.Fraction;
 		set => progress_bar.Fraction = value;
-	}
-
-	uint timeout_id = 0;
-
-	void IProgressDialog.Show ()
-	{
-		timeout_id = GLib.Functions.TimeoutAdd (
-			0,
-			500,
-			() => {
-				Show ();
-				timeout_id = 0;
-				return false;
-			}
-		);
-	}
-
-	void IProgressDialog.Hide ()
-	{
-		if (timeout_id != 0)
-			GLib.Source.Remove (timeout_id);
-
-		Hide ();
 	}
 }


### PR DESCRIPTION
If we read the implementation of the progress dialog, we'd see there is a delay of 500 milliseconds inside the `Show` method. I am not sure why the delay is there, and in any case I think it should be handled externally; not by the dialog itself.

In the first commit I moved the handling of the delay outside of the dialog class, to the `LivePreviewManager`.

In the second commit I removed the delay entirely.

The overall diff makes it appear as if the `LivePreviewManager` didn't change, and in fact that is the combined result of the two commits, but by looking at each of them separately, what happened will become clearer.