### PR TITLE
No state is saved in `AsyncEffectRenderer` anymore

### DIFF
--- a/Pinta.Core/Classes/RenderHandle.cs
+++ b/Pinta.Core/Classes/RenderHandle.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pinta.Core;
+
+internal readonly record struct CompletionInfo (
+	bool WasCanceled,
+	IReadOnlyList<Exception> Errors);
+
+internal sealed class RenderHandle
+{
+	internal double Progress
+		=> get_progress ();
+
+	/// <summary>
+	/// Retrieves the union of all tiles that have finished rendering since the
+	/// last time this method was called, and resets the updated area.
+	/// </summary>
+	/// <returns>
+	/// True if there was an updated area to retrieve, otherwise false.
+	/// </returns>
+	internal bool TryConsumeBounds (out RectangleI bounds)
+		=> bounds_consumer (out bounds);
+
+	internal Task<CompletionInfo> Task { get; }
+	internal void Cancel ()
+	{
+		cancellation.Cancel ();
+	}
+
+	private readonly CancellationTokenSource cancellation;
+	private readonly BoundsConsumer bounds_consumer;
+	private readonly Func<double> get_progress;
+
+	internal RenderHandle (
+		Task<CompletionInfo> task,
+		CancellationTokenSource cts,
+		BoundsConsumer boundsConsumer,
+		Func<double> getProgress)
+	{
+		Task = task;
+		cancellation = cts;
+		bounds_consumer = boundsConsumer;
+		get_progress = getProgress;
+	}
+
+	internal delegate bool BoundsConsumer (out RectangleI bounds);
+}

--- a/Pinta.Core/Classes/RenderHandle.cs
+++ b/Pinta.Core/Classes/RenderHandle.cs
@@ -9,7 +9,7 @@ internal readonly record struct CompletionInfo (
 	bool WasCanceled,
 	IReadOnlyList<Exception> Errors);
 
-internal sealed class RenderHandle
+internal sealed class RenderHandle : IDisposable
 {
 	internal double Progress
 		=> get_progress ();
@@ -47,4 +47,18 @@ internal sealed class RenderHandle
 	}
 
 	internal delegate bool BoundsConsumer (out RectangleI bounds);
+
+	public void Dispose ()
+	{
+		Dispose (disposing: true);
+	}
+	private void Dispose (bool disposing)
+	{
+		cancellation.Dispose ();
+	}
+
+	~RenderHandle ()
+	{
+		Dispose (disposing: false);
+	}
 }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -200,6 +200,8 @@ public sealed class LivePreviewManager : ILivePreview
 			dialog.Hide ();
 
 			renderAlive = false;
+
+			renderHandle?.Dispose ();
 		}
 
 		// === Methods ===
@@ -215,6 +217,7 @@ public sealed class LivePreviewManager : ILivePreview
 			handlersInQueue++;
 			renderHandle.Cancel ();
 			await renderHandle.Task;
+			renderHandle.Dispose ();
 			handlersInQueue--;
 			if (handlersInQueue > 0) return;
 			renderHandle = AsyncEffectRenderer.Start (settings, effect, layer.Surface, LivePreviewSurface);

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -101,12 +101,12 @@ public sealed class LivePreviewManager : ILivePreview
 		SimpleHistoryItem historyItem = new (effect.Icon, effect.Name);
 		historyItem.TakeSnapshotOfLayer (doc.Layers.CurrentUserLayerIndex);
 
-		AsyncEffectRenderer renderer = new (settings);
+		RenderHandle renderHandle = null!; // NRT: Assigned before first use
 
 		IProgressDialog dialog = chrome.ProgressDialog;
 		dialog.Title = Translations.GetString ("Rendering Effect");
 		dialog.Text = effect.Name;
-		dialog.Progress = renderer.Progress;
+		dialog.Progress = 0;
 		dialog.Canceled += HandleProgressDialogCancel;
 
 		bool renderAlive = true;
