### PR TITLE
Eliminate use of the OnNotify event

### DIFF
--- a/Pinta.Docking/DockNotebook.cs
+++ b/Pinta.Docking/DockNotebook.cs
@@ -67,15 +67,11 @@ public sealed class DockNotebook : Box
 		Append (tab_view);
 
 		// Emit an event when the current tab is changed.
-		// This requires listening to the selected-page property change.
-		tab_view.OnNotify += (o, e) => {
-			if (e.Pspec.GetName () != "selected-page")
-				return;
-
-			var page = tab_view.SelectedPage;
+		Adw.TabView.SelectedPagePropertyDefinition.Notify (tab_view, (_, _) => {
+			Adw.TabPage? page = tab_view.SelectedPage;
 			IDockNotebookItem? item = FindItemForPage (page);
 			ActiveTabChanged?.Invoke (this, new TabEventArgs (item));
-		};
+		});
 
 		// Prompt the user to save unsaved changes before closing.
 		tab_view.OnClosePage += (o, e) => {

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -133,9 +133,9 @@ internal sealed class AddinInfoView : Adw.Bin
 	private Gtk.Switch CreateEnableSwitch ()
 	{
 		Gtk.Switch result = new () { Visible = false };
-		result.OnNotify += (o, e) => {
-			if (e.Pspec.GetName () != "active") return;
+		result.OnStateSet += (_, _) => {
 			HandleEnableSwitched ();
+			return false;
 		};
 		return result;
 	}

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -868,9 +868,6 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			// every time the color changes
 			void ActiveWindowChangeHandler (object? _, GObject.Object.NotifySignalArgs args)
 			{
-				if (args.Pspec.GetName () != "is-active")
-					return;
-
 				if (IsActive) {
 					this.SetOpacity (1.0f);
 					return;
@@ -887,14 +884,14 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 
 			palette.PrimaryColorChanged += PrimaryChangeHandler;
 			palette.SecondaryColorChanged += SecondaryChangeHandler;
-			this.OnNotify += ActiveWindowChangeHandler;
+			IsActivePropertyDefinition.Notify (this, ActiveWindowChangeHandler);
 
 			// Remove event handlers on exit (in particular, we don't want to handle the
 			// 'is-active' property changing as the dialog is being closed (bug #1390)).
 			this.OnResponse += (_, _) => {
 				palette.PrimaryColorChanged -= PrimaryChangeHandler;
 				palette.SecondaryColorChanged -= SecondaryChangeHandler;
-				this.OnNotify -= ActiveWindowChangeHandler;
+				IsActivePropertyDefinition.Unnotify (this, ActiveWindowChangeHandler);
 			};
 		}
 

--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -171,11 +171,9 @@ public sealed class TextTool : BaseTool
 					Gtk.Settings.GetDefault ()!.GtkFontName!)),
 			};
 			font_button.SetDialog (fontDialog);
-			font_button.OnNotify += (_, args) => {
-				if (args.Pspec.GetName () == "font-desc") {
-					HandleFontChanged ();
-				}
-			};
+			Gtk.FontDialogButton.FontDescPropertyDefinition.Notify (font_button, (_, _) => {
+				HandleFontChanged ();
+			});
 		}
 
 		tb.Append (font_button);

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -429,11 +429,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 	private void WireUpEvents ()
 	{
 		// Handle preset changes
-		// Gtk.DropDown doesn't have a proper signal for this, so listen to changes in the 'selected' property.
-		preset_dropdown.OnNotify += (o, args) => {
-			if (args.Pspec.GetName () != "selected")
-				return;
-
+		Gtk.DropDown.SelectedPropertyDefinition.Notify (preset_dropdown, (_, _) => {
 			Size new_size = IsValidSize ? NewImageSize : Size.Empty;
 
 			string? preset_text = preset_dropdown_model.GetString (preset_dropdown.Selected);
@@ -455,7 +451,8 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 			UpdateOrientation ();
 			preview_box.Update (NewImageSize);
-		};
+		});
+
 		// Handle width/height entry changes
 		width_entry.OnChanged ((o, e) => {
 			if (suppress_events)


### PR DESCRIPTION
This can generally be replaced by using the `Notify` method on the property definition, which avoids comparing against the string property name and also avoids running the event handler for every property change on the object