### PR TITLE
Async event handlers

### DIFF
--- a/Pinta.Core/Delegates/AsyncReturningEventArgs.cs
+++ b/Pinta.Core/Delegates/AsyncReturningEventArgs.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pinta.Core;
+
+public static class AsyncEventArgs<TSender, TArgs>
+{
+	public delegate Task<TResult> Returning<TResult> (TSender sender, TArgs args);
+	public delegate Task Simple (TSender sender, TArgs args);
+}
+
+public static class AsyncEventArgsExtensions
+{
+	public static async Task<ImmutableArray<TResult>> InvokeSequential<TSender, TArgs, TResult> (
+		this AsyncEventArgs<TSender, TArgs>.Returning<TResult> handlerBundle,
+		TSender sender,
+		TArgs args)
+	{
+		var invocationList =
+			handlerBundle
+			.GetInvocationList ()
+			.Cast<AsyncEventArgs<TSender, TArgs>.Returning<TResult>> ()
+			.ToArray ();
+
+		var builder = ImmutableArray.CreateBuilder<TResult> (invocationList.Length);
+
+		foreach (var item in invocationList) {
+			TResult itemResult = await item (sender, args);
+			builder.Add (itemResult);
+		}
+
+		return builder.ToImmutable ();
+	}
+
+	public static async Task InvokeSequential<TSender, TArgs, TResult> (
+		this AsyncEventArgs<TSender, TArgs>.Simple handlerBundle,
+		TSender sender,
+		TArgs args)
+	{
+		var invocationList =
+			handlerBundle
+			.GetInvocationList ()
+			.Cast<AsyncEventArgs<TSender, TArgs>.Simple> ()
+			.ToArray ();
+
+		foreach (var item in invocationList)
+			await item (sender, args);
+	}
+}


### PR DESCRIPTION
This idea arose from what's inside the `SaveFile` and `SaveFileAs` methods inside `SaveDocumentImplmentationAction`, which ultimately handle `FileActions.SaveDocument`.

The methods in question show a dialog and have to wait for the user's response before deciding if the document is to be saved or not, but this is not made asynchronous because the standard `EventHandler<TEventArgs>` returns `void`, so the only way is by forcing asynchronous operations to be run in blocking (synchronous) mode.

Arguably, this could be structured in a different way, but using this proposed delegate type is one way to start refactoring the code, and (in my opinion) is not too bad either.