### PR TITLE
Bundle the Vulkan DLL with the Windows installer

### DIFF
--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -82,6 +82,9 @@
     <GtkFile Include="$(MinGWBinFolder)\libwebpdemux-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libwebpmux-3.dll" />
 
+    <!-- Package the Vulkan DLL (https://gitlab.gnome.org/GNOME/gtk/-/issues/7214) -->
+    <GtkFile Include="$(MinGWBinFolder)\vulkan-1.dll" />
+
     <GtkFile Include="$(MinGWBinFolder)\gdbus.exe" />
     <GtkFile Include="$(MinGWBinFolder)\gdk-pixbuf-query-loaders.exe" />
     <GtkFile Include="$(MinGWBinFolder)\gspawn-win64-helper.exe" />


### PR DESCRIPTION
This is recommended by upstream (https://gitlab.gnome.org/GNOME/gtk/-/issues/7214) and should fix issues with a Vulkan DLL being picked up which doesn't match GTK's requirements

Bug: #1497