### PR TITLE
Add a Union method to RectangleD

### DIFF
--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -4,7 +4,7 @@
 // Author:
 //       Cameron White <cameronwhite91@gmail.com>
 //
-// Copyright (c) 2022 
+// Copyright (c) 2022
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,18 @@ public readonly record struct RectangleD (
 	public RectangleD (in PointD point, double width, double height)
 		: this (point.X, point.Y, width, height)
 	{ }
+
+	public static RectangleD FromLTRB (
+		double left,
+		double top,
+		double right,
+		double bottom
+	)
+		=> new (
+			left,
+			top,
+			right - left + 1,
+			bottom - top + 1);
 
 	public static RectangleD Zero { get; } = new (0d, 0d, 0d, 0d);
 
@@ -81,6 +93,15 @@ public readonly record struct RectangleD (
 
 	public readonly PointD GetCenter ()
 		=> new (X + 0.5 * Width, Y + 0.5 * Height);
+
+	public RectangleD Union (in RectangleD b)
+	{
+		double left = Math.Min (Left, b.Left);
+		double right = Math.Max (Right, b.Right);
+		double top = Math.Min (Top, b.Top);
+		double bottom = Math.Max (Bottom, b.Bottom);
+		return FromLTRB (left, top, right, bottom);
+	}
 
 	public readonly RectangleD Inflated (double width, double height)
 	{

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
@@ -55,44 +55,6 @@ partial class CairoExtensions
 			y2 - y1);
 	}
 
-	/// <summary>
-	/// Computes and returns the Union (largest possible combination) of two Rectangles.
-	/// The two given Rectangles do not need to intersect.
-	///
-	/// Another way to understand this function is that it computes and returns the
-	/// smallest possible Rectangle that encompasses both given Rectangles.
-	///
-	/// This function works as is intuitively expected with neither, either, or both given Rectangles being null.
-	/// </summary>
-	/// <param name="r1">The first given Rectangle.</param>
-	/// <param name="r2">The second given Rectangle.</param>
-	/// <returns></returns>
-	public static RectangleD? UnionRectangles (
-		this RectangleD? r1,
-		RectangleD? r2)
-	{
-		if (!r1.HasValue) //r2 is the only given Rectangle that could still have a value, and if it's null, return that anyways.
-			return r2;
-
-		if (!r2.HasValue) //Only r1 has a value.
-			return r1;
-
-		// If execution reaches this point, then both r1 and r2 have values.
-
-		//Calculate the left-most and top-most values.
-
-		PointD min = new (
-			X: Math.Min (r1.Value.X, r2.Value.X),
-			Y: Math.Min (r1.Value.Y, r2.Value.Y));
-
-		//Calculate the right-most and bottom-most values and subtract the left-most and top-most values from them to get the width and height.
-		return new (
-			min.X,
-			min.Y,
-			Math.Max (r1.Value.X + r1.Value.Width, r2.Value.X + r2.Value.Width) - min.X,
-			Math.Max (r1.Value.Y + r1.Value.Height, r2.Value.Y + r2.Value.Height) - min.Y);
-	}
-
 	public static RectangleI GetRectangleFromPoints (
 		PointI a,
 		PointI b,
@@ -379,26 +341,6 @@ partial class CairoExtensions
 		double newY = p.Y;
 		m.TransformPoint (ref newX, ref newY);
 		p = new PointD (newX, newY);
-	}
-
-	/// <summary>
-	/// Port of gdk_cairo_get_clip_rectangle from GTK3
-	/// </summary>
-	public static bool GetClipRectangle (
-		Context context,
-		out RectangleI rect)
-	{
-		context.ClipExtents (
-			out double x1,
-			out double y1,
-			out double x2,
-			out double y2);
-
-		bool clip_exists = x1 < x2 && y1 < y2;
-
-		rect = new RectangleD (x1, y1, x2 - x1, y2 - y1).ToInt ();
-
-		return clip_exists;
 	}
 
 	private static void GetRectangle (this Region region, int i, out CairoRectangleInt rect)

--- a/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ArrowedEditEngine.cs
-//  
+//
 // Author:
 //	   Andrew Davis <andrew.3.1415@gmail.com>
-// 
+//
 // Copyright (c) 2014 Andrew Davis, GSoC 2014
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -232,7 +232,7 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 	}
 
 
-	protected override void DrawExtras (ref RectangleD? dirty, Context g, ShapeEngine engine)
+	protected override void DrawExtras (ref RectangleD? totalDirty, Context g, ShapeEngine engine)
 	{
 		if (engine is LineCurveSeriesEngine lCSEngine && engine.ControlPoints.Count > 0) {
 
@@ -240,25 +240,25 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 			ReadOnlySpan<GeneratedPoint> genPoints = engine.GeneratedPoints;
 
 			if (lCSEngine.Arrow1.Show && genPoints.Length > 1) {
-				var rect = lCSEngine.Arrow1.Draw (
+				RectangleD dirty = lCSEngine.Arrow1.Draw (
 					g,
 					lCSEngine.OutlineColor,
 					genPoints[0].Position,
 					genPoints[1].Position);
-				dirty = dirty.UnionRectangles (rect);
+				totalDirty = totalDirty?.Union (dirty) ?? dirty;
 			}
 
 			if (lCSEngine.Arrow2.Show && genPoints.Length > 1) {
-				var rect = lCSEngine.Arrow2.Draw (
+				RectangleD dirty = lCSEngine.Arrow2.Draw (
 					g,
 					lCSEngine.OutlineColor,
 					genPoints[^1].Position,
 					genPoints[^2].Position);
-				dirty = dirty.UnionRectangles (rect);
+				totalDirty = totalDirty?.Union (dirty) ?? dirty;
 			}
 		}
 
-		base.DrawExtras (ref dirty, g, engine);
+		base.DrawExtras (ref totalDirty, g, engine);
 	}
 
 	private Gtk.Separator ArrowSeparator

--- a/tests/Pinta.Core.Tests/RectangleTests.cs
+++ b/tests/Pinta.Core.Tests/RectangleTests.cs
@@ -30,6 +30,8 @@ internal sealed class RectangleTests
 		Assert.That (built.Top, Is.EqualTo (t));
 		Assert.That (built.Right, Is.EqualTo (r));
 		Assert.That (built.Bottom, Is.EqualTo (b));
+
+		Assert.That (RectangleD.FromLTRB (l, t, r, b), Is.EqualTo (built.ToDouble ()));
 	}
 
 	[TestCaseSource (nameof (not_equal_cases))]
@@ -38,7 +40,10 @@ internal sealed class RectangleTests
 
 	[TestCaseSource (nameof (union_cases))]
 	public void CorrectUnion (RectangleI a, RectangleI b, RectangleI expected)
-		=> Assert.That (a.Union (b), Is.EqualTo (expected));
+	{
+		Assert.That (a.Union (b), Is.EqualTo (expected));
+		Assert.That (a.ToDouble ().Union (b.ToDouble ()), Is.EqualTo (expected.ToDouble ()));
+	}
 
 	[TestCaseSource (nameof (intersect_cases))]
 	public void CorrectIntersection (RectangleI a, RectangleI b, RectangleI expected)


### PR DESCRIPTION
- This was living in `CairoExtensions` as an extension method on nullable rectangles, but really should now be in the `RectangleD` class to match `RectangleI`. Although the extension method was convenient in some cases, it also led to some very ugly casting in order to use it
- Also removed unused method `GetClipRectangle()`