### PR TITLE
 Modified `ColorPickerSlider.DrawGradient` to use proper gradient 

### DIFF
--- a/Pinta.Core/Classes/Color/ColorBgra.Blending.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.Blending.cs
@@ -44,7 +44,7 @@ partial struct ColorBgra
 	/// <param name="from">The color value that represents 0 on the lerp number line.</param>
 	/// <param name="to">The color value that represents 255 on the lerp number line.</param>
 	/// <param name="frac">A value in the range [0, 255].</param>
-	public static ColorBgra Lerp (ColorBgra from, ColorBgra to, byte frac)
+	public static ColorBgra Lerp (in ColorBgra from, in ColorBgra to, byte frac)
 		=> FromBgra (
 			b: Mathematics.LerpByte (from.B, to.B, frac),
 			g: Mathematics.LerpByte (from.G, to.G, frac),
@@ -57,7 +57,7 @@ partial struct ColorBgra
 	/// <param name="from">The color value that represents 0 on the lerp number line.</param>
 	/// <param name="to">The color value that represents 1 on the lerp number line.</param>
 	/// <param name="frac">A value in the range [0, 1].</param>
-	public static ColorBgra Lerp (ColorBgra from, ColorBgra to, float frac)
+	public static ColorBgra Lerp (in ColorBgra from, in ColorBgra to, float frac)
 		=> FromBgra (
 			b: Utility.ClampToByte (Mathematics.Lerp (from.B, to.B, frac)),
 			g: Utility.ClampToByte (Mathematics.Lerp (from.G, to.G, frac)),
@@ -70,7 +70,7 @@ partial struct ColorBgra
 	/// <param name="from">The color value that represents 0 on the lerp number line.</param>
 	/// <param name="to">The color value that represents 1 on the lerp number line.</param>
 	/// <param name="frac">A value in the range [0, 1].</param>
-	public static ColorBgra Lerp (ColorBgra from, ColorBgra to, double frac)
+	public static ColorBgra Lerp (in ColorBgra from, in ColorBgra to, double frac)
 		=> FromBgra (
 			b: Utility.ClampToByte (Mathematics.Lerp (from.B, to.B, frac)),
 			g: Utility.ClampToByte (Mathematics.Lerp (from.G, to.G, frac)),

--- a/Pinta.Core/Classes/Color/ColorBgra.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.cs
@@ -17,7 +17,7 @@ namespace Pinta.Core;
 /// </summary>
 [Serializable]
 [StructLayout (LayoutKind.Explicit)]
-public readonly partial struct ColorBgra
+public readonly partial struct ColorBgra : IColor<ColorBgra>
 {
 	[FieldOffset (0)]
 	public readonly byte B;

--- a/Pinta.Core/Classes/IColor.cs
+++ b/Pinta.Core/Classes/IColor.cs
@@ -1,0 +1,6 @@
+namespace Pinta.Core;
+
+public interface IColor<TColor>
+{
+	static abstract TColor Lerp (in TColor from, in TColor to, double frac);
+}

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.ColorType.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.ColorType.cs
@@ -9,7 +9,9 @@ public readonly record struct Color (
 	double R,
 	double G,
 	double B,
-	double A)
+	double A
+)
+	: IColor<Color>
 {
 	public Color (double r, double g, double b)
 		: this (r, g, b, 1.0)
@@ -250,5 +252,14 @@ public readonly record struct Color (
 		// return an RgbColor structure, with values scaled
 		// to be between 0 and 255.
 		return new Color (r, g, b, alpha);
+	}
+
+	public static Color Lerp (in Color from, in Color to, double frac)
+	{
+		return new (
+			R: Mathematics.Lerp (from.R, to.R, frac),
+			G: Mathematics.Lerp (from.G, to.G, frac),
+			B: Mathematics.Lerp (from.B, to.B, frac),
+			A: Mathematics.Lerp (from.A, to.A, frac));
 	}
 }

--- a/Pinta.Effects/Effects/CloudsEffect.cs
+++ b/Pinta.Effects/Effects/CloudsEffect.cs
@@ -62,7 +62,7 @@ public sealed class CloudsEffect : BaseEffect
 		int scale,
 		byte seed,
 		double power,
-		ColorGradient gradient)
+		ColorGradient<ColorBgra> gradient)
 	{
 		int w = surface.Width;
 		int h = surface.Height;
@@ -82,7 +82,7 @@ public sealed class CloudsEffect : BaseEffect
 		int scale,
 		byte seed,
 		double power,
-		ColorGradient gradient,
+		ColorGradient<ColorBgra> gradient,
 		int w,
 		int dy,
 		int x)

--- a/Pinta.Effects/Effects/GradientHelper.cs
+++ b/Pinta.Effects/Effects/GradientHelper.cs
@@ -62,7 +62,7 @@ internal static class GradientHelper
 	private const double DefaultStartPosition = 0;
 	private const double DefaultEndPosition = 1;
 
-	public static ColorGradient CreateBaseGradientForEffect (
+	public static ColorGradient<ColorBgra> CreateBaseGradientForEffect (
 		IPaletteService palette,
 		ColorSchemeSource colorSchemeSource,
 		PresetGradients colorScheme,
@@ -112,7 +112,7 @@ internal static class GradientHelper
 		}
 	}
 
-	public static ColorGradient CreateColorGradient (PresetGradients scheme)
+	public static ColorGradient<ColorBgra> CreateColorGradient (PresetGradients scheme)
 	{
 		return scheme switch {
 

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -71,7 +71,7 @@ public sealed class JuliaFractalEffect : BaseEffect
 		double invCount,
 		RadiansAngle angleTheta,
 		int factor,
-		ColorGradient colorGradient);
+		ColorGradient<ColorBgra> colorGradient);
 	private JuliaSettings CreateSettings (ImageSurface dst)
 	{
 		Size canvasSize = dst.GetSize ();

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -70,7 +70,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		RadiansAngle angleTheta,
 		int factor,
 		bool invertColors,
-		ColorGradient colorGradient);
+		ColorGradient<ColorBgra> colorGradient);
 	private MandelbrotSettings CreateSettings (ImageSurface dst)
 	{
 		const double ZOOM_FACTOR = 20.0;
@@ -78,7 +78,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		double zoom = 1 + ZOOM_FACTOR * Data.Zoom;
 		int count = Data.Quality * Data.Quality + 1;
 
-		ColorGradient baseGradient =
+		var baseGradient =
 			GradientHelper
 			.CreateBaseGradientForEffect (
 				palette,

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Cairo;
@@ -391,15 +392,19 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
-					CurrentColor.CopyHsv (hue: 0),
-					CurrentColor.CopyHsv (hue: 60),
-					CurrentColor.CopyHsv (hue: 120),
-					CurrentColor.CopyHsv (hue: 180),
-					CurrentColor.CopyHsv (hue: 240),
-					CurrentColor.CopyHsv (hue: 300),
-					CurrentColor.CopyHsv (hue: 360)
-				]
+				ColorGradient.Create (
+					startColor: CurrentColor.CopyHsv (hue: 0),
+					endColor: CurrentColor.CopyHsv (hue: 360),
+					startPosition: 0,
+					endPosition: 360,
+					new Dictionary<double, Color> {
+						[60] = CurrentColor.CopyHsv (hue: 60),
+						[120] = CurrentColor.CopyHsv (hue: 120),
+						[180] = CurrentColor.CopyHsv (hue: 180),
+						[240] = CurrentColor.CopyHsv (hue: 240),
+						[300] = CurrentColor.CopyHsv (hue: 300),
+					}
+				)
 			)
 		);
 		hueSlider.OnValueChange += (sender, args) => {
@@ -419,10 +424,9 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
+				ColorGradient.Create (
 					CurrentColor.CopyHsv (sat: 0),
-					CurrentColor.CopyHsv (sat: 1),
-				]
+					CurrentColor.CopyHsv (sat: 1))
 			)
 		);
 		saturationSlider.OnValueChange += (sender, args) => {
@@ -442,10 +446,9 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
+				ColorGradient.Create (
 					CurrentColor.CopyHsv (value: 0),
-					CurrentColor.CopyHsv (value: 1),
-				]
+					CurrentColor.CopyHsv (value: 1))
 			)
 		);
 		valueSlider.OnValueChange += (sender, args) => {
@@ -465,10 +468,9 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
+				ColorGradient.Create (
 					CurrentColor with { R = 0 },
-					CurrentColor with { R = 1 },
-				]
+					CurrentColor with { R = 1 })
 			)
 		);
 		redSlider.OnValueChange += (sender, args) => {
@@ -488,10 +490,9 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
+				ColorGradient.Create (
 					CurrentColor with { G = 0 },
-					CurrentColor with { G = 1 },
-				]
+					CurrentColor with { G = 1 })
 			)
 		);
 		greenSlider.OnValueChange += (sender, args) => {
@@ -511,10 +512,9 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
+				ColorGradient.Create (
 					CurrentColor with { B = 0 },
-					CurrentColor with { B = 1 },
-				]
+					CurrentColor with { B = 1 })
 			)
 		);
 		blueSlider.OnValueChange += (sender, args) => {
@@ -534,10 +534,9 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 				c,
 				w,
 				h,
-				[
+				ColorGradient.Create (
 					CurrentColor with { A = 0 },
-					CurrentColor with { A = 1 },
-				]
+					CurrentColor with { A = 1 })
 			)
 		);
 		alphaSlider.OnValueChange += (sender, args) => {

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerSlider.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerSlider.cs
@@ -199,7 +199,7 @@ public sealed class ColorPickerSlider : Gtk.Box
 		suppress_event = false;
 	}
 
