### PR TITLE
Work around a bug in Mono.Addins which could fail to fetch the add-in repository

### DIFF
--- a/Pinta/AddinSetupService.cs
+++ b/Pinta/AddinSetupService.cs
@@ -1,21 +1,21 @@
-// 
+//
 // AddinSetupService.cs
-//  
+//
 // Author:
 //       Lluis Sanchez Gual <lluis@novell.com>
-// 
+//
 // Copyright (c) 2011 Novell, Inc (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Net;
+using System.Net.Http;
 using Mono.Addins;
 using Mono.Addins.Setup;
 using Pinta.Core;
@@ -34,6 +36,18 @@ public sealed class AddinSetupService : SetupService
 {
 	internal AddinSetupService (AddinRegistry r) : base (r)
 	{
+		Mono.Addins.Setup.HttpClientProvider.SetHttpClientFactory (CreateHttpClient);
+	}
+
+	private static HttpClient CreateHttpClient (string uri)
+	{
+		// Work around a bug (#1542) in Mono.Addins.Setup.HttpClientDownloadFileRequest,
+		// which assumes that ContentLength is never null.
+		// Github's server (which hosts the repo) doesn't provide this for gzipped responses.
+		HttpClientHandler handler = new () {
+			AutomaticDecompression = DecompressionMethods.Deflate
+		};
+		return new HttpClient (handler);
 	}
 
 	public bool AreRepositoriesRegistered ()


### PR DESCRIPTION
Some internal code in Mono.Addins assumes the header's ContentLength property is never null, but this is not the case for gzipped responses from Github's server. This started happening recently so it may have been a change on Github's end. The workaround is to register our own HttpClient provider which disables gzip compression in our requests.

Fixes: #1542