### PR TITLE
Colors in `Palette` exposed as `ReadOnlyCollection`

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -791,8 +791,8 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 
 			Palette currentPalette = palette.CurrentPalette;
 
-			for (int i = 0; i < currentPalette.Count; i++)
-				g.FillRectangle (PaletteWidget.GetSwatchBounds (palette, i, palette_rect), currentPalette[i]);
+			for (int i = 0; i < currentPalette.Colors.Count; i++)
+				g.FillRectangle (PaletteWidget.GetSwatchBounds (palette, i, palette_rect), currentPalette.Colors[i]);
 		});
 
 		Gtk.Box swatchBox = new () { Spacing = spacing };
@@ -960,7 +960,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			if (index < 0)
 				return;
 
-			CurrentColor = palette.CurrentPalette[index];
+			CurrentColor = palette.CurrentPalette.Colors[index];
 			UpdateView ();
 		}
 	}

--- a/Pinta.Gui.Widgets/Widgets/PaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/PaletteWidget.cs
@@ -18,7 +18,7 @@ internal static class PaletteWidget
 		int max =
 			recentColorPalette
 			? palette.RecentlyUsedColors.Count
-			: palette.CurrentPalette.Count;
+			: palette.CurrentPalette.Colors.Count;
 
 		// This could be more efficient, but is good enough for now
 		for (int i = 0; i < max; i++)

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -120,14 +120,14 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 					break;
 
 				if (button == GtkExtensions.MOUSE_RIGHT_BUTTON) {
-					palette.SecondaryColor = palette.CurrentPalette[index];
+					palette.SecondaryColor = palette.CurrentPalette.Colors[index];
 				} else if (button == GtkExtensions.MOUSE_LEFT_BUTTON) {
-					palette.PrimaryColor = palette.CurrentPalette[index];
+					palette.PrimaryColor = palette.CurrentPalette.Colors[index];
 				} else {
-					var colors = await GetUserChosenColor ([palette.CurrentPalette[index]], 0, Translations.GetString ("Choose Palette Color"));
+					var colors = await GetUserChosenColor ([palette.CurrentPalette.Colors[index]], 0, Translations.GetString ("Choose Palette Color"));
 					var color = colors?[0];
 					if (color != null)
-						palette.CurrentPalette[index] = color.Value;
+						palette.CurrentPalette.SetColor (index, color.Value);
 				}
 
 				break;
@@ -181,8 +181,8 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		// Draw color swatches
 		var currentPalette = palette.CurrentPalette;
 
-		for (int i = 0; i < currentPalette.Count; i++)
-			g.FillRectangle (PaletteWidget.GetSwatchBounds (palette, i, palette_rect), currentPalette[i]);
+		for (int i = 0; i < currentPalette.Colors.Count; i++)
+			g.FillRectangle (PaletteWidget.GetSwatchBounds (palette, i, palette_rect), currentPalette.Colors[i]);
 
 		g.Dispose ();
 	}

--- a/Pinta/Actions/Edit/ResizePaletteAction.cs
+++ b/Pinta/Actions/Edit/ResizePaletteAction.cs
@@ -62,7 +62,7 @@ internal sealed class ResizePaletteAction : IActionHandler
 			Translations.GetString ("New palette size:"),
 			1,
 			96,
-			palette.CurrentPalette.Count);
+			palette.CurrentPalette.Colors.Count);
 
 		Gtk.ResponseType response = await dialog.RunAsync ();
 


### PR DESCRIPTION
I was thinking of being able to use the current palette for the dithering effect. To make that possible we have to be able to enumerate the colors in the palette.

Perhaps designing the class in a different way (from scratch) would be cleaner, but I think this will do for now.