### PR TITLE
Created `IAngle` interface

### DIFF
--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -418,8 +418,8 @@ public static class Utility
 	{
 		ArgumentOutOfRangeException.ThrowIfLessThan (steps, 1);
 
-		const double FULL_TURN = RadiansAngle.MAX_RADIANS;
-		double stepAngle = FULL_TURN / steps;
+		double fullTurn = RadiansAngle.FullTurn;
+		double stepAngle = fullTurn / steps;
 		double sector = Math.Round (angle.Radians / stepAngle) * stepAngle;
 
 		return new (sector);

--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -2,17 +2,23 @@ using System;
 
 namespace Pinta.Core;
 
-public readonly struct RadiansAngle
+public interface IAngle<TAngle> where TAngle : IAngle<TAngle>
 {
-	public const double MAX_RADIANS = Math.PI * 2;
-	public readonly double Radians { get; }
+	static abstract double FullTurn { get; }
+	static abstract bool operator == (TAngle a, TAngle b);
+	static abstract bool operator != (TAngle a, TAngle b);
+}
 
+public readonly struct RadiansAngle : IAngle<RadiansAngle>
+{
+	public static double FullTurn => Math.PI * 2;
+	public readonly double Radians { get; }
 	public RadiansAngle (double radians)
 	{
 		Radians = radians switch {
 			0 => 0,
-			>= 0 => radians % MAX_RADIANS,
-			_ => (MAX_RADIANS + (radians % MAX_RADIANS)) % MAX_RADIANS
+			>= 0 => radians % FullTurn,
+			_ => (FullTurn + (radians % FullTurn)) % FullTurn
 		};
 	}
 
@@ -26,8 +32,6 @@ public readonly struct RadiansAngle
 	public static RadiansAngle operator - (RadiansAngle a, RadiansAngle b) => new (a.Radians - b.Radians);
 	public static bool operator == (RadiansAngle a, RadiansAngle b) => a.Equals (b);
 	public static bool operator != (RadiansAngle a, RadiansAngle b) => !a.Equals (b);
-	public static bool operator > (RadiansAngle a, RadiansAngle b) => a.Radians > b.Radians;
-	public static bool operator < (RadiansAngle a, RadiansAngle b) => a.Radians < b.Radians;
 	public override readonly int GetHashCode () => Radians.GetHashCode ();
 	public override readonly bool Equals (object? obj)
 	{
@@ -36,17 +40,16 @@ public readonly struct RadiansAngle
 	}
 }
 
-public readonly struct DegreesAngle
+public readonly struct DegreesAngle : IAngle<DegreesAngle>
 {
-	public const double MAX_DEGREES = 360;
+	public static double FullTurn => 360;
 	public readonly double Degrees { get; }
-
 	public DegreesAngle (double degrees)
 	{
 		Degrees = degrees switch {
 			0 => 0,
-			>= 0 => degrees % MAX_DEGREES,
-			_ => (MAX_DEGREES + (degrees % MAX_DEGREES)) % MAX_DEGREES
+			>= 0 => degrees % FullTurn,
+			_ => (FullTurn + (degrees % FullTurn)) % FullTurn
 		};
 	}
 
@@ -60,8 +63,6 @@ public readonly struct DegreesAngle
 	public static DegreesAngle operator - (DegreesAngle a, DegreesAngle b) => new (a.Degrees - b.Degrees);
 	public static bool operator == (DegreesAngle a, DegreesAngle b) => a.Equals (b);
 	public static bool operator != (DegreesAngle a, DegreesAngle b) => !a.Equals (b);
-	public static bool operator > (DegreesAngle a, DegreesAngle b) => a.Degrees > b.Degrees;
-	public static bool operator < (DegreesAngle a, DegreesAngle b) => a.Degrees < b.Degrees;
 	public override readonly int GetHashCode () => Degrees.GetHashCode ();
 	public override readonly bool Equals (object? obj)
 	{
@@ -70,17 +71,16 @@ public readonly struct DegreesAngle
 	}
 }
 
-public readonly struct RevolutionsAngle
+public readonly struct RevolutionsAngle : IAngle<RevolutionsAngle>
 {
-	public const double MAX_REVOLUTIONS = 1;
+	public static double FullTurn => 1;
 	public readonly double Revolutions { get; }
-
 	public RevolutionsAngle (double revolutions)
 	{
 		Revolutions = revolutions switch {
 			0 => 0,
-			>= 0 => revolutions % MAX_REVOLUTIONS,
-			_ => (MAX_REVOLUTIONS + (revolutions % MAX_REVOLUTIONS)) % MAX_REVOLUTIONS
+			>= 0 => revolutions % FullTurn,
+			_ => (FullTurn + (revolutions % FullTurn)) % FullTurn
 		};
 	}
 
@@ -94,8 +94,6 @@ public readonly struct RevolutionsAngle
 	public static RevolutionsAngle operator - (RevolutionsAngle a, RevolutionsAngle b) => new (a.Revolutions - b.Revolutions);
 	public static bool operator == (RevolutionsAngle a, RevolutionsAngle b) => a.Revolutions == b.Revolutions;
 	public static bool operator != (RevolutionsAngle a, RevolutionsAngle b) => a.Revolutions != b.Revolutions;
-	public static bool operator > (RevolutionsAngle a, RevolutionsAngle b) => a.Revolutions > b.Revolutions;
-	public static bool operator < (RevolutionsAngle a, RevolutionsAngle b) => a.Revolutions < b.Revolutions;
 	public override readonly int GetHashCode () => Revolutions.GetHashCode ();
 	public override readonly bool Equals (object? obj)
 	{

--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -7,6 +7,8 @@ public interface IAngle<TAngle> where TAngle : IAngle<TAngle>
 	static abstract double FullTurn { get; }
 	static abstract bool operator == (TAngle a, TAngle b);
 	static abstract bool operator != (TAngle a, TAngle b);
+	static abstract TAngle operator + (TAngle a, TAngle b);
+	static abstract TAngle operator - (TAngle a, TAngle b);
 }
 
 public readonly struct RadiansAngle : IAngle<RadiansAngle>

--- a/Pinta.Core/Classes/Angle.cs
+++ b/Pinta.Core/Classes/Angle.cs
@@ -12,7 +12,14 @@ public interface IAngle<TAngle> where TAngle : IAngle<TAngle>
 public readonly struct RadiansAngle : IAngle<RadiansAngle>
 {
 	public static double FullTurn => Math.PI * 2;
+
+	/// <remarks>The value can only be in the range [0, <see cref="FullTurn" />)</remarks>
 	public readonly double Radians { get; }
+
+	/// <remarks>
+	/// <paramref name="radians"/> is wrapped around to be within the allowable
+	/// range of the <see cref="Radians"/> property
+	/// </remarks>
 	public RadiansAngle (double radians)
 	{
 		Radians = radians switch {
@@ -43,7 +50,15 @@ public readonly struct RadiansAngle : IAngle<RadiansAngle>
 public readonly struct DegreesAngle : IAngle<DegreesAngle>
 {
 	public static double FullTurn => 360;
+
+
+	/// <remarks>The value can only be in the range [0, <see cref="FullTurn" />)</remarks>
 	public readonly double Degrees { get; }
+
+	/// <remarks>
+	/// <paramref name="degrees"/> is wrapped around to be within the allowable
+	/// range of the <see cref="Degrees"/> property
+	/// </remarks>
 	public DegreesAngle (double degrees)
 	{
 		Degrees = degrees switch {
@@ -74,7 +89,14 @@ public readonly struct DegreesAngle : IAngle<DegreesAngle>
 public readonly struct RevolutionsAngle : IAngle<RevolutionsAngle>
 {
 	public static double FullTurn => 1;
+
+	/// <remarks>The value can only be in the range [0, <see cref="FullTurn" />)</remarks>
 	public readonly double Revolutions { get; }
+
+	/// <remarks>
+	/// <paramref name="revolutions"/> is wrapped around to be within the allowable
+	/// range of the <see cref="Revolutions"/> property
+	/// </remarks>
 	public RevolutionsAngle (double revolutions)
 	{
 		Revolutions = revolutions switch {

--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -110,7 +110,7 @@ public sealed class DentsEffect : BaseEffect
 
 		double scaleR = 400.0 / settings.defaultRadius / dentsData.Scale;
 		double refractionScale = dentsData.Refraction / 100.0 / scaleR;
-		double theta = RadiansAngle.MAX_RADIANS * turbulence / 10.0;
+		double theta = RadiansAngle.FullTurn * turbulence / 10.0;
 		double effectiveRoughness = roughness / 100.0;
 
 		// We don't want the perlin noise frequency components exceeding the nyquist limit, so we will limit 'detail' appropriately

--- a/Pinta.Effects/Effects/FragmentEffect.cs
+++ b/Pinta.Effects/Effects/FragmentEffect.cs
@@ -55,8 +55,8 @@ public sealed class FragmentEffect : BaseEffect
 		RadiansAngle rotation,
 		int distance)
 	{
-		RadiansAngle pointStep = new (RadiansAngle.MAX_RADIANS / fragments);
-		RadiansAngle adjustedRotation = rotation - new RadiansAngle (RadiansAngle.MAX_RADIANS / 4);
+		RadiansAngle pointStep = new (RadiansAngle.FullTurn / fragments);
+		RadiansAngle adjustedRotation = rotation - new RadiansAngle (RadiansAngle.FullTurn / 4);
 		var pointOffsets = ImmutableArray.CreateBuilder<PointI> (fragments);
 		pointOffsets.Count = fragments;
 		for (int i = 0; i < fragments; i++) {


### PR DESCRIPTION
It exposes _static_ information about the angle type. Conversions between types should still be explicit

Also, removed the `<` and `>` operators because they aren't used and they could be confusing (for instance, an angle of 370 degrees would be less than an angle of 20 degrees)

Related to the above, I'm thinking that the `+` and `-` operators could be confusing, too, or at least misleading. Perhaps their signature shouldn't be `(TAngle a, TAngle b)`, but `(TAngle a, double b)`. But I need to think about it, and feedback on this idea would be helpful, too.