### PR TITLE
Refactor DocumentSelection

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Document.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -76,8 +76,8 @@ public sealed class Document
 	{
 		// --- Mandatory fields
 
-		PreviousSelection = new (this);
-		Selection = new DocumentSelection (this);
+		PreviousSelection = new ();
+		Selection = new DocumentSelection ();
 
 		Layers = new DocumentLayers (tools, this);
 		Workspace = new DocumentWorkspace (actions, tools, this);
@@ -89,7 +89,7 @@ public sealed class Document
 		this.tools = tools;
 		this.workspace = workspace;
 
-		// --- Post-initialization 
+		// --- Post-initialization
 
 		if (file is not null) {
 
@@ -285,7 +285,7 @@ public sealed class Document
 	/// <param name="canvasOnly">false for the whole selection, true for the part only on our canvas</param>
 	public RectangleI GetSelectedBounds (bool canvasOnly)
 	{
-		RectangleI bounds = Selection.SelectionPath.GetBounds ();
+		RectangleI bounds = Selection.GetBounds ().ToInt ();
 
 		if (canvasOnly)
 			bounds = ClampToImageSize (bounds);

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Core.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Core.cs
@@ -57,12 +57,19 @@ partial class CairoExtensions
 		return newsurf;
 	}
 
-	public static Path Clone (this Path path)
+	/// <summary>
+	/// Placeholder surface used for <see cref="CreatePathContext"/>
+	/// Another option would be to use a different surface type, like
+	/// cairo_recording_surface_create(), but an empty image works okay.
+	/// </summary>
+	private static readonly Lazy<ImageSurface> empty_surface = new (() => CreateImageSurface (Format.Argb32, 0, 0));
+
+	/// <summary>
+	/// Creates a Cairo context without a backing image surface, which can only be used for building a Cairo.Path.
+	/// </summary>
+	public static Context CreatePathContext ()
 	{
-		Document doc = PintaCore.Workspace.ActiveDocument;
-		using Context g = new (doc.Layers.CurrentUserLayer.Surface);
-		g.AppendPath (path);
-		return g.CopyPath ();
+		return new Context (empty_surface.Value);
 	}
 
 	/// <summary>

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
@@ -85,14 +85,6 @@ partial class CairoExtensions
 			y2 - y1);
 	}
 
-	public static RectangleI GetBounds (this Path path)
-	{
-		Document doc = PintaCore.Workspace.ActiveDocument;
-		using Context g = new (doc.Layers.CurrentUserLayer.Surface);
-		g.AppendPath (path);
-		return g.PathExtents ().ToInt ();
-	}
-
 	public static RectangleI GetBounds (this ImageSurface surf)
 		=> new (0, 0, surf.Width, surf.Height);
 

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -82,8 +82,7 @@ public sealed class LivePreviewManager : ILivePreview
 			workspace.ImageSize.Width,
 			workspace.ImageSize.Height);
 
-		Cairo.Path? selectionPath = selection.Visible ? selection.SelectionPath : null;
-		RenderBounds = (selectionPath != null) ? selectionPath.GetBounds () : LivePreviewSurface.GetBounds ();
+		RenderBounds = selection.Visible ? selection.GetBounds ().ToInt () : LivePreviewSurface.GetBounds ();
 		RenderBounds = workspace.ClampToImageSize (RenderBounds);
 
 		const uint UPDATE_MILLISECONDS = 100;

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -316,7 +316,7 @@ public partial class LevelsDialog : Gtk.Dialog
 		Document doc = workspace.ActiveDocument;
 
 		ImageSurface surface = doc.Layers.CurrentUserLayer.Surface;
-		RectangleI rect = doc.Selection.SelectionPath.GetBounds ();
+		RectangleI rect = doc.Selection.GetBounds ().ToInt ();
 		histogram_input.Histogram.UpdateHistogram (surface, rect);
 		UpdateOutputHistogram ();
 	}

--- a/Pinta.Tools/Tools/MoveSelectedTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectedTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // MoveSelectedTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -58,7 +58,7 @@ public sealed class MoveSelectedTool : BaseTransformTool
 	public override int Priority => 5;
 
 	protected override RectangleD GetSourceRectangle (Document document)
-		=> document.Selection.SelectionPath.GetBounds ().ToDouble ();
+		=> document.Selection.GetBounds ();
 
 	protected override void OnStartTransform (Document document)
 	{

--- a/Pinta.Tools/Tools/MoveSelectionTool.cs
+++ b/Pinta.Tools/Tools/MoveSelectionTool.cs
@@ -60,7 +60,7 @@ public sealed class MoveSelectionTool : BaseTransformTool
 	public override bool IsSelectionTool => true;
 
 	protected override RectangleD GetSourceRectangle (Document document)
-		=> document.Selection.SelectionPath.GetBounds ().ToDouble ();
+		=> document.Selection.GetBounds ();
 
 	protected override void OnStartTransform (Document document)
 	{

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -630,7 +630,7 @@ internal sealed class MainWindow
 
 	private void ZoomToSelection_Activated (object sender, EventArgs e)
 	{
-		PintaCore.Workspace.ActiveWorkspace.ZoomToCanvasRectangle (PintaCore.Workspace.ActiveDocument.Selection.SelectionPath.GetBounds ().ToDouble ());
+		PintaCore.Workspace.ActiveWorkspace.ZoomToCanvasRectangle (PintaCore.Workspace.ActiveDocument.Selection.GetBounds ());
 	}
 
 	private void ZoomToWindow_Activated (object sender, EventArgs e)


### PR DESCRIPTION
This tidies up some minor issues before making further changes in PR #1515

- Remove the reference to the owning document. This was only used for creating a Cairo.Context for building the selection path, but this doesn't actually need access to the document's active layer. Instead, a new utility method provides a context which can be used solely for building paths

- Use `DocumentSelection.Bounds()` to get the selection bounds, rather than going through the Cairo.Path. This also makes the GetBounds() extension method unused, eliminating some references to the global PintaCore

- Remove unused Path.Clone() extension method