### PR TITLE
Removes duplicated entries from Layers Menu

### DIFF
--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -56,17 +56,17 @@ public sealed class LayerActions
 		WorkspaceManager workspace,
 		ImageActions image)
 	{
-		AddNewLayer = new Command ("addnewlayer", Translations.GetString ("Add New Layer"), null, Resources.Icons.LayerNew);
-		DeleteLayer = new Command ("deletelayer", Translations.GetString ("Delete Layer"), null, Resources.Icons.LayerDelete);
-		DuplicateLayer = new Command ("duplicatelayer", Translations.GetString ("Duplicate Layer"), null, Resources.Icons.LayerDuplicate);
-		MergeLayerDown = new Command ("mergelayerdown", Translations.GetString ("Merge Layer Down"), null, Resources.Icons.LayerMergeDown);
+		AddNewLayer = new Command ("addnewlayer", Translations.GetString ("Add New Layer\n<Primary><Shift>N"), null, Resources.Icons.LayerNew);
+		DeleteLayer = new Command ("deletelayer", Translations.GetString ("Delete Layer\n<Primary><Shift>Delete"), null, Resources.Icons.LayerDelete);
+		DuplicateLayer = new Command ("duplicatelayer", Translations.GetString ("Duplicate Layer\n<Primary><Shift>D"), null, Resources.Icons.LayerDuplicate);
+		MergeLayerDown = new Command ("mergelayerdown", Translations.GetString ("Merge Layer Down\n<Primary>M"), null, Resources.Icons.LayerMergeDown);
 		ImportFromFile = new Command ("importfromfile", Translations.GetString ("Import from File..."), null, Resources.Icons.LayerImport);
 		FlipHorizontal = new Command ("fliplayerhorizontal", Translations.GetString ("Flip Horizontal"), null, Resources.Icons.LayerFlipHorizontal);
 		FlipVertical = new Command ("fliplayervertical", Translations.GetString ("Flip Vertical"), null, Resources.Icons.LayerFlipVertical);
 		RotateZoom = new Command ("RotateZoom", Translations.GetString ("Rotate / Zoom Layer..."), null, Resources.Icons.LayerRotateZoom);
 		MoveLayerUp = new Command ("movelayerup", Translations.GetString ("Move Layer Up"), null, Resources.Icons.LayerMoveUp);
 		MoveLayerDown = new Command ("movelayerdown", Translations.GetString ("Move Layer Down"), null, Resources.Icons.LayerMoveDown);
-		Properties = new Command ("properties", Translations.GetString ("Layer Properties..."), null, Resources.Icons.LayerProperties);
+		Properties = new Command ("properties", Translations.GetString ("Layer Properties...\nF4"), null, Resources.Icons.LayerProperties);
 		this.chrome = chrome;
 		image_formats = imageFormats;
 		recent_files = recentFiles;
@@ -93,10 +93,6 @@ public sealed class LayerActions
 		menu.AppendSection (null, flip_section);
 		menu.AppendSection (null, prop_section);
 
-		app.AddAccelAction (AddNewLayer, "<Primary><Shift>N");
-		app.AddAccelAction (DeleteLayer, "<Primary><Shift>Delete");
-		app.AddAccelAction (DuplicateLayer, "<Primary><Shift>D");
-		app.AddAccelAction (MergeLayerDown, "<Primary>M");
 		app.AddAction (ImportFromFile);
 		app.AddAction (FlipHorizontal);
 		app.AddAction (FlipVertical);

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -85,14 +85,14 @@ public sealed class LayerActions
 		Gio.Menu prop_section = Gio.Menu.New ();
 		prop_section.AppendItem (Properties.CreateMenuItem ());
 
-		menu.AppendItem (AddNewLayer.CreateMenuItem ());
-		menu.AppendItem (DeleteLayer.CreateMenuItem ());
-		menu.AppendItem (DuplicateLayer.CreateMenuItem ());
-		menu.AppendItem (MergeLayerDown.CreateMenuItem ());
 		menu.AppendItem (ImportFromFile.CreateMenuItem ());
 		menu.AppendSection (null, flip_section);
 		menu.AppendSection (null, prop_section);
 
+		app.AddAccelAction (AddNewLayer, "<Primary><Shift>N");
+		app.AddAccelAction (DeleteLayer, "<Primary><Shift>Delete");
+		app.AddAccelAction (DuplicateLayer, "<Primary><Shift>D");
+		app.AddAccelAction (MergeLayerDown, "<Primary>M");
 		app.AddAction (ImportFromFile);
 		app.AddAction (FlipHorizontal);
 		app.AddAction (FlipVertical);


### PR DESCRIPTION
Removes "Add New Layer", "Delete Layer", "Duplicate Layer" and "Merge Layer Down" from Layers Menu, as it is already present on the Layers Panel. Also adds the shortcuts to the respective buttons in the Layers Panel (on hover), making them more discoverable.

Partially fixes #1386