### PR TITLE
Refactoring in `ColorPickerDialog`

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -87,15 +87,15 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 	public ColorPick Colors { get; private set; }
 
 	private Color CurrentColor {
-		get => GetTargeted ();
+		get => GetTargeted (Colors, primary_selected);
 		set => SetTargeted (value);
 	}
 
-	private Color GetTargeted ()
+	private static Color GetTargeted (ColorPick colors, bool primarySelected)
 	{
-		return Colors switch {
-			SingleColor singleColor => primary_selected ? singleColor.Color : throw new InvalidOperationException (),
-			PaletteColors paletteColors => primary_selected ? paletteColors.Primary : paletteColors.Secondary,
+		return colors switch {
+			SingleColor singleColor => primarySelected ? singleColor.Color : throw new InvalidOperationException (),
+			PaletteColors paletteColors => primarySelected ? paletteColors.Primary : paletteColors.Secondary,
 			_ => throw new UnreachableException (),
 		};
 	}
@@ -346,10 +346,8 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 
 		// Handles the ColorPickerSliders + Hex entry.
 
-		Colors = adjustable;
-
 		Gtk.Entry hexEntry = new () {
-			Text_ = CurrentColor.ToHex (),
+			Text_ = GetTargeted (adjustable, primary_selected).ToHex (),
 			MaxWidthChars = 10,
 		};
 		hexEntry.OnChanged (HexEntry_OnChanged);
@@ -376,7 +374,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 360,
 				Text = Translations.GetString ("Hue"),
-				InitialValue = CurrentColor.ToHsv ().Hue,
+				InitialValue = GetTargeted (adjustable, primary_selected).ToHsv ().Hue,
 			}
 		);
 		hueSlider.Gradient.SetDrawFunc (
@@ -408,7 +406,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 100,
 				Text = Translations.GetString ("Sat"),
-				InitialValue = CurrentColor.ToHsv ().Sat * 100.0,
+				InitialValue = GetTargeted (adjustable, primary_selected).ToHsv ().Sat * 100.0,
 			}
 		);
 		saturationSlider.Gradient.SetDrawFunc (
@@ -430,7 +428,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 100,
 				Text = Translations.GetString ("Value"),
-				InitialValue = CurrentColor.ToHsv ().Val * 100.0,
+				InitialValue = GetTargeted (adjustable, primary_selected).ToHsv ().Val * 100.0,
 			}
 		);
 		valueSlider.Gradient.SetDrawFunc (
@@ -452,7 +450,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Red"),
-				InitialValue = CurrentColor.R * 255.0,
+				InitialValue = GetTargeted (adjustable, primary_selected).R * 255.0,
 			}
 		);
 		redSlider.Gradient.SetDrawFunc (
@@ -474,7 +472,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Green"),
-				InitialValue = CurrentColor.G * 255.0,
+				InitialValue = GetTargeted (adjustable, primary_selected).G * 255.0,
 			}
 		);
 		greenSlider.Gradient.SetDrawFunc (
@@ -496,7 +494,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Blue"),
-				InitialValue = CurrentColor.B * 255.0,
+				InitialValue = GetTargeted (adjustable, primary_selected).B * 255.0,
 			}
 		);
 		blueSlider.Gradient.SetDrawFunc (
@@ -518,7 +516,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Alpha"),
-				InitialValue = CurrentColor.A * 255.0,
+				InitialValue = GetTargeted (adjustable, primary_selected).A * 255.0,
 			}
 		);
 		alphaSlider.Gradient.SetDrawFunc (
@@ -634,6 +632,8 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 		this.SetDefaultResponse (Gtk.ResponseType.Cancel);
 
 		// --- References to keep
+
+		Colors = adjustable;
 
 		primary_selected = primarySelected;
 		original_colors = adjustable;

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -195,8 +195,6 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 		bool livePalette,
 		string windowTitle)
 	{
-		primary_selected = true;
-
 		bool showWatches = !livePalette;
 
 		Gtk.Button resetButton = new () { Label = Translations.GetString ("Reset Color") };
@@ -347,7 +345,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 		// Handles the ColorPickerSliders + Hex entry.
 
 		Gtk.Entry hexEntry = new () {
-			Text_ = GetTargeted (adjustable, primary_selected).ToHex (),
+			Text_ = GetTargeted (adjustable, true).ToHex (),
 			MaxWidthChars = 10,
 		};
 		hexEntry.OnChanged (HexEntry_OnChanged);
@@ -374,7 +372,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 360,
 				Text = Translations.GetString ("Hue"),
-				InitialValue = GetTargeted (adjustable, primary_selected).ToHsv ().Hue,
+				InitialValue = GetTargeted (adjustable, true).ToHsv ().Hue,
 			}
 		);
 		hueSlider.Gradient.SetDrawFunc (
@@ -406,7 +404,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 100,
 				Text = Translations.GetString ("Sat"),
-				InitialValue = GetTargeted (adjustable, primary_selected).ToHsv ().Sat * 100.0,
+				InitialValue = GetTargeted (adjustable, true).ToHsv ().Sat * 100.0,
 			}
 		);
 		saturationSlider.Gradient.SetDrawFunc (
@@ -428,7 +426,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 100,
 				Text = Translations.GetString ("Value"),
-				InitialValue = GetTargeted (adjustable, primary_selected).ToHsv ().Val * 100.0,
+				InitialValue = GetTargeted (adjustable, true).ToHsv ().Val * 100.0,
 			}
 		);
 		valueSlider.Gradient.SetDrawFunc (
@@ -450,7 +448,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Red"),
-				InitialValue = GetTargeted (adjustable, primary_selected).R * 255.0,
+				InitialValue = GetTargeted (adjustable, true).R * 255.0,
 			}
 		);
 		redSlider.Gradient.SetDrawFunc (
@@ -472,7 +470,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Green"),
-				InitialValue = GetTargeted (adjustable, primary_selected).G * 255.0,
+				InitialValue = GetTargeted (adjustable, true).G * 255.0,
 			}
 		);
 		greenSlider.Gradient.SetDrawFunc (
@@ -494,7 +492,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Blue"),
-				InitialValue = GetTargeted (adjustable, primary_selected).B * 255.0,
+				InitialValue = GetTargeted (adjustable, true).B * 255.0,
 			}
 		);
 		blueSlider.Gradient.SetDrawFunc (
@@ -516,7 +514,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Alpha"),
-				InitialValue = GetTargeted (adjustable, primary_selected).A * 255.0,
+				InitialValue = GetTargeted (adjustable, true).A * 255.0,
 			}
 		);
 		alphaSlider.Gradient.SetDrawFunc (
@@ -602,7 +600,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			palette.PrimaryColorChanged += PrimaryChangeHandler;
 			palette.SecondaryColorChanged += SecondaryChangeHandler;
 			IsActivePropertyDefinition.Notify (this, ActiveWindowChangeHandler);
-			this.OnResponse += ColorPickerDialog_OnResponse;
+			OnResponse += ColorPickerDialog_OnResponse;
 		}
 
 		// --- Initialization (Gtk.Widget)

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -87,11 +87,11 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 	public ColorPick Colors { get; private set; }
 
 	private Color CurrentColor {
-		get => GetTargeted (Colors, primary_selected);
+		get => ExtractTargetedColor (Colors, primary_selected);
 		set => SetTargeted (value);
 	}
 
