### PR TITLE
Move methods for creating rectangles from a pair of points into the RectangleD / RectangleI classes

### DIFF
--- a/Pinta.Core/Classes/DocumentWorkspace.cs
+++ b/Pinta.Core/Classes/DocumentWorkspace.cs
@@ -170,7 +170,7 @@ public sealed class DocumentWorkspace
 		PointD canvasTopLeft = ViewPointToCanvas (windowTopLeft);
 		PointD canvasBtmRight = ViewPointToCanvas (windowBtmRight);
 
-		RectangleI canvasRect = CairoExtensions.PointsToRectangle (canvasTopLeft, canvasBtmRight).ToInt ();
+		RectangleI canvasRect = RectangleD.FromPoints (canvasTopLeft, canvasBtmRight).ToInt ();
 		OnCanvasInvalidated (new CanvasInvalidatedEventArgs (canvasRect));
 	}
 

--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -50,6 +50,20 @@ public readonly record struct RectangleD (
 			right - left + 1,
 			bottom - top + 1);
 
+	/// <summary>
+	/// Creates a rectangle with positive width & height from the provided points.
+	/// Note that the second point will be the bottom right corner of the rectangle,
+	/// and the pixel is not inside the rectangle itself.
+	/// </summary>
+	public static RectangleD FromPoints (in PointD a, in PointD b)
+	{
+		double x1 = Math.Min (a.X, b.X);
+		double y1 = Math.Min (a.Y, b.Y);
+		double x2 = Math.Max (a.X, b.X);
+		double y2 = Math.Max (a.Y, b.Y);
+		return new (x1, y1, x2 - x1, y2 - y1);
+	}
+
 	public static RectangleD Zero { get; } = new (0d, 0d, 0d, 0d);
 
 	public readonly RectangleI ToInt ()

--- a/Pinta.Core/Classes/Rectangle.cs
+++ b/Pinta.Core/Classes/Rectangle.cs
@@ -152,6 +152,20 @@ public readonly record struct RectangleI (
 			right - left + 1,
 			bottom - top + 1);
 
+	/// <summary>
+	/// Creates a rectangle with positive width & height from the provided points.
+	/// Note that the second point will be the bottom right corner of the rectangle,
+	/// and the pixel is not inside the rectangle itself.
+	/// </summary>
+	public static RectangleI FromPoints (in PointI a, in PointI b)
+	{
+		int x1 = Math.Min (a.X, b.X);
+		int y1 = Math.Min (a.Y, b.Y);
+		int x2 = Math.Max (a.X, b.X);
+		int y2 = Math.Max (a.Y, b.Y);
+		return new (x1, y1, x2 - x1, y2 - y1);
+	}
+
 	public readonly RectangleD ToDouble ()
 		=> new (X, Y, Width, Height);
 

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
@@ -55,19 +55,6 @@ partial class CairoExtensions
 			y2 - y1);
 	}
 
-	public static RectangleI GetRectangleFromPoints (
-		PointI a,
-		PointI b,
-		int inflate)
-	{
-		int x1 = Math.Min (a.X, b.X);
-		int y1 = Math.Min (a.Y, b.Y);
-		int x2 = Math.Max (a.X, b.X);
-		int y2 = Math.Max (a.Y, b.Y);
-
-		return new RectangleI (x1, y1, x2 - x1, y2 - y1).Inflated (inflate, inflate);
-	}
-
 	/// <summary>
 	/// Create a rectangle with a positive width / height from the provided points.
 	/// </summary>

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
@@ -55,25 +55,6 @@ partial class CairoExtensions
 			y2 - y1);
 	}
 
