### PR TITLE
Consolidate methods for converting colors to/from hex strings

### DIFF
--- a/Pinta.Core/Classes/Color/ColorBgra.Conversion.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.Conversion.cs
@@ -37,37 +37,6 @@ partial struct ColorBgra
 			Utility.ClampToByte (r),
 			Utility.ClampToByte (a));
 
-	public static bool TryParseHexString (string hexString, out ColorBgra color)
-	{
-		try {
-			uint value = Convert.ToUInt32 (hexString, 16);
-			color = FromUInt32 (value);
-			return true;
-		} catch (Exception) {
-			color = Zero;
-			return false;
-		}
-	}
-
-	public readonly string ToHexString ()
-	{
-		int rgbNumber = (R << 16) | (G << 8) | B;
-
-		string colorString = Convert.ToString (rgbNumber, 16);
-
-		while (colorString.Length < 6)
-			colorString = "0" + colorString;
-
-		string alphaString = Convert.ToString (A, 16);
-
-		while (alphaString.Length < 2)
-			alphaString = "0" + alphaString;
-
-		colorString = alphaString + colorString;
-
-		return colorString.ToUpper ();
-	}
-
 	/// <summary>
 	/// Constructs a new ColorBgra instance with the given 32-bit value.
 	/// </summary>

--- a/tests/Pinta.Core.Tests/ColorTests.cs
+++ b/tests/Pinta.Core.Tests/ColorTests.cs
@@ -36,11 +36,19 @@ internal sealed class ColorTests
 	[TestCase ("#CC33AA99", 0.8, 0.2, 0.6667, 0.6)]
 	[TestCase ("C3A9", 0.8, 0.2, 0.6667, 0.6)]
 	[TestCase ("C3A", 0.8, 0.2, 0.6667, 1)]
-	public void Hex (string hex, double r, double g, double b, double a)
+	public void FromHex (string hex, double r, double g, double b, double a)
 	{
-		var hc = Color.FromHex (hex)!.Value;
-		hc = new (Math.Round (hc.R, 4), Math.Round (hc.G, 4), Math.Round (hc.B, 4));
-		var c = new Color (r, g, b);
-		Assert.That (hc, Is.EqualTo (c));
+		Color hc = Color.FromHex (hex)!.Value;
+		hc = new (Math.Round (hc.R, 4), Math.Round (hc.G, 4), Math.Round (hc.B, 4), Math.Round (hc.A, 4));
+		Color expectedColor = new (r, g, b, a);
+		Assert.That (hc, Is.EqualTo (expectedColor));
+	}
+
+	[TestCase (0.6, 0, 0.3, 1.0, true, "99004CFF")]
+	[TestCase (0.6, 0, 0.3, 1.0, false, "99004C")]
+	public void ToHex (double r, double g, double b, double a, bool alpha, string expected)
+	{
+		Color c = new (r, g, b, a);
+		Assert.That (c.ToHex (alpha), Is.EqualTo (expected));
 	}
 }


### PR DESCRIPTION
- Remove the `ColorBgra` hex conversion methods in favour of the ones in `Cairo.Color`. In the palette manager this was a source of conversions between ColorBgra and Cairo.Color which didn't convert between premultiplied alpha, which we want to eliminate for bug #1553. There was also no need for having duplicate logic for this in different color types

- Since `ColorBgra.TohexString()` didn't produce a hex string in RGBA order, we need some simple wrappers to reorder the color channels. This preserves compatibility when loading existing settings from disk

- Fix the `Cairo.Color` tests to include alpha when parsing hex strings, and add tests for converting to hex