### PR TITLE
Fix the gradient renderer's use of straight vs premultiplied alpha

### DIFF
--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -70,7 +70,7 @@ public abstract class GradientRenderer
 
 		for (int i = 0; i < 256; ++i) {
 			byte a = (byte) i;
-			lerp_colors[a] = ColorBgra.Blend (start_color, end_color, a);
+			lerp_colors[a] = ColorBgra.Lerp (start_color, end_color, a);
 			lerp_alphas[a] = Mathematics.LerpByte (bounds.StartAlpha, bounds.EndAlpha, a);
 		}
 

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // GradientTool.cs
-//  
+//
 // Author:
 //       Olivier Dufour <olivier.duff@gmail.com>
-// 
+//
 // Copyright (c) 2010 Olivier Dufour
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -106,11 +106,11 @@ public sealed class GradientTool : BaseTool
 		var gr = CreateGradientRenderer ();
 
 		if (button == MouseButton.Right) {
-			gr.StartColor = palette.SecondaryColor.ToColorBgra ();
-			gr.EndColor = palette.PrimaryColor.ToColorBgra ();
+			gr.StartColor = palette.SecondaryColor.ToColorBgra ().ToPremultipliedAlpha ();
+			gr.EndColor = palette.PrimaryColor.ToColorBgra ().ToPremultipliedAlpha ();
 		} else {
-			gr.StartColor = palette.PrimaryColor.ToColorBgra ();
-			gr.EndColor = palette.SecondaryColor.ToColorBgra ();
+			gr.StartColor = palette.PrimaryColor.ToColorBgra ().ToPremultipliedAlpha ();
+			gr.EndColor = palette.SecondaryColor.ToColorBgra ().ToPremultipliedAlpha ();
 		}
 
 		gr.StartPoint = startpoint;


### PR DESCRIPTION
- The start and end colors should have premultiplied alpha since they are used when modifying the image surface's data directly (see `GradientRenderer.ProcessGradientLine()`)

- Replace `ColorBgra.Blend()` with `ColorBgra.Lerp()` for premultiplied alpha (see #1546)

Fixes: #1543