### PR TITLE
[GUI] Move "View" menu out of the hamburger menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Thanks to the following contributors who worked on this release:
 - @JGCarroll
 - @Lehonti
 - @UrtsiSantsi
+- @pedropaulosuzuki
 
 ### Added
 - Added an option (View -> Show/Hide -> Menu Bar) to switch to a menu bar layout instead of a header bar (#781, #1418)
@@ -21,6 +22,7 @@ Thanks to the following contributors who worked on this release:
 - Improved the sizing of the toolbox icons, particularly for high DPI displays (#1374)
 - The text tool now uses the system's default font rather than being hardcoded to Arial, which may not exist on some systems (#1422, #1421)
 - Removed use of deprecated Gtk.FontButton (#1421)
+- View menu moved from hamburger menu to dedicated button (#1428, #1471)
 
 ### Fixed
 - Fixed an issue where the toolbar's height could change when switching tools (#1370, #1391) 

--- a/Pinta.Resources/Icons.cs
+++ b/Pinta.Resources/Icons.cs
@@ -238,6 +238,7 @@ public static class Icons
 	public const string ToolZoom = "tool-zoom-symbolic";
 
 	public const string ViewGrid = "view-grid";
+	public const string ViewMenu = "view-reveal-symbolic";
 	public const string ViewRulers = "view-rulers";
 	public const string ViewZoom100 = "view-zoom-100";
 	public const string ViewZoomSelection = "view-zoom-selection";

--- a/Pinta.Resources/Icons.cs
+++ b/Pinta.Resources/Icons.cs
@@ -73,6 +73,7 @@ public static class StandardIcons
 	public const string ValueIncrease = "value-increase-symbolic";
 	public const string ViewFullscreen = "view-fullscreen-symbolic";
 	public const string ViewRefresh = "view-refresh-symbolic";
+	public const string ViewReveal = "view-reveal-symbolic";
 
 	public const string WindowClose = "window-close-symbolic";
 	public const string WindowMaximize = "window-maximize-symbolic";
@@ -238,7 +239,6 @@ public static class Icons
 	public const string ToolZoom = "tool-zoom-symbolic";
 
 	public const string ViewGrid = "view-grid";
-	public const string ViewMenu = "view-reveal-symbolic";
 	public const string ViewRulers = "view-rulers";
 	public const string ViewZoom100 = "view-zoom-100";
 	public const string ViewZoomSelection = "view-zoom-selection";

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -387,6 +387,11 @@ internal sealed class MainWindow
 		PintaCore.Actions.Edit.RegisterActions (app, edit_menu);
 		this.menu_bar.AppendSubmenu (Translations.GetString ("_Edit"), edit_menu);
 
+		this.view_menu = Gio.Menu.New ();
+		PintaCore.Actions.View.RegisterActions (app, this.view_menu);
+		if (using_menu_bar)
+			this.menu_bar.AppendSubmenu (Translations.GetString ("_View"), this.view_menu);
+
 		this.image_menu = Gio.Menu.New ();
 		PintaCore.Actions.Image.RegisterActions (app, this.image_menu);
 		if (using_menu_bar)
@@ -398,11 +403,6 @@ internal sealed class MainWindow
 
 		// When using a header bar, the View, Image, Effects, and Adjustments menus
 		// are shown as menu buttons in the toolbar (see CreateMainToolBar ())
-		this.view_menu = Gio.Menu.New ();
-		PintaCore.Actions.View.RegisterActions (app, this.view_menu);
-		if (using_menu_bar)
-			this.menu_bar.AppendSubmenu (Translations.GetString ("_View"), this.view_menu);
-		
 		var adj_menu = Gio.Menu.New ();
 		if (using_menu_bar)
 			this.menu_bar.AppendSubmenu (Translations.GetString ("_Adjustments"), adj_menu);
@@ -459,7 +459,7 @@ internal sealed class MainWindow
 
 			header_bar.PackEnd (new Gtk.MenuButton () {
 				MenuModel = this.view_menu,
-				IconName = Resources.Icons.ViewMenu,
+				IconName = Resources.StandardIcons.ViewReveal,
 				TooltipText = Translations.GetString ("View"),
 			});
 

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -398,7 +398,6 @@ internal sealed class MainWindow
 
 		// When using a header bar, the View, Image, Effects, and Adjustments menus
 		// are shown as menu buttons in the toolbar (see CreateMainToolBar ())
-
 		this.view_menu = Gio.Menu.New ();
 		PintaCore.Actions.View.RegisterActions (app, this.view_menu);
 		if (using_menu_bar)

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -43,6 +43,7 @@ internal sealed class MainWindow
 	Dock dock = null!;
 	Gio.Menu menu_bar = null!;
 	Gio.Menu image_menu = null!;
+	Gio.Menu view_menu = null!;
 
 	CanvasPad canvas_pad = null!;
 
@@ -386,10 +387,6 @@ internal sealed class MainWindow
 		PintaCore.Actions.Edit.RegisterActions (app, edit_menu);
 		this.menu_bar.AppendSubmenu (Translations.GetString ("_Edit"), edit_menu);
 
-		var view_menu = Gio.Menu.New ();
-		PintaCore.Actions.View.RegisterActions (app, view_menu);
-		this.menu_bar.AppendSubmenu (Translations.GetString ("_View"), view_menu);
-
 		this.image_menu = Gio.Menu.New ();
 		PintaCore.Actions.Image.RegisterActions (app, this.image_menu);
 		if (using_menu_bar)
@@ -399,8 +396,14 @@ internal sealed class MainWindow
 		PintaCore.Actions.Layers.RegisterActions (app, layers_menu);
 		this.menu_bar.AppendSubmenu (Translations.GetString ("_Layers"), layers_menu);
 
-		// When using a header bar, the Image, Effects, and Adjustments menus
+		// When using a header bar, the View, Image, Effects, and Adjustments menus
 		// are shown as menu buttons in the toolbar (see CreateMainToolBar ())
+
+		this.view_menu = Gio.Menu.New ();
+		PintaCore.Actions.View.RegisterActions (app, this.view_menu);
+		if (using_menu_bar)
+			this.menu_bar.AppendSubmenu (Translations.GetString ("_View"), this.view_menu);
+		
 		var adj_menu = Gio.Menu.New ();
 		if (using_menu_bar)
 			this.menu_bar.AppendSubmenu (Translations.GetString ("_Adjustments"), adj_menu);
@@ -422,7 +425,7 @@ internal sealed class MainWindow
 		this.menu_bar.AppendSubmenu (Translations.GetString ("_Help"), help_menu);
 
 		var pad_section = Gio.Menu.New ();
-		view_menu.AppendSection (null, pad_section);
+		this.view_menu.AppendSection (null, pad_section);
 
 		PintaCore.Chrome.InitializeMainMenu (adj_menu, effects_menu);
 	}
@@ -453,6 +456,12 @@ internal sealed class MainWindow
 				MenuModel = this.image_menu,
 				IconName = Resources.StandardIcons.ImageGeneric,
 				TooltipText = Translations.GetString ("Image"),
+			});
+
+			header_bar.PackEnd (new Gtk.MenuButton () {
+				MenuModel = this.view_menu,
+				IconName = Resources.Icons.ViewMenu,
+				TooltipText = Translations.GetString ("View"),
 			});
 
 			PintaCore.Actions.CreateHeaderToolBar (header_bar);


### PR DESCRIPTION
Creates a separate button for the View menu, making it easier to access (when compared to the current hamburger submenu solution). Doesn't change behavior when using the menubar.

Used the icon 'view-reveal-symbolic'. Not sure if it's always bundled with GTK/LibAdwaita or if it's a system icon that might cause problems on Windows/MacOS builds (if so, help needed here).

Part of #1428.