### PR TITLE
Refactored `Command`

### DIFF
--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -38,19 +38,22 @@ public class Command
 {
 	public Gio.SimpleAction Action { get; }
 	public string Name => Action.Name!;
-	public SignalHandler<Gio.SimpleAction, Gio.SimpleAction.ActivateSignalArgs>? Activated;
+	public event SignalHandler<Gio.SimpleAction, Gio.SimpleAction.ActivateSignalArgs>? Activated;
 	public void Activate ()
 	{
 		Action.Activate (null);
 	}
 
 	public string Label { get; }
-	public string? ShortLabel { get; set; }
+	public string? ShortLabel { get; init; }
 	public string? Tooltip { get; }
 	public string? IconName { get; }
 	public string FullName => $"app.{Name}";
-	public bool IsImportant { get; set; } = false;
-	public bool Sensitive { get => Action.Enabled; set => Action.Enabled = value; }
+	public bool IsImportant { get; } = false;
+	public bool Sensitive {
+		get => Action.Enabled;
+		set => Action.Enabled = value;
+	}
 	public ImmutableArray<string> Shortcuts { get; }
 
 	public Command (
@@ -74,22 +77,20 @@ public class Command
 
 		Shortcuts =
 			shortcuts is null
-			? ImmutableArray<string>.Empty
-			: shortcuts.ToImmutableArray ();
+			? []
+			: [.. shortcuts];
 	}
 
 	public Gio.MenuItem CreateMenuItem ()
-	{
-		return Gio.MenuItem.New (Label, FullName);
-	}
+		=> Gio.MenuItem.New (Label, FullName);
 }
 
 public sealed class ToggleCommand : Command
 {
 	public ToggleCommand (string name, string label, string? tooltip, string? stock_id)
-	    : base (name, label, tooltip, stock_id, GLib.Variant.NewBoolean (false))
+		: base (name, label, tooltip, stock_id, GLib.Variant.NewBoolean (false))
 	{
-		Activated += (o, args) => {
+		Activated += (_, _) => {
 			bool active = !State.GetBoolean ();
 			Toggled?.Invoke (active, interactive: true);
 			Action.ChangeState (GLib.Variant.NewBoolean (active));
@@ -99,15 +100,14 @@ public sealed class ToggleCommand : Command
 	public bool Value {
 		get => State.GetBoolean ();
 		set {
-			if (value != Value) {
-				Toggled?.Invoke (value, interactive: false);
-				Action.ChangeState (GLib.Variant.NewBoolean (value));
-			}
+			if (value == Value) return;
+			Toggled?.Invoke (value, interactive: false);
+			Action.ChangeState (GLib.Variant.NewBoolean (value));
 		}
 	}
 
 	public delegate void ToggledHandler (bool value, bool interactive);
-	public ToggledHandler? Toggled;
+	public event ToggledHandler? Toggled;
 
 	private GLib.Variant State => Action.GetState () ?? throw new InvalidOperationException ("Action should not be stateless!");
 }

--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -87,8 +87,19 @@ public class Command
 
 public sealed class ToggleCommand : Command
 {
-	public ToggleCommand (string name, string label, string? tooltip, string? stock_id)
-		: base (name, label, tooltip, stock_id, GLib.Variant.NewBoolean (false))
+	public ToggleCommand (
+		string name,
+		string label,
+		string? tooltip,
+		string? stock_id
+	)
+		: base (
+			name,
+			label,
+			tooltip,
+			stock_id,
+			GLib.Variant.NewBoolean (false)
+		)
 	{
 		Activated += (_, _) => {
 			bool active = !State.GetBoolean ();

--- a/Pinta.Core/Actions/FileActions.cs
+++ b/Pinta.Core/Actions/FileActions.cs
@@ -43,9 +43,7 @@ public sealed class FileActions
 
 	private readonly SystemManager system;
 	private readonly AppActions app;
-	public FileActions (
-		SystemManager system,
-		AppActions app)
+	public FileActions (SystemManager system, AppActions app)
 	{
 		New = new Command (
 			"new",
@@ -152,6 +150,9 @@ public sealed class FileActions
 	{
 		ModifyCompressionEventArgs e = new (defaultCompression, parent);
 		ModifyCompression?.Invoke (this, e);
-		return e.Cancel ? -1 : e.Quality;
+		return
+			e.Cancel
+			? -1
+			: e.Quality;
 	}
 }

--- a/Pinta.Core/Actions/FileActions.cs
+++ b/Pinta.Core/Actions/FileActions.cs
@@ -25,7 +25,6 @@
 // THE SOFTWARE.
 
 using System;
-using System.Collections.Immutable;
 
 namespace Pinta.Core;
 
@@ -53,7 +52,8 @@ public sealed class FileActions
 			Translations.GetString ("New..."),
 			null,
 			Resources.StandardIcons.DocumentNew,
-			shortcuts: ["<Primary>N"]);
+			shortcuts: ["<Primary>N"]
+		) { ShortLabel = Translations.GetString ("New") };
 
 		NewScreenshot = new Command (
 			"NewScreenshot",
@@ -66,7 +66,8 @@ public sealed class FileActions
 			Translations.GetString ("Open..."),
 			null,
 			Resources.StandardIcons.DocumentOpen,
-			shortcuts: ["<Primary>O"]);
+			shortcuts: ["<Primary>O"]
+		) { ShortLabel = Translations.GetString ("Open") };
 
 		Close = new Command (
 			"close",
@@ -94,9 +95,6 @@ public sealed class FileActions
 			Translations.GetString ("Print"),
 			null,
 			Resources.StandardIcons.DocumentPrint);
-
-		New.ShortLabel = Translations.GetString ("New");
-		Open.ShortLabel = Translations.GetString ("Open");
 
 		this.system = system;
 		this.app = app;


### PR DESCRIPTION
- Event handlers didn't have the `event` keyword, so it was added
- Some properties didn't need setters, so they were removed or changed