### PR TITLE
Resize panel to full size on Maximize

### DIFF
--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -85,7 +85,7 @@ public sealed class DockPanel : Gtk.Box
 			popover.Child = null;
 
 			Pane.StartChild = Item;
-			Pane.ResizeStartChild = false;
+			Pane.ResizeStartChild = true;
 			Pane.ShrinkStartChild = false;
 		}
 

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -165,35 +165,39 @@ public sealed class DockPanel : Gtk.Box
 		}
 	}
 
-	private void UpdatePaneConnections ()
+	private void UpdatePaneConnections()
 	{
 		// Get all maximized (visible) items
-		var maximizedItems = items.Where (item => !item.IsMinimized).ToArray ();
-
+		var maximizedItems = items.Where(item => !item.IsMinimized).ToArray();
+		
 		// Reset all EndChild connections
-		foreach (var item in items) {
+		foreach (var item in items)
+		{
 			item.Pane.EndChild = null;
 		}
-
+		
 		// Remove all panes from the container
-		var currentChild = GetFirstChild ();
-		while (currentChild != null && currentChild != dock_bar) {
-			var next = currentChild.GetNextSibling ();
-			Remove (currentChild);
+		var currentChild = GetFirstChild();
+		while (currentChild != null && currentChild != dock_bar)
+		{
+			var next = currentChild.GetNextSibling();
+			Remove(currentChild);
 			currentChild = next;
 		}
-
-		if (maximizedItems.Length > 0) {
+		
+		if (maximizedItems.Length > 0)
+		{
 			// Rebuild the chain connecting only maximized panes
-			for (int i = 0; i < maximizedItems.Length - 1; i++) {
+			for (int i = 0; i < maximizedItems.Length - 1; i++)
+			{
 				maximizedItems[i].Pane.EndChild = maximizedItems[i + 1].Pane;
 			}
-
+			
 			// Add the root pane (first maximized pane) back to the container
 			var rootPane = maximizedItems[0].Pane;
 			rootPane.Hexpand = true;
 			rootPane.Halign = Gtk.Align.Fill;
-			Prepend (rootPane);
+			Prepend(rootPane);
 		}
 	}
 }

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -85,7 +85,7 @@ public sealed class DockPanel : Gtk.Box
 			popover.Child = null;
 
 			Pane.StartChild = Item;
-			Pane.ResizeStartChild = true;
+			Pane.ResizeStartChild = false;
 			Pane.ShrinkStartChild = false;
 
 			updateConnections ();

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -165,39 +165,35 @@ public sealed class DockPanel : Gtk.Box
 		}
 	}
 
-	private void UpdatePaneConnections()
+	private void UpdatePaneConnections ()
 	{
 		// Get all maximized (visible) items
-		var maximizedItems = items.Where(item => !item.IsMinimized).ToArray();
-		
+		var maximizedItems = items.Where (item => !item.IsMinimized).ToArray ();
+
 		// Reset all EndChild connections
-		foreach (var item in items)
-		{
+		foreach (var item in items) {
 			item.Pane.EndChild = null;
 		}
-		
+
 		// Remove all panes from the container
-		var currentChild = GetFirstChild();
-		while (currentChild != null && currentChild != dock_bar)
-		{
-			var next = currentChild.GetNextSibling();
-			Remove(currentChild);
+		var currentChild = GetFirstChild ();
+		while (currentChild != null && currentChild != dock_bar) {
+			var next = currentChild.GetNextSibling ();
+			Remove (currentChild);
 			currentChild = next;
 		}
-		
-		if (maximizedItems.Length > 0)
-		{
+
+		if (maximizedItems.Length > 0) {
 			// Rebuild the chain connecting only maximized panes
-			for (int i = 0; i < maximizedItems.Length - 1; i++)
-			{
+			for (int i = 0; i < maximizedItems.Length - 1; i++) {
 				maximizedItems[i].Pane.EndChild = maximizedItems[i + 1].Pane;
 			}
-			
+
 			// Add the root pane (first maximized pane) back to the container
 			var rootPane = maximizedItems[0].Pane;
 			rootPane.Hexpand = true;
 			rootPane.Halign = Gtk.Align.Fill;
-			Prepend(rootPane);
+			Prepend (rootPane);
 		}
 	}
 }

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -75,7 +75,7 @@ public sealed class DockPanel : Gtk.Box
 		public bool IsMinimized
 			=> popover.Child is not null;
 
-		public void UpdateOnMaximize (Gtk.Box dockBar)
+		public void UpdateOnMaximize (Gtk.Box dockBar, Action updateConnections)
 		{
 			// Remove the reopen button from the dock bar.
 			// Note that it might not already be in the dock bar, e.g. on startup.
@@ -87,15 +87,19 @@ public sealed class DockPanel : Gtk.Box
 			Pane.StartChild = Item;
 			Pane.ResizeStartChild = true;
 			Pane.ShrinkStartChild = false;
+
+			updateConnections ();
 		}
 
-		public void UpdateOnMinimize (Gtk.Box dock_bar)
+		public void UpdateOnMinimize (Gtk.Box dock_bar, Action updateConnections)
 		{
 			Pane.StartChild = null;
 			popover.Child = Item;
 
 			dock_bar.Append (ReopenButton);
 			ReopenButton.Active = false;
+
+			updateConnections ();
 		}
 	}
 
@@ -130,10 +134,10 @@ public sealed class DockPanel : Gtk.Box
 		}
 
 		items.Add (panelItem);
-		panelItem.UpdateOnMaximize (dock_bar);
+		panelItem.UpdateOnMaximize (dock_bar, UpdatePaneConnections);
 
-		item.MinimizeClicked += (_, _) => panelItem.UpdateOnMinimize (dock_bar);
-		item.MaximizeClicked += (_, _) => panelItem.UpdateOnMaximize (dock_bar);
+		item.MinimizeClicked += (_, _) => panelItem.UpdateOnMinimize (dock_bar, UpdatePaneConnections);
+		item.MaximizeClicked += (_, _) => panelItem.UpdateOnMaximize (dock_bar, UpdatePaneConnections);
 	}
 
 	public void SaveSettings (ISettingsService settings)
@@ -158,6 +162,42 @@ public sealed class DockPanel : Gtk.Box
 			panel_item.Pane.Position = settings.GetSetting<int> (
 				SplitPosKey (panel_item), panel_item.Pane.Position);
 #endif
+		}
+	}
+
+	private void UpdatePaneConnections()
+	{
+		// Get all maximized (visible) items
+		var maximizedItems = items.Where(item => !item.IsMinimized).ToArray();
+		
+		// Reset all EndChild connections
+		foreach (var item in items)
+		{
+			item.Pane.EndChild = null;
+		}
+		
+		// Remove all panes from the container
+		var currentChild = GetFirstChild();
+		while (currentChild != null && currentChild != dock_bar)
+		{
+			var next = currentChild.GetNextSibling();
+			Remove(currentChild);
+			currentChild = next;
+		}
+		
+		if (maximizedItems.Length > 0)
+		{
+			// Rebuild the chain connecting only maximized panes
+			for (int i = 0; i < maximizedItems.Length - 1; i++)
+			{
+				maximizedItems[i].Pane.EndChild = maximizedItems[i + 1].Pane;
+			}
+			
+			// Add the root pane (first maximized pane) back to the container
+			var rootPane = maximizedItems[0].Pane;
+			rootPane.Hexpand = true;
+			rootPane.Halign = Gtk.Align.Fill;
+			Prepend(rootPane);
 		}
 	}
 }

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -92,7 +92,6 @@ public sealed class DockPanel : Gtk.Box
 		public void UpdateOnMinimize (Gtk.Box dock_bar)
 		{
 			Pane.StartChild = null;
-			Pane.PositionSet = false;
 			popover.Child = Item;
 
 			dock_bar.Append (ReopenButton);

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -85,13 +85,14 @@ public sealed class DockPanel : Gtk.Box
 			popover.Child = null;
 
 			Pane.StartChild = Item;
-			Pane.ResizeStartChild = false;
+			Pane.ResizeStartChild = true;
 			Pane.ShrinkStartChild = false;
 		}
 
 		public void UpdateOnMinimize (Gtk.Box dock_bar)
 		{
 			Pane.StartChild = null;
+			Pane.PositionSet = false;
 			popover.Child = Item;
 
 			dock_bar.Append (ReopenButton);

--- a/Pinta.Docking/DockPanel.cs
+++ b/Pinta.Docking/DockPanel.cs
@@ -133,7 +133,13 @@ public sealed class DockPanel : Gtk.Box
 		items.Add (panelItem);
 		panelItem.UpdateOnMaximize (dock_bar);
 
-		item.MinimizeClicked += (_, _) => panelItem.UpdateOnMinimize (dock_bar);
+		item.MinimizeClicked += (_, _) => {
+			panelItem.UpdateOnMinimize (dock_bar);
+
+			int index = items.IndexOf (panelItem);
+			if (index > 0)
+				items[index - 1].Pane.PositionSet = false;
+		};
 		item.MaximizeClicked += (_, _) => panelItem.UpdateOnMaximize (dock_bar);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/PintaProject/Pinta/issues/1472

After minimizing a panel in a vertical stack, the remaining pane wouldn’t expand correctly. The fix sets ResizeStartChild to true when maximizing and clears the PositionSet flag when minimizing.

- Allow the first pane in a stack to resize by enabling ResizeStartChild during maximize
- Clear the pane’s stored divider position on minimize to let the remaining panel fill the space