### PR TITLE
Color pickers for `SimpleEffectDialog`

### DIFF
--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -85,12 +85,9 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int count = data.Quality * data.Quality + 1;
 
 		var baseGradient =
-			GradientHelper
-			.CreateBaseGradientForEffect (
-				palette,
-				data.ColorSchemeSource,
-				data.ColorScheme,
-				data.ColorSchemeSeed)
+			ColorGradient.Create (
+				data.SomeColorBgra,
+				data.SomeCairoColor.ToColorBgra ())
 			.Resized (0, 1023);
 
 		return new (
@@ -200,5 +197,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 		[Caption ("Invert Colors")]
 		public bool InvertColors { get; set; } = false;
+		public Color SomeCairoColor { get; set; } = Color.Magenta;
+		public ColorBgra SomeColorBgra { get; set; } = ColorBgra.Cyan;
 	}
 }

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -85,9 +85,12 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int count = data.Quality * data.Quality + 1;
 
 		var baseGradient =
-			ColorGradient.Create (
-				data.SomeColorBgra,
-				data.SomeCairoColor.ToColorBgra ())
+			GradientHelper
+			.CreateBaseGradientForEffect (
+				palette,
+				data.ColorSchemeSource,
+				data.ColorScheme,
+				data.ColorSchemeSeed)
 			.Resized (0, 1023);
 
 		return new (
@@ -197,7 +200,5 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 		[Caption ("Invert Colors")]
 		public bool InvertColors { get; set; } = false;
-		public Color SomeCairoColor { get; set; } = Color.Magenta;
-		public ColorBgra SomeColorBgra { get; set; } = ColorBgra.Cyan;
 	}
 }


### PR DESCRIPTION
Closes #1501

The first commit is the change itself.

The second commit is the demo.

The third commit is the reversal of the demo.

![grafik](https://github.com/user-attachments/assets/3654032f-867e-4365-95aa-0c4bbb3889a0)
