### PR TITLE
Prevent cursor position and selection size widget icons from jumping around when the coordinates update

### DIFF
--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -283,7 +283,6 @@ public sealed class ViewActions
 
 	public void CreateStatusBar (Gtk.Box statusbar)
 	{
-		statusbar.Append (GtkExtensions.CreateToolBarSeparator ());
 		statusbar.Append (ZoomOut.CreateToolBarItem ());
 		statusbar.Append (ZoomComboBox);
 		statusbar.Append (ZoomIn.CreateToolBarItem ());

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -142,13 +142,12 @@ public sealed class ActionManager
 
 	public void CreateStatusBar (Gtk.Box statusbar, WorkspaceManager workspaceManager)
 	{
-		// Cursor position widget - left aligned with enough space for 12 characters
-		// to display the coordinates.
+		// Cursor position widget - left aligned with enough space to display coordinates up to tens of thousands (e.g. 10000, 10000).
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.CursorPosition));
 		var cursor = Gtk.Label.New ("  0, 0");
 		cursor.Xalign = 0.0f;
 		cursor.Halign = Gtk.Align.Start;
-		cursor.WidthChars = 12;
+		cursor.WidthChars = 11;
 		statusbar.Append (cursor);
 
 		chrome.LastCanvasCursorPointChanged += delegate {
@@ -156,8 +155,7 @@ public sealed class ActionManager
 			cursor.SetText ($"  {pt.X}, {pt.Y}");
 		};
 
-		// Selection size widget - left aligned with enough space for 12 characters
-		// to display the size.
+		// Cursor position widget - left aligned with enough space to display coordinates up to tens of thousands (e.g. 10000, 10000).
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.ToolSelectRectangle));
 		var selection_size = Gtk.Label.New ("  0, 0");
 		selection_size.Xalign = 0.0f;

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -162,7 +162,7 @@ public sealed class ActionManager
 		var selection_size = Gtk.Label.New ("  0, 0");
 		selection_size.Xalign = 0.0f;
 		selection_size.Halign = Gtk.Align.Start;
-		selection_size.WidthChars = 12;
+		selection_size.WidthChars = 11;
 		statusbar.Append (selection_size);
 
 		workspaceManager.SelectionChanged += delegate {

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -155,7 +155,7 @@ public sealed class ActionManager
 			cursor.SetText ($"  {pt.X}, {pt.Y}");
 		};
 
-		// Cursor position widget - left aligned with enough space to display coordinates up to tens of thousands (e.g. 10000, 10000).
+		// Selection size widget - left aligned with enough space to display coordinates up to tens of thousands (e.g. 10000, 10000).
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.ToolSelectRectangle));
 		var selection_size = Gtk.Label.New ("  0, 0");
 		selection_size.Xalign = 0.0f;

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -156,8 +156,6 @@ public sealed class ActionManager
 			cursor.SetText ($"  {pt.X}, {pt.Y}");
 		};
 
-		statusbar.Append (GtkExtensions.CreateToolBarSeparator ());
-
 		// Selection size widget - left aligned with enough space for 12 characters
 		// to display the size.
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.ToolSelectRectangle));

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -142,9 +142,13 @@ public sealed class ActionManager
 
 	public void CreateStatusBar (Gtk.Box statusbar, WorkspaceManager workspaceManager)
 	{
-		// Cursor position widget
+		// Cursor position widget - left aligned with enough space for 12 characters
+		// to display the coordinates.
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.CursorPosition));
 		var cursor = Gtk.Label.New ("  0, 0");
+		cursor.Xalign = 0.0f;
+		cursor.Halign = Gtk.Align.Start;
+		cursor.WidthChars = 12;
 		statusbar.Append (cursor);
 
 		chrome.LastCanvasCursorPointChanged += delegate {
@@ -154,9 +158,13 @@ public sealed class ActionManager
 
 		statusbar.Append (GtkExtensions.CreateToolBarSeparator ());
 
-		// Selection size widget
+		// Selection size widget - left aligned with enough space for 12 characters
+		// to display the size.
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.ToolSelectRectangle));
 		var selection_size = Gtk.Label.New ("  0, 0");
+		selection_size.Xalign = 0.0f;
+		selection_size.Halign = Gtk.Align.Start;
+		selection_size.WidthChars = 12;
 		statusbar.Append (selection_size);
 
 		workspaceManager.SelectionChanged += delegate {

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -144,7 +144,7 @@ public sealed class ActionManager
 	{
 		// Cursor position widget - left aligned with enough space to display coordinates up to tens of thousands (e.g. 10000, 10000).
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.CursorPosition));
-		var cursor = Gtk.Label.New ("  0, 0");
+		var cursor = Gtk.Label.New ("0, 0");
 		cursor.Xalign = 0.0f;
 		cursor.Halign = Gtk.Align.Start;
 		cursor.WidthChars = 11;
@@ -152,12 +152,12 @@ public sealed class ActionManager
 
 		chrome.LastCanvasCursorPointChanged += delegate {
 			var pt = chrome.LastCanvasCursorPoint;
-			cursor.SetText ($"  {pt.X}, {pt.Y}");
+			cursor.SetText ($"{pt.X}, {pt.Y}");
 		};
 
 		// Selection size widget - left aligned with enough space to display coordinates up to tens of thousands (e.g. 10000, 10000).
 		statusbar.Append (Gtk.Image.NewFromIconName (Resources.Icons.ToolSelectRectangle));
-		var selection_size = Gtk.Label.New ("  0, 0");
+		var selection_size = Gtk.Label.New ("0, 0");
 		selection_size.Xalign = 0.0f;
 		selection_size.Halign = Gtk.Align.Start;
 		selection_size.WidthChars = 11;
@@ -165,7 +165,7 @@ public sealed class ActionManager
 
 		workspaceManager.SelectionChanged += delegate {
 			var bounds = workspaceManager.HasOpenDocuments ? workspaceManager.ActiveDocument.Selection.GetBounds () : new RectangleD ();
-			selection_size.SetText ($"  {bounds.Width}, {bounds.Height}");
+			selection_size.SetText ($"{bounds.Width}, {bounds.Height}");
 		};
 
 		// Document zoom widget


### PR DESCRIPTION
Fixes https://github.com/PintaProject/Pinta/issues/1429

Both cursor position and selection rectangle size widgets and labels are now  left aligned with enough space for 12 characters so that coordinates in the tens of thousands can be displayed. 

<img width="332" alt="Pinta_coordinate_widgets" src="https://github.com/user-attachments/assets/7578a3fa-b349-4d8e-b2b8-ea18c0309d4e" />

The widgets can still overlap the color palette if the application window has a very narrow size, but that feels like a separate issue to address (maybe by imposing a minimum width for the application window) and it's not so bad now that the icons aren't jumping around anymore.  