@@ -121,7 +121,8 @@ public sealed class LivePreviewManager : ILivePreview
 			if (effect.EffectData != null)
 				effect.EffectData.PropertyChanged += EffectData_PropertyChanged;
 
-			renderer.Start (
+			renderHandle = AsyncEffectRenderer.Start (
+				settings,
 				effect,
 				layer.Surface,
 				LivePreviewSurface);
@@ -131,7 +132,7 @@ public sealed class LivePreviewManager : ILivePreview
 				UPDATE_MILLISECONDS,
 				() => {
 					if (!renderAlive) return false;
-					PollForUpdate (renderer);
+					PollForUpdate (renderHandle);
 					return true; // Keep ticking as long as the effect is active.
 				}
 			);
@@ -142,7 +143,8 @@ public sealed class LivePreviewManager : ILivePreview
 
 			if (!userConfirmed) {
 				Debug.WriteLine ("User decided not to proceed with the render");
-				await renderer.Finish (cancel: true);
+				renderHandle.Cancel ();
+				await renderHandle.Task;
 				return;
 			}
 
@@ -151,17 +153,18 @@ public sealed class LivePreviewManager : ILivePreview
 
 			dialog.Show ();
 
-			var result = await renderer.Finish (cancel: false);
+			var result = await renderHandle.Task;
 
 			// Final poll after the renderer finishes to ensure the last-rendered tiles are displayed.
-			PollForUpdate (renderer);
+			PollForUpdate (renderHandle);
 
 			foreach (var ex in result.Errors)
 				Debug.WriteLine ("AsyncEffectRenderer Error while rendering effect: " + effectName + " exception: " + ex.Message + "\n" + ex.StackTrace);
 
 			if (result.WasCanceled) {
 				Debug.WriteLine ("User decided to cancel the render");
-				await renderer.Finish (cancel: true);
+				renderHandle.Cancel ();
+				await renderHandle.Task;
 				return;
 			}
 
@@ -203,27 +206,28 @@ public sealed class LivePreviewManager : ILivePreview
 
 		void HandleProgressDialogCancel (object? o, EventArgs e)
 		{
-			renderer.Finish (cancel: true);
+			renderHandle.Cancel ();
 		}
 
 		async void EffectData_PropertyChanged (object? sender, PropertyChangedEventArgs e)
 		{
 			// TODO: calculate bounds
 			handlersInQueue++;
-			await renderer.Finish (cancel: true);
+			renderHandle.Cancel ();
+			await renderHandle.Task;
 			handlersInQueue--;
 			if (handlersInQueue > 0) return;
-			renderer.Start (effect, layer.Surface, LivePreviewSurface);
+			renderHandle = AsyncEffectRenderer.Start (settings, effect, layer.Surface, LivePreviewSurface);
 		}
 
 		// This method now polls the renderer for its state instead of being a passive event handler.
-		void PollForUpdate (AsyncEffectRenderer renderer)
+		void PollForUpdate (RenderHandle renderTask)
 		{
 			Debug.WriteLine (DateTime.Now.ToString ("HH:mm:ss:ffff") + " Polling for update.");
 
-			chrome.ProgressDialog.Progress = renderer.Progress;
+			chrome.ProgressDialog.Progress = renderTask.Progress;
 
-			if (!renderer.TryConsumeBounds (out RectangleI updatedBounds))
+			if (!renderTask.TryConsumeBounds (out RectangleI updatedBounds))
 				return;
 
 			double scale = workspace.Scale;


### PR DESCRIPTION
All state consists of local variables in the `Start` method, accessible from local functions, too, but not being exposed to the outside, except in a controlled way, through the `RenderHandle` object that is being returned.

Further refactoring is needed, but it's getting closer to what was discussed in https://github.com/PintaProject/Pinta/pull/1009#issuecomment-2384659481 :)