### PR TITLE
Build: Support referencing GirCore via project reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,5 +11,8 @@
     <Authors>PintaProject</Authors>
     <Company />
     <Product />
+    
+    <!-- Add an absolute path to a local GirCore source directory to use it instead of the NuGet package -->
+    <GirCoreSource />
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,13 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <GirCoreVersion>0.6.3</GirCoreVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="GirCore.Adw-1" Version="0.6.3" />
-    <PackageVersion Include="GirCore.GObject-2.0.Integration" Version="0.6.3" />
-    <PackageVersion Include="GirCore.Gtk-4.0" Version="0.6.3" />
-    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="0.6.3" />
+    <PackageVersion Include="GirCore.Adw-1" Version="$(GirCoreVersion)" />
+    <PackageVersion Include="GirCore.GObject-2.0.Integration" Version="$(GirCoreVersion)" />
+    <PackageVersion Include="GirCore.Gtk-4.0" Version="$(GirCoreVersion)" />
+    <PackageVersion Include="GirCore.PangoCairo-1.0" Version="$(GirCoreVersion)" />
     <!-- Note: at least 1.4.2-alpha3 is required for fixes to uninstalling addins, from https://github.com/mono/mono-addins/pull/198 -->
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <Import Project="../properties/ReferenceGirCoreAdw1.props" />
+  <Import Project="../properties/ReferenceGirCorePangoCairo10.props" />
+
   <ItemGroup>
     <PackageReference Include="NGettext" />
     <PackageReference Include="ParagonClipper" />
-    <PackageReference Include="GirCore.Adw-1" />
-    <PackageReference Include="GirCore.PangoCairo-1.0" />
     <PackageReference Include="Mono.Addins" />
   </ItemGroup>
   <ItemGroup>

--- a/Pinta.Docking/Pinta.Docking.csproj
+++ b/Pinta.Docking/Pinta.Docking.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../properties/ReferenceGirCoreAdw1.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="GirCore.Adw-1" />
   </ItemGroup>
 </Project>

--- a/Pinta.Gui.Addins/Pinta.Gui.Addins.csproj
+++ b/Pinta.Gui.Addins/Pinta.Gui.Addins.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../properties/ReferenceGirCoreAdw1.props" />
+  <Import Project="../properties/ReferenceGirCoreGObject20Integration.props" />
+
   <ItemGroup>
-    <PackageReference Include="GirCore.Adw-1" />
-    <PackageReference Include="GirCore.GObject-2.0.Integration" />
     <PackageReference Include="Mono.Addins" />
     <PackageReference Include="Mono.Addins.Setup" />
   </ItemGroup>

--- a/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
+++ b/Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="GirCore.GObject-2.0.Integration" />
-  </ItemGroup>
+
+  <Import Project="../properties/ReferenceGirCoreGObject20Integration.props" />
+  
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />
   </ItemGroup>

--- a/Pinta.Resources/Pinta.Resources.csproj
+++ b/Pinta.Resources/Pinta.Resources.csproj
@@ -63,7 +63,6 @@
       <LogicalName>style.css</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="GirCore.Gtk-4.0" />
-  </ItemGroup>
+
+  <Import Project="../properties/ReferenceGirCoreGtk40.props" />
 </Project>

