### PR TITLE
Fix performance issues when opening many documents

### DIFF
--- a/Pinta.Core/Actions/WindowActions.cs
+++ b/Pinta.Core/Actions/WindowActions.cs
@@ -102,6 +102,10 @@ public sealed class WindowActions
 			CloseAll]);
 
 		app.AddAction (active_doc_action);
+
+		// Assign accelerators up to Alt-9 for the active documents.
+		for (int i = 0; i < 9; ++i)
+			app.SetAccelsForAction (BuildActionId (i), [$"<Alt>{i + 1}"]);
 	}
 
 	public void SetActiveDocument (Document doc)
@@ -113,16 +117,14 @@ public sealed class WindowActions
 	private void AddDocumentMenuItem (int idx)
 	{
 		Document doc = workspace.OpenDocuments[idx];
-		string action_id = $"app.{doc_action_id}({idx})";
-		string label = $"{doc.DisplayName}{(doc.IsDirty ? '*' : string.Empty)}";
-		Gio.MenuItem menu_item = Gio.MenuItem.New (label, action_id);
+		string actionId = BuildActionId (idx);
+		string label = $"{doc.DisplayName}{(doc.IsDirty ? "*" : string.Empty)}";
 
-		doc_section.AppendItem (menu_item);
-
-		// We only assign accelerators up to Alt-9
-		if (idx < 9)
-			chrome.Application.SetAccelsForAction (action_id, [$"<Alt>{idx + 1}"]);
+		Gio.MenuItem menuItem = Gio.MenuItem.New (label, actionId);
+		doc_section.AppendItem (menuItem);
 	}
+
+	private static string BuildActionId (int idx) => $"app.{doc_action_id}({idx})";
 
 	private void RebuildDocumentMenu ()
 	{

--- a/Pinta.Core/Actions/WindowActions.cs
+++ b/Pinta.Core/Actions/WindowActions.cs
@@ -35,12 +35,8 @@ public sealed class WindowActions
 	public Command SaveAll { get; }
 	public Command CloseAll { get; }
 
-	private readonly ChromeManager chrome;
 	private readonly WorkspaceManager workspace;
-	public WindowActions (
-		ChromeManager chrome,
-		ToolManager tools,
-		WorkspaceManager workspace)
+	public WindowActions (WorkspaceManager workspace)
 	{
 		SaveAll = new Command (
 			"SaveAll",
@@ -63,16 +59,8 @@ public sealed class WindowActions
 			GLib.Variant.NewInt32 (-1));
 
 		active_doc_action.OnActivate += (o, e) => {
-
-			var idx = e.Parameter!.GetInt32 ();
-
-			if (idx >= workspace.OpenDocuments.Count)
-				return;
-
-			workspace.SetActiveDocumentInternal (
-				tools,
-				workspace.OpenDocuments[idx]);
-
+			int idx = e.Parameter!.GetInt32 ();
+			workspace.SetActiveDocument (idx);
 			active_doc_action.ChangeState (e.Parameter);
 		};
 
@@ -81,9 +69,11 @@ public sealed class WindowActions
 			e.Document.IsDirtyChanged += (_, _) => RebuildDocumentMenu ();
 			AddDocumentMenuItem (workspace.OpenDocuments.IndexOf (e.Document));
 		};
+		workspace.ActiveDocumentChanged += (_, _) => {
+			active_doc_action.ChangeState (GLib.Variant.NewInt32 (workspace.ActiveDocumentIndex));
+		};
 		workspace.DocumentClosed += (_, _) => RebuildDocumentMenu ();
 
-		this.chrome = chrome;
 		this.workspace = workspace;
 	}
 
@@ -106,12 +96,6 @@ public sealed class WindowActions
 		// Assign accelerators up to Alt-9 for the active documents.
 		for (int i = 0; i < 9; ++i)
 			app.SetAccelsForAction (BuildActionId (i), [$"<Alt>{i + 1}"]);
-	}
-
-	public void SetActiveDocument (Document doc)
-	{
-		int idx = workspace.OpenDocuments.IndexOf (doc);
-		active_doc_action.Activate (GLib.Variant.NewInt32 (idx));
 	}
 
 	private void AddDocumentMenuItem (int idx)