-	private static Color GetTargeted (ColorPick colors, bool primarySelected)
+	private static Color ExtractTargetedColor (ColorPick colors, bool primarySelected)
 	{
 		return colors switch {
 			SingleColor singleColor => primarySelected ? singleColor.Color : throw new InvalidOperationException (),
@@ -345,7 +345,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 		// Handles the ColorPickerSliders + Hex entry.
 
 		Gtk.Entry hexEntry = new () {
-			Text_ = GetTargeted (adjustable, true).ToHex (),
+			Text_ = ExtractTargetedColor (adjustable, true).ToHex (),
 			MaxWidthChars = 10,
 		};
 		hexEntry.OnChanged (HexEntry_OnChanged);
@@ -372,7 +372,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 360,
 				Text = Translations.GetString ("Hue"),
-				InitialValue = GetTargeted (adjustable, true).ToHsv ().Hue,
+				InitialValue = ExtractTargetedColor (adjustable, true).ToHsv ().Hue,
 			}
 		);
 		hueSlider.Gradient.SetDrawFunc (
@@ -404,7 +404,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 100,
 				Text = Translations.GetString ("Sat"),
-				InitialValue = GetTargeted (adjustable, true).ToHsv ().Sat * 100.0,
+				InitialValue = ExtractTargetedColor (adjustable, true).ToHsv ().Sat * 100.0,
 			}
 		);
 		saturationSlider.Gradient.SetDrawFunc (
@@ -426,7 +426,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 100,
 				Text = Translations.GetString ("Value"),
-				InitialValue = GetTargeted (adjustable, true).ToHsv ().Val * 100.0,
+				InitialValue = ExtractTargetedColor (adjustable, true).ToHsv ().Val * 100.0,
 			}
 		);
 		valueSlider.Gradient.SetDrawFunc (
@@ -448,7 +448,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Red"),
-				InitialValue = GetTargeted (adjustable, true).R * 255.0,
+				InitialValue = ExtractTargetedColor (adjustable, true).R * 255.0,
 			}
 		);
 		redSlider.Gradient.SetDrawFunc (
@@ -470,7 +470,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Green"),
-				InitialValue = GetTargeted (adjustable, true).G * 255.0,
+				InitialValue = ExtractTargetedColor (adjustable, true).G * 255.0,
 			}
 		);
 		greenSlider.Gradient.SetDrawFunc (
@@ -492,7 +492,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Blue"),
-				InitialValue = GetTargeted (adjustable, true).B * 255.0,
+				InitialValue = ExtractTargetedColor (adjustable, true).B * 255.0,
 			}
 		);
 		blueSlider.Gradient.SetDrawFunc (
@@ -514,7 +514,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 			settings: cpsArgs with {
 				Max = 255,
 				Text = Translations.GetString ("Alpha"),
-				InitialValue = GetTargeted (adjustable, true).A * 255.0,
+				InitialValue = ExtractTargetedColor (adjustable, true).A * 255.0,
 			}
 		);
 		alphaSlider.Gradient.SetDrawFunc (


### PR DESCRIPTION
The `get`ter of `CurrentColor` was changed so that code inside the constructor would depend less on the state of the object (which hasn't been properly initialized). This made it possible to move the assignment to the `Colors` property all the way to the end of the constructor