### PR TITLE
Fix the data root directory for installed Windows builds

### DIFF
--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -97,7 +97,16 @@ public sealed class SystemManager : ISystemService
 			return Path.Combine (contents_dir!.FullName, "Resources", "share");
 		}
 
+		// On Windows, the installed executable is under Pinta/bin and data is under Pinta/share.
+		if (GetOperatingSystem () == OS.Windows) {
+			string parentDir = Path.Combine (app_dir, "..");
+			bool develMode = Path.Exists (Path.Combine (parentDir, "Pinta.sln"));
+			if (!develMode)
+				return Path.Combine (parentDir, "share");
+		}
+
 		// Otherwise, translations etc are contained under the executable's folder.
+		// (e.g. for local development builds)
 		return app_dir;
 	}
 


### PR DESCRIPTION
This broke with #622 which changed the directory layout for the installer.

Bug: #1473