-	/// <summary>
-	/// Create a rectangle with a positive width / height from the provided points.
-	/// </summary>
-	public static RectangleD PointsToRectangle (
-		PointD p1,
-		PointD p2)
-	{
-		double y1 = Math.Min (p1.Y, p2.Y);
-		double y2 = Math.Max (p1.Y, p2.Y);
-		double x1 = Math.Min (p1.X, p2.X);
-		double x2 = Math.Max (p1.X, p2.X);
-
-		return new (
-			x1,
-			y1,
-			x2 - x1,
-			y2 - y1);
-	}
-
 	public static Region CreateRegion (in RectangleI rect)
 	{
 		CairoRectangleInt cairo_rect = new () {

--- a/Pinta.Tools/Tools/CloneStampTool.cs
+++ b/Pinta.Tools/Tools/CloneStampTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // CloneStampTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -113,11 +113,12 @@ public sealed class CloneStampTool : BaseBrushTool
 
 		g.Stroke ();
 
-		var dirty_rect = CairoExtensions.GetRectangleFromPoints (last_point.Value, e.Point, BrushWidth + 2);
+		int dirtyPadding = BrushWidth + 2;
+		RectangleI dirtyRect = RectangleI.FromPoints (last_point.Value, e.Point).Inflated (dirtyPadding, dirtyPadding);
 
 		last_point = e.Point;
 		surface_modified = true;
-		document.Workspace.Invalidate (dirty_rect);
+		document.Workspace.Invalidate (dirtyRect);
 	}
 
 	protected override void OnMouseUp (Document document, ToolMouseEventArgs e)

--- a/Pinta.Tools/Tools/EraserTool.cs
+++ b/Pinta.Tools/Tools/EraserTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // EraserTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -106,7 +106,8 @@ public sealed class EraserTool : BaseBrushTool
 				break;
 		}
 
-		var dirty = CairoExtensions.GetRectangleFromPoints (last_point.Value, new_point, BrushWidth + 2);
+		int dirtyPadding = BrushWidth + 2;
+		RectangleI dirty = RectangleI.FromPoints (last_point.Value, new_point).Inflated (dirtyPadding, dirtyPadding);
 
 		if (document.Workspace.IsPartiallyOffscreen (dirty))
 			document.Workspace.Invalidate ();

--- a/Pinta.Tools/Tools/PencilTool.cs
+++ b/Pinta.Tools/Tools/PencilTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // PencilTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -153,7 +153,7 @@ public sealed class PencilTool : BaseTool
 			g.Stroke ();
 		}
 
-		var dirty = CairoExtensions.GetRectangleFromPoints (last_point.Value, new PointI (x, y), 4);
+		RectangleI dirty = RectangleI.FromPoints (last_point.Value, new PointI (x, y)).Inflated (4, 4);
 
 		document.Workspace.Invalidate (document.ClampToImageSize (dirty));
 

--- a/Pinta.Tools/Tools/RecolorTool.cs
+++ b/Pinta.Tools/Tools/RecolorTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // RecolorTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -114,7 +114,8 @@ public class RecolorTool : BaseBrushTool
 		var surf = document.Layers.CurrentUserLayer.Surface;
 		var tmp_layer = document.Layers.ToolLayer.Surface;
 
-		var roi = CairoExtensions.GetRectangleFromPoints (last_point.Value, new PointI (x, y), BrushWidth + 2);
+		int roiPadding = BrushWidth + 2;
+		RectangleI roi = RectangleI.FromPoints (last_point.Value, new PointI (x, y)).Inflated (roiPadding, roiPadding);
 
 		roi = workspace.ClampToImageSize (roi);
 		var myTolerance = (int) (Tolerance * 256);

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -349,7 +349,7 @@ public abstract class SelectTool : BaseTool
 
 		ShowHandles (true);
 
-		RectangleD rect = CairoExtensions.PointsToRectangle (shape_origin, shape_end);
+		RectangleD rect = RectangleD.FromPoints (shape_origin, shape_end);
 
 		DrawShape (document, rect, document.Layers.SelectionLayer);
 

