### PR TITLE
Only add a handler for the brush width's OnValueChanged event once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Thanks to the following contributors who worked on this release:
 - Fixed a bug where cancelling the color picker dialog could still update the palette colors (#1390, #1411)
 - The text tool's "Normal and Outline" mode now draws the outline behind the text to avoid obscuring it (#1423, #1426) 
 - Improved the handling of negative angle values in the Rotate / Zoom Layer dialog (#1142, #1440)
+- Fixed potential crashes when adjusting the brush width (#1340)
 
 ## [3.0](https://github.com/PintaProject/Pinta/releases/tag/3.0) - 2025/04/11
 

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -47,6 +47,8 @@ public abstract class BaseBrushTool : BaseTool
 		Palette = services.GetService<IPaletteService> ();
 
 		BrushWidthSpinButton.TooltipText = Translations.GetString ("Change brush width. Shortcut keys: [ ]");
+		// Change the cursor when the BrushWidth is changed.
+		BrushWidthSpinButton.OnValueChanged += (_, _) => SetCursor (DefaultCursor);
 	}
 
 	protected override bool ShowAntialiasingButton => true;
@@ -65,9 +67,6 @@ public abstract class BaseBrushTool : BaseTool
 
 		tb.Append (BrushWidthLabel);
 		tb.Append (BrushWidthSpinButton);
-
-		// Change the cursor when the BrushWidth is changed.
-		BrushWidthSpinButton.OnValueChanged += (sender, e) => SetCursor (DefaultCursor);
 	}
 
 	protected override void OnMouseDown (Document document, ToolMouseEventArgs e)


### PR DESCRIPTION
This was being done every time the tool was entered, which is incorrect and will cause the event handler to be run multiple times (after the fixes in gir.core for how closures are implemented).

This also triggered a bug in gir.core from subscribing to the signal multiple times with the exact same delegate.

Bug: #1340