### PR TITLE
Numeric spin in angle picker now wraps around

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
@@ -36,7 +36,7 @@ public sealed class AnglePickerWidget : Gtk.Box
 		};
 		anglePickerGraphic.ValueChanged += HandleAnglePickerValueChanged;
 
-		Gtk.SpinButton numericSpin = Gtk.SpinButton.NewWithRange (0, 360, 1);
+		Gtk.SpinButton numericSpin = Gtk.SpinButton.NewWithRange (-360, 360, 1);
 		numericSpin.Configure (numericSpin.GetAdjustment (), 1, 2);
 		numericSpin.CanFocus = true;
 		numericSpin.Numeric = true;

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
@@ -44,6 +44,7 @@ public sealed class AnglePickerWidget : Gtk.Box
 		numericSpin.Valign = Gtk.Align.Start;
 		numericSpin.OnValueChanged += HandleSpinValueChanged;
 		numericSpin.SetActivatesDefaultImmediate (true);
+		numericSpin.Wrap = true;
 
 		Gtk.Button resetButton = new () {
 			IconName = Resources.StandardIcons.GoPrevious,

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
@@ -37,6 +37,7 @@ public sealed class AnglePickerWidget : Gtk.Box
 		anglePickerGraphic.ValueChanged += HandleAnglePickerValueChanged;
 
 		Gtk.SpinButton numericSpin = Gtk.SpinButton.NewWithRange (-360, 360, 1);
+		numericSpin.Value = 0;
 		numericSpin.Configure (numericSpin.GetAdjustment (), 1, 2);
 		numericSpin.CanFocus = true;
 		numericSpin.Numeric = true;

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerWidget.cs
@@ -45,7 +45,6 @@ public sealed class AnglePickerWidget : Gtk.Box
 		numericSpin.Valign = Gtk.Align.Start;
 		numericSpin.OnValueChanged += HandleSpinValueChanged;
 		numericSpin.SetActivatesDefaultImmediate (true);
-		numericSpin.Wrap = true;
 
 		Gtk.Button resetButton = new () {
 			IconName = Resources.StandardIcons.GoPrevious,


### PR DESCRIPTION
Fixes #1142

The only catch that I see is that the range _includes_ 360 itself. It's annoying but not a huge problem, because the `Value` exposed by the widget is always a valid angle.

I think (but I'm not sure) that the value of 360 could be excluded through coercion by creating the `Gtk.SpinButton` with a `Gtk.Adjustment` and playing a bit with its `OnValueChanged` signal.