### PR TITLE
Wrapper for proper disposing of timers

### DIFF
--- a/Pinta.Core/Classes/Wrappers/GLibTimerWrapper.cs
+++ b/Pinta.Core/Classes/Wrappers/GLibTimerWrapper.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pinta.Core;
+
+public readonly struct GLibTimerWrapper : IDisposable
+{
+	private readonly uint timer_id;
+	private GLibTimerWrapper (uint timerId)
+	{
+		timer_id = timerId;
+	}
+
+	public void Dispose ()
+	{
+		if (timer_id == 0) return;
+		GLib.Source.Remove (timer_id);
+	}
+
+	public static implicit operator GLibTimerWrapper (uint timerId)
+		=> new (timerId);
+}

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -92,7 +92,6 @@ public sealed class LivePreviewManager : ILivePreview
 			renderBounds: RenderBounds,
 			effectIsTileable: effect.IsTileable);
 
-		uint updateTimerId = 0;
 		int handlersInQueue = 0;
 		Layer layer = doc.Layers.CurrentUserLayer;
 
@@ -127,7 +126,7 @@ public sealed class LivePreviewManager : ILivePreview
 				layer.Surface,
 				LivePreviewSurface);
 
-			updateTimerId = GLib.Functions.TimeoutAdd (
+			using GLibTimerWrapper _ = GLib.Functions.TimeoutAdd (
 				0,
 				UPDATE_MILLISECONDS,
 				() => {
@@ -186,9 +185,6 @@ public sealed class LivePreviewManager : ILivePreview
 			IsEnabled = false;
 			LivePreviewSurface = null!;
 			workspace.Invalidate ();
-
-			if (updateTimerId > 0)
-				GLib.Source.Remove (updateTimerId);
 
 			if (effect.EffectData != null)
 				effect.EffectData.PropertyChanged -= EffectData_PropertyChanged;

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -210,7 +210,7 @@ internal sealed class MainWindow
 			if (canvasHasBeenShown)
 				return;
 
-			GLib.Functions.TimeoutAdd (
+			using GLibTimerWrapper _ = GLib.Functions.TimeoutAdd ( // Executed on UI thread
 				0,
 				0,
 				() => {


### PR DESCRIPTION
In a future pull request I might do something similar for `RenderHandle`