--- a/Pinta.Core/Actions/WindowActions.cs
+++ b/Pinta.Core/Actions/WindowActions.cs
@@ -31,6 +31,7 @@ public sealed class WindowActions
 	private Gio.Menu doc_section = null!; // NRT - Set in RegisterActions
 	private static readonly string doc_action_id = "active_document";
 	private readonly Gio.SimpleAction active_doc_action;
+	private uint deferred_update_event;
 
 	public Command SaveAll { get; }
 	public Command CloseAll { get; }
@@ -69,9 +70,8 @@ public sealed class WindowActions
 			e.Document.IsDirtyChanged += (_, _) => RebuildDocumentMenu ();
 			AddDocumentMenuItem (workspace.OpenDocuments.IndexOf (e.Document));
 		};
-		workspace.ActiveDocumentChanged += (_, _) => {
-			active_doc_action.ChangeState (GLib.Variant.NewInt32 (workspace.ActiveDocumentIndex));
-		};
+
+		workspace.ActiveDocumentChanged += OnActiveDocumentChanged;
 		workspace.DocumentClosed += (_, _) => RebuildDocumentMenu ();
 
 		this.workspace = workspace;
@@ -118,5 +118,19 @@ public sealed class WindowActions
 			AddDocumentMenuItem (i);
 
 		workspace.ResetTitle ();
+	}
+
+	private void OnActiveDocumentChanged (object? o, System.EventArgs eventArgs)
+	{
+		// Updating the action's state can be surprisingly expensive when e.g. opening
+		// many documents (bug #1574), so an update is deferred until we return to the event loop.
+		if (deferred_update_event > 0)
+			return;
+
+		deferred_update_event = GLib.Functions.IdleAdd (GLib.Constants.PRIORITY_DEFAULT, () => {
+			active_doc_action.ChangeState (GLib.Variant.NewInt32 (workspace.ActiveDocumentIndex));
+			deferred_update_event = 0;
+			return false;
+		});
 	}
 }

--- a/Pinta.Core/Managers/ActionManager.cs
+++ b/Pinta.Core/Managers/ActionManager.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ActionManager.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -60,7 +60,7 @@ public sealed class ActionManager
 		EditActions edit = new (chrome, paletteFormats, palette, tools, workspace);
 		EffectsActions effects = new (chrome);
 		ViewActions view = new (chrome, workspace);
-		WindowActions window = new (chrome, tools, workspace);
+		WindowActions window = new (workspace);
 
 		// --- Action handlers that depend on other handlers
 

--- a/Pinta.Core/Managers/ToolManager.cs
+++ b/Pinta.Core/Managers/ToolManager.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ToolManager.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -92,6 +92,9 @@ public sealed class ToolManager : IEnumerable<BaseTool>, IToolService
 	{
 		workspace_manager = workspaceManager;
 		chrome_manager = chromeManager;
+
+		// Before the active document has changed, the current tool should commit unfinished changes.
+		workspace_manager.PreActiveDocumentChanged += (_, _) => Commit ();
 	}
 
 	private bool is_panning;
@@ -158,7 +161,7 @@ public sealed class ToolManager : IEnumerable<BaseTool>, IToolService
 
 		BaseTool new_tool = tb.Tool;
 
-		// Don't let the user unselect the current tool	
+		// Don't let the user unselect the current tool
 		if (CurrentTool != null && new_tool.GetType ().Name == CurrentTool.GetType ().Name) {
 			if (PreviousTool != CurrentTool)
 				tb.Active = true;

--- a/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
+++ b/Pinta/Actions/Edit/PasteIntoNewImageAction.cs
@@ -1,21 +1,21 @@
-// 
+//
 // PasteIntoNewImageAction.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -60,7 +60,7 @@ internal sealed class PasteIntoNewImageAction : IActionHandler
 		Gdk.Texture? cb_texture = await cb.ReadTextureAsync ();
 
 		if (cb_texture is not null)
-			workspace.NewDocumentFromImage (actions, cb_texture.ToSurface ());
+			workspace.NewDocumentFromImage (cb_texture.ToSurface ());
 		else
 			await PasteAction.ShowClipboardEmptyDialog (chrome);
 	}