--- a/Pinta.sln
+++ b/Pinta.sln
@@ -29,6 +29,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6DE60B92-C365-4DB5-9D5F-956317DD2E19}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinta.Gui.Addins", "Pinta.Gui.Addins\Pinta.Gui.Addins.csproj", "{2460CAAF-37BA-4795-8C86-7DFCB57F94A5}"
@@ -38,6 +40,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "installer", "installer", "{ADED7547-5FA7-4157-951F-1CA5C933B4F7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinta.AddinUtils", "installer\addins\Pinta.AddinUtils.csproj", "{90F56F18-1720-4F89-A5F9-6CA710CC9694}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "properties", "properties", "{38B8CD22-1CA6-4176-A4DE-ED43A1B6557F}"
+	ProjectSection(SolutionItems) = preProject
+		properties\ReferenceGirCoreAdw1.props = properties\ReferenceGirCoreAdw1.props
+		properties\ReferenceGirCorePangoCairo10.props = properties\ReferenceGirCorePangoCairo10.props
+		properties\ReferenceGirCoreGObject20Integration.props = properties\ReferenceGirCoreGObject20Integration.props
+		properties\ReferenceGirCoreGtk40.props = properties\ReferenceGirCoreGtk40.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -102,6 +112,7 @@ Global
 		{8A8B7C9F-4AE0-4E2B-A4DF-CBABCD0DE864} = {8D23D7B9-C97E-498C-A1C5-6159E305D9BA}
 		{3062EBB6-E84B-4EFF-BAB2-E0EAFF7EF755} = {8D23D7B9-C97E-498C-A1C5-6159E305D9BA}
 		{90F56F18-1720-4F89-A5F9-6CA710CC9694} = {ADED7547-5FA7-4157-951F-1CA5C933B4F7}
+		{38B8CD22-1CA6-4176-A4DE-ED43A1B6557F} = {6DE60B92-C365-4DB5-9D5F-956317DD2E19}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4985F1D9-0ABE-4E83-98D2-8D119EA4075D}

--- a/Pinta/Pinta.csproj
+++ b/Pinta/Pinta.csproj
@@ -10,9 +10,10 @@
     <BuildTranslations>false</BuildTranslations>
   </PropertyGroup>
 
+  <Import Project="../properties/ReferenceGirCoreAdw1.props" />
+
   <ItemGroup>
     <PackageReference Include="Tmds.DBus" />
-    <PackageReference Include="GirCore.Adw-1" />
     <PackageReference Include="Mono.Addins" />
     <PackageReference Include="Mono.Addins.Setup" />
     <PackageReference Include="Mono.Addins.CecilReflector" />

--- a/properties/ReferenceGirCoreAdw1.props
+++ b/properties/ReferenceGirCoreAdw1.props
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup>
+        <ProjectReference Condition="'$(GirCoreSource)' != ''" Include="$(GirCoreSource)/src/Libs/Adw-1/Adw-1.csproj" />
+        <PackageReference Condition="'$(GirCoreSource)' == ''" Include="GirCore.Adw-1" />
+    </ItemGroup>
+</Project>

--- a/properties/ReferenceGirCoreGObject20Integration.props
+++ b/properties/ReferenceGirCoreGObject20Integration.props
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup>
+        <ProjectReference Condition="'$(GirCoreSource)' != ''" Include="$(GirCoreSource)/src/Extensions/GObject-2.0.Integration/GObject-2.0.Integration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <PackageReference Condition="'$(GirCoreSource)' == ''" Include="GirCore.GObject-2.0.Integration" />
+    </ItemGroup>
+</Project>

--- a/properties/ReferenceGirCoreGtk40.props
+++ b/properties/ReferenceGirCoreGtk40.props
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup>
+        <ProjectReference Condition="'$(GirCoreSource)' != ''" Include="$(GirCoreSource)/src/Libs/Gtk-4.0/Gtk-4.0.csproj" />
+        <PackageReference Condition="'$(GirCoreSource)' == ''" Include="GirCore.Gtk-4.0" />
+    </ItemGroup>
+</Project>

--- a/properties/ReferenceGirCorePangoCairo10.props
+++ b/properties/ReferenceGirCorePangoCairo10.props
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup>
+        <ProjectReference Condition="'$(GirCoreSource)' != ''" Include="$(GirCoreSource)/src/Libs/PangoCairo-1.0/PangoCairo-1.0.csproj" />
+        <PackageReference Condition="'$(GirCoreSource)' == ''" Include="GirCore.PangoCairo-1.0" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
To enable easy debugging of GirCore libraries, the msbuild property "GirCoreSource" can be set to a path where the GirCore source is located.

If this property is set the GirCore package references will be replaced by project references which point to the local GirCore source.