### PR TITLE
Changed `IColor` interface

### DIFF
--- a/Pinta.Core/Classes/Color/ColorBgra.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.cs
@@ -17,7 +17,9 @@ namespace Pinta.Core;
 /// </summary>
 [Serializable]
 [StructLayout (LayoutKind.Explicit)]
-public readonly partial struct ColorBgra : IColor<ColorBgra>
+public readonly partial struct ColorBgra :
+	IInterpolableColor<ColorBgra>,
+	IAlphaColor<ColorBgra>
 {
 	[FieldOffset (0)]
 	public readonly byte B;

--- a/Pinta.Core/Classes/ColorGradient.cs
+++ b/Pinta.Core/Classes/ColorGradient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Pinta.Core;
 
 namespace Pinta.Core;
 
@@ -10,7 +9,7 @@ namespace Pinta.Core;
 /// Helps obtain intermediate colors at a certain position,
 /// based on the start and end colors, and any additional color stops
 /// </summary>
-public sealed class ColorGradient<TColor> where TColor : IColor<TColor>
+public sealed class ColorGradient<TColor> where TColor : IInterpolableColor<TColor>
 {
 	/// <summary>
 	/// Color at the initial position in the gradient
@@ -198,7 +197,7 @@ public static class ColorGradient
 		TColor startColor,
 		TColor endColor
 	)
-		where TColor : IColor<TColor>
+		where TColor : IInterpolableColor<TColor>
 	=> new (
 		startColor,
 		endColor,
@@ -217,7 +216,7 @@ public static class ColorGradient
 		double startPosition,
 		double endPosition
 	)
-		where TColor : IColor<TColor>
+		where TColor : IInterpolableColor<TColor>
 	=> new (
 		startColor,
 		endColor,
@@ -237,7 +236,7 @@ public static class ColorGradient
 		double endPosition,
 		IEnumerable<KeyValuePair<double, TColor>> stops
 	)
-		where TColor : IColor<TColor>
+		where TColor : IInterpolableColor<TColor>
 	=> new (
 		startColor,
 		endColor,

--- a/Pinta.Core/Classes/HsvColor.cs
+++ b/Pinta.Core/Classes/HsvColor.cs
@@ -15,11 +15,20 @@ namespace Pinta.Core;
 /// "A Primer on Building a Color Picker User Control with GDI+ in Visual Basic .NET or C#"
 /// http://www.msdnaa.net/Resources/display.aspx?ResID=2460
 /// </summary>
-public readonly struct HsvColor
+public readonly struct HsvColor : IColor<HsvColor>
 {
 	public double Hue { get; init; } // 0-360
 	public double Sat { get; init; } // 0-1
 	public double Val { get; init; } // 0-1
+
+	public static HsvColor Black => new (0, 0, 0);
+	public static HsvColor Red => new (0, 1, 1);
+	public static HsvColor Green => new (120, 1, 1);
+	public static HsvColor Blue => new (240, 1, 1);
+	public static HsvColor Yellow => new (60, 1, 1);
+	public static HsvColor Magenta => new (300, 1, 1);
+	public static HsvColor Cyan => new (180, 1, 1);
+	public static HsvColor White => new (0, 0, 1);
 
 	public HsvColor (double hue, double sat, double val)
 	{

--- a/Pinta.Core/Classes/IColor.cs
+++ b/Pinta.Core/Classes/IColor.cs
@@ -1,6 +1,26 @@
 namespace Pinta.Core;
 
-public interface IColor<TColor>
+public interface IColor<TColor> where TColor : IColor<TColor>
+{
+	static abstract TColor Black { get; }
+
+	static abstract TColor Red { get; }
+	static abstract TColor Green { get; }
+	static abstract TColor Blue { get; }
+
+	static abstract TColor Yellow { get; }
+	static abstract TColor Magenta { get; }
+	static abstract TColor Cyan { get; }
+
+	static abstract TColor White { get; }
+}
+
+public interface IAlphaColor<TColor> : IColor<TColor> where TColor : IAlphaColor<TColor>
+{
+	static abstract TColor Transparent { get; }
+}
+
+public interface IInterpolableColor<TColor> : IColor<TColor> where TColor : IInterpolableColor<TColor>
 {
 	static abstract TColor Lerp (in TColor from, in TColor to, double frac);
 }

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.ColorType.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.ColorType.cs
@@ -9,10 +9,21 @@ public readonly record struct Color (
 	double R,
 	double G,
 	double B,
-	double A
-)
-	: IColor<Color>
+	double A)
+:
+	IInterpolableColor<Color>,
+	IAlphaColor<Color>
 {
+	public static Color Black => new (0, 0, 0);
+	public static Color Red => new (1, 0, 0);
+	public static Color Green => new (0, 1, 0);
+	public static Color Blue => new (0, 0, 1);
+	public static Color Yellow => new (1, 1, 0);
+	public static Color Magenta => new (1, 0, 1);
+	public static Color Cyan => new (0, 1, 1);
+	public static Color White => new (1, 1, 1);
+	public static Color Transparent => new (0, 0, 0, 0);
+
 	public Color (double r, double g, double b)
 		: this (r, g, b, 1.0)
 	{ }


### PR DESCRIPTION
Now there is a hierarchy, to be used depending on the capabilities of the color in question.

The idea came when considering what happens if one tries to use `HsvColor` as a type argument for `ColorGradient`. I think it simply doesn't make sense, because the hue component of it is an angle.