--- a/Pinta.Tools/Tools/ZoomTool.cs
+++ b/Pinta.Tools/Tools/ZoomTool.cs
@@ -126,11 +126,11 @@ public sealed class ZoomTool : BaseTool
 
 		if (mouse_down == MouseButton.Left || mouse_down == MouseButton.Right) {
 			if (e.MouseButton == MouseButton.Left) {
-				var shape_origin_window = document.Workspace.CanvasPointToView (shape_origin);
-				if (shape_origin_window.Distance (e.WindowPoint) <= tolerance) {
+				PointD shapeOriginWindow = document.Workspace.CanvasPointToView (shape_origin);
+				if (shapeOriginWindow.Distance (e.WindowPoint) <= tolerance) {
 					document.Workspace.ZoomInAroundCanvasPoint (e.PointDouble);
 				} else {
-					document.Workspace.ZoomToCanvasRectangle (CairoExtensions.PointsToRectangle (shape_origin, e.PointDouble));
+					document.Workspace.ZoomToCanvasRectangle (RectangleD.FromPoints (shape_origin, e.PointDouble));
 				}
 			} else {
 				document.Workspace.ZoomOutAroundCanvasPoint (e.PointDouble);
@@ -149,7 +149,7 @@ public sealed class ZoomTool : BaseTool
 		if (!is_drawing)
 			return;
 
-		var r = CairoExtensions.PointsToRectangle (shape_origin.Rounded (), point.Rounded ());
+		RectangleD r = RectangleD.FromPoints (shape_origin.Rounded (), point.Rounded ());
 
 		document.Layers.ToolLayer.Clear ();
 		document.Layers.ToolLayer.Hidden = false;

--- a/tests/Pinta.Core.Tests/RectangleTests.cs
+++ b/tests/Pinta.Core.Tests/RectangleTests.cs
@@ -34,6 +34,12 @@ internal sealed class RectangleTests
 		Assert.That (RectangleD.FromLTRB (l, t, r, b), Is.EqualTo (built.ToDouble ()));
 	}
 
+	[TestCaseSource (nameof (from_points_cases))]
+	public void CorrectFromPoints (PointI a, PointI b, RectangleI expected)
+	{
+		Assert.That (RectangleI.FromPoints (a, b), Is.EqualTo (expected));
+	}
+
 	[TestCaseSource (nameof (not_equal_cases))]
 	public void CorrectNotEqual (RectangleI a, RectangleI b)
 		=> Assert.That (a, Is.Not.EqualTo (b));
@@ -130,5 +136,14 @@ internal sealed class RectangleTests
 		yield return new (
 			RectangleI.FromLTRB (1, 1, 1, 1),
 			RectangleI.FromLTRB (0, 0, 1, 1));
+	}
+
+	private static readonly IReadOnlyList<TestCaseData> from_points_cases = CreateFromPointsCases ().ToArray ();
+	private static IEnumerable<TestCaseData> CreateFromPointsCases ()
+	{
+		yield return new (
+			new PointI (3, 4),
+			new PointI (5, 6),
+			RectangleI.FromLTRB (3, 4, 4, 5));
 	}
 }

--- a/tests/Pinta.Core.Tests/RectangleTests.cs
+++ b/tests/Pinta.Core.Tests/RectangleTests.cs
@@ -38,6 +38,7 @@ internal sealed class RectangleTests
 	public void CorrectFromPoints (PointI a, PointI b, RectangleI expected)
 	{
 		Assert.That (RectangleI.FromPoints (a, b), Is.EqualTo (expected));
+		Assert.That (RectangleD.FromPoints (a.ToDouble (), b.ToDouble ()), Is.EqualTo (expected.ToDouble ()));
 	}
 
 	[TestCaseSource (nameof (not_equal_cases))]


### PR DESCRIPTION
The two methods previously had inconsistent naming from each other, and are reasonable constructors to have built-in.
This was part of the https://github.com/PintaProject/Pinta/tree/feature/resize-selected-pixels branch which I'm attempting to resurrect and split into smaller PRs