-	public void DrawGradient (Context context, int width, int height, Color[] colors)
+	public void DrawGradient (Context context, int width, int height, ColorGradient<Color> colors)
 	{
 		context.Antialias = Antialias.None;
 
@@ -248,8 +248,14 @@ public sealed class ColorPickerSlider : Gtk.Box
 			x1: p.X,
 			y1: p.Y);
 
-		for (int i = 0; i < colors.Length; i++)
-			pat.AddColorStop (i / (double) (colors.Length - 1), colors[i]);
+		var normalized = colors.Resized (startPosition: 0, endPosition: 1);
+
+		pat.AddColorStop (normalized.StartPosition, normalized.StartColor);
+
+		for (int i = 0; i < normalized.StopsCount; i++)
+			pat.AddColorStop (normalized.Positions[i], normalized.Colors[i]);
+
+		pat.AddColorStop (normalized.EndPosition, normalized.EndColor);
 
 		context.Rectangle (
 			settings.SliderPaddingWidth,

--- a/tests/Pinta.Effects.Tests/GradientTests.cs
+++ b/tests/Pinta.Effects.Tests/GradientTests.cs
@@ -76,7 +76,7 @@ internal sealed class GradientTests
 	[TestCaseSource (nameof (stops_color_checks))]
 	public void Gradient_Stop_Colors_Are_Same (double minPosition, double maxPosition, IReadOnlyDictionary<double, ColorBgra> checks)
 	{
-		ColorGradient gradient = ColorGradient.Create (default_start_color, default_end_color, minPosition, maxPosition, checks);
+		var gradient = ColorGradient.Create (default_start_color, default_end_color, minPosition, maxPosition, checks);
 		foreach (var check in checks) {
 			var returned = gradient.GetColor (check.Key);
 			Assert.That (check.Value, Is.EqualTo (returned));
@@ -106,7 +106,7 @@ internal sealed class GradientTests
 	}
 
 	[TestCaseSource (nameof (interpolated_color_checks))]
-	public void Gradient_Interpolated_Colors_Are_Correct (ColorGradient gradient, IReadOnlyDictionary<double, ColorBgra> checks)
+	public void Gradient_Interpolated_Colors_Are_Correct (ColorGradient<ColorBgra> gradient, IReadOnlyDictionary<double, ColorBgra> checks)
 	{
 		foreach (var check in checks) {
 			var interpolated = gradient.GetColor (check.Key);
@@ -120,7 +120,7 @@ internal sealed class GradientTests
 	private static readonly IReadOnlyList<TestCaseData> interpolated_color_checks = CreateInterpolatedColorChecks ().ToArray ();
 	private static IEnumerable<TestCaseData> CreateInterpolatedColorChecks ()
 	{
-		ColorGradient blackToWhite255 = ColorGradient.Create (
+		var blackToWhite255 = ColorGradient.Create (
 			ColorBgra.Black,
 			ColorBgra.White,
 			byte.MinValue,
@@ -135,7 +135,7 @@ internal sealed class GradientTests
 			}
 		);
 
-		ColorGradient blackToWhite1 = ColorGradient.Create (
+		var blackToWhite1 = ColorGradient.Create (
 			ColorBgra.Black,
 			ColorBgra.White,
 			0,


### PR DESCRIPTION
This requires making `ColorGradient` generic, otherwise there would be lots of unnecessary conversions