### PR TITLE
Add a replacement for ColorBgra.Blend() which didn't use premultiplied alpha

### DIFF
--- a/Pinta.Core/Algorithms/Mathematics.cs
+++ b/Pinta.Core/Algorithms/Mathematics.cs
@@ -27,6 +27,14 @@ public static class Mathematics
 	public static TNumber MagnitudeSquared<TNumber> (TNumber x, TNumber y) where TNumber : INumber<TNumber>
 		=> x * x + y * y;
 
+	/// <summary>
+	/// Linear interpolation for byte values, where the blend factor is from 0-255.
+	/// </summary>
+	public static byte LerpByte (byte from, byte to, byte frac)
+	{
+		return (byte) (from + ((to - from) * frac) / 255);
+	}
+
 	/// <summary>Linear interpolation</summary>
 	public static TNumber Lerp<TNumber> (
 		TNumber from,

--- a/Pinta.Core/Classes/Color/ColorBgra.Blending.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.Blending.cs
@@ -13,7 +13,7 @@ partial struct ColorBgra
 {
 	/// <summary>
 	/// Smoothly blends between two colors.
-	/// NOTE: this assumes unpremultipled alpha!
+	/// <remarks>This assumes straight alpha!</remarks>
 	/// </summary>
 	public static ColorBgra Blend (ColorBgra ca, ColorBgra cb, byte cbAlpha)
 	{
@@ -37,6 +37,19 @@ partial struct ColorBgra
 
 		return FromBgra ((byte) b, (byte) g, (byte) r, (byte) cbAT);
 	}
+
+	/// <summary>
+	/// Linearly interpolates between two color values with premultiplied alpha.
+	/// </summary>
+	/// <param name="from">The color value that represents 0 on the lerp number line.</param>
+	/// <param name="to">The color value that represents 255 on the lerp number line.</param>
+	/// <param name="frac">A value in the range [0, 255].</param>
+	public static ColorBgra Lerp (ColorBgra from, ColorBgra to, byte frac)
+		=> FromBgra (
+			b: Mathematics.LerpByte (from.B, to.B, frac),
+			g: Mathematics.LerpByte (from.G, to.G, frac),
+			r: Mathematics.LerpByte (from.R, to.R, frac),
+			a: Mathematics.LerpByte (from.A, to.A, frac));
 
 	/// <summary>
 	/// Linearly interpolates between two color values with premultiplied alpha.
@@ -119,6 +132,7 @@ partial struct ColorBgra
 
 	/// <summary>
 	/// Returns a new ColorBgra with the same color values but with a new alpha component value.
+	/// <remarks>This assumes straight alpha!</remarks>
 	/// </summary>
 	public readonly ColorBgra NewAlpha (byte newA) => FromBgra (B, G, R, newA);
 

--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -71,7 +71,7 @@ public abstract class GradientRenderer
 		for (int i = 0; i < 256; ++i) {
 			byte a = (byte) i;
 			lerp_colors[a] = ColorBgra.Blend (start_color, end_color, a);
-			lerp_alphas[a] = (byte) (bounds.StartAlpha + ((bounds.EndAlpha - bounds.StartAlpha) * a) / 255);
+			lerp_alphas[a] = Mathematics.LerpByte (bounds.StartAlpha, bounds.EndAlpha, a);
 		}
 
 		lerp_cache_is_valid = true;

--- a/tests/Pinta.Core.Tests/MathematicsTests.cs
+++ b/tests/Pinta.Core.Tests/MathematicsTests.cs
@@ -38,6 +38,17 @@ internal sealed class MathematicsTests
 		Assert.Throws<ArgumentOutOfRangeException> (() => Mathematics.EuclidGCD (b, a));
 	}
 
+	[TestCase (115, 130, 0, 115)]
+	[TestCase (115, 130, 255, 130)]
+	[TestCase (115, 130, 128, 122)]
+	[TestCase (130, 115, 128, 123)]
+	[TestCase (255, 255, 255, 255)]
+	[TestCase (0, 0, 255, 0)]
+	public void LerpByte (byte a, byte b, byte frac, byte expected)
+	{
+		Assert.That (Mathematics.LerpByte (a, b, frac), Is.EqualTo (expected));
+	}
+
 	[TestCaseSource (nameof (lerp_cases))]
 	public void Lerp_ComputesValues (LerpCase values)
 	{


### PR DESCRIPTION
This is named Lerp() to match the existing float-based lerp methods. The usages of the old Blend() method should be replaced in future commits since it's very error-prone (Cairo surfaces store premultiplied alpha)

Bug: #1543