--- a/Pinta/Actions/File/CloseDocumentAction.cs
+++ b/Pinta/Actions/File/CloseDocumentAction.cs
@@ -1,21 +1,21 @@
-// 
+//
 // CloseDocumentAction.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -64,7 +64,7 @@ internal sealed class CloseDocumentAction : IActionHandler
 
 		// If it's not dirty, just close it
 		if (!workspace.ActiveDocument.IsDirty) {
-			workspace.CloseActiveDocument (actions);
+			workspace.CloseActiveDocument ();
 			return;
 		}
 
@@ -99,10 +99,10 @@ internal sealed class CloseDocumentAction : IActionHandler
 			// If saved is false, then the user
 			// must have cancelled the Save dialog
 			if (saved)
-				workspace.CloseActiveDocument (actions);
+				workspace.CloseActiveDocument ();
 
 		} else if (response == discard_response) {
-			workspace.CloseActiveDocument (actions);
+			workspace.CloseActiveDocument ();
 		}
 
 	}

--- a/Pinta/Actions/File/NewDocumentAction.cs
+++ b/Pinta/Actions/File/NewDocumentAction.cs
@@ -1,21 +1,21 @@
-// 
+//
 // NewDocumentAction.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -101,7 +101,6 @@ internal sealed class NewDocumentAction : IActionHandler
 				return;
 
 			workspace.NewDocument (
-				actions,
 				dialog.NewImageSize,
 				dialog.NewImageBackground);
 

--- a/Pinta/Actions/Window/SaveAllDocumentsAction.cs
+++ b/Pinta/Actions/Window/SaveAllDocumentsAction.cs
@@ -1,21 +1,21 @@
-// 
+//
 // SaveAllDocumentsAction.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -53,12 +53,13 @@ internal sealed class SaveAllDocumentsAction : IActionHandler
 
 	private async void Activated (object sender, EventArgs e)
 	{
-		foreach (Document doc in workspace.OpenDocuments) {
+		for (int i = 0; i < workspace.OpenDocuments.Count; ++i) {
+			Document doc = workspace.OpenDocuments[i];
 
 			if (!doc.IsDirty && doc.HasFile)
 				continue;
 
-			window.SetActiveDocument (doc);
+			workspace.SetActiveDocument (i);
 
 			// Loop through all of these until we get a cancel
 			if (!await doc.Save (false))

--- a/Pinta/Main.cs
+++ b/Pinta/Main.cs
@@ -141,7 +141,6 @@ internal sealed class MainClass
 		} else {
 			// Create a blank document
 			PintaCore.Workspace.NewDocument (
-				PintaCore.Actions,
 				new Core.Size (800, 600),
 				new Cairo.Color (1, 1, 1));
 		}

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -147,10 +147,11 @@ internal sealed class MainWindow
 	{
 		var view = (DocumentViewContent) e.Item;
 
-		if (PintaCore.Workspace.OpenDocuments.IndexOf (view.Document) < 0)
+		int index = PintaCore.Workspace.OpenDocuments.IndexOf (view.Document);
+		if (index < 0)
 			return;
 
-		PintaCore.Actions.Window.SetActiveDocument (view.Document);
+		PintaCore.Workspace.SetActiveDocument (index);
 		PintaCore.Actions.File.Close.Activate ();
 
 		if (PintaCore.Workspace.OpenDocuments.IndexOf (view.Document) < 0)
@@ -169,7 +170,8 @@ internal sealed class MainWindow
 
 		var view = (DocumentViewContent) item;
 
-		PintaCore.Actions.Window.SetActiveDocument (view.Document);
+		int index = PintaCore.Workspace.OpenDocuments.IndexOf (view.Document);
+		PintaCore.Workspace.SetActiveDocument (index);
 		((CanvasWindow) view.Widget).Canvas.Cursor = PintaCore.Tools.CurrentTool?.CurrentCursor;
 	}
 


### PR DESCRIPTION
`SetAccelsForAction()` is quite expensive (I suspect it needs to go through and update any widgets which might be using the action), so this should be done once up front rather than when rebuilding the menu.

This improves the performance of opening 20 documents at once from 17s to 400ms

Bug: #1574