### PR TITLE
Specified increment size in several `double`-typed effect configuration parameters

### DIFF
--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -166,13 +166,16 @@ public sealed class AddNoiseEffect : BaseEffect
 
 	public sealed class NoiseData : EffectData
 	{
-		[Caption ("Intensity"), MinimumValue (0), MaximumValue (100)]
+		[Caption ("Intensity")]
+		[MinimumValue (0), MaximumValue (100)]
 		public int Intensity { get; set; } = 64;
 
-		[Caption ("Color Saturation"), MinimumValue (0), MaximumValue (400)]
+		[Caption ("Color Saturation")]
+		[MinimumValue (0), MaximumValue (400)]
 		public int ColorSaturation { get; set; } = 100;
 
-		[Caption ("Coverage"), MinimumValue (0), DigitsValue (2), MaximumValue (100)]
+		[Caption ("Coverage")]
+		[MinimumValue (0), MaximumValue (100), DigitsValue (2), IncrementValue (1)]
 		public double Coverage { get; set; } = 100.0;
 
 		[Caption ("Random Noise Seed")]

--- a/Pinta.Effects/Effects/AddNoiseEffect.cs
+++ b/Pinta.Effects/Effects/AddNoiseEffect.cs
@@ -102,17 +102,16 @@ public sealed class AddNoiseEffect : BaseEffect
 		int dev,
 		int sat);
 
-	private AddNoiseSettings CreateSettings (ImageSurface src)
+	private AddNoiseSettings CreateSettings (ImageSurface source)
 	{
 		var data = Data;
 		int intensity = data.Intensity;
-		int color_saturation = data.ColorSaturation;
 		return new (
-			size: src.GetSize (),
+			size: source.GetSize (),
 			seed: data.Seed,
 			coverage: 0.01 * data.Coverage,
 			dev: intensity * intensity / 4,
-			sat: color_saturation * 4096 / 100
+			sat: data.ColorSaturation * 4096 / 100
 		);
 	}
 

--- a/Pinta.Effects/Effects/CellsEffect.cs
+++ b/Pinta.Effects/Effects/CellsEffect.cs
@@ -133,18 +133,18 @@ public sealed class CellsEffect : BaseEffect
 
 	public sealed class CellsData : EffectData
 	{
-
 		[Caption ("Distance Metric")]
 		public DistanceMetric DistanceMetric { get; set; } = DistanceMetric.Euclidean;
 
-		[Caption ("Number of Cells"), MinimumValue (1), MaximumValue (1024)]
+		[Caption ("Number of Cells")]
+		[MinimumValue (1), MaximumValue (1024)]
 		public int NumberOfCells { get; set; } = 100;
 
 		[Caption ("Random Point Locations")]
 		public RandomSeed RandomPointLocations { get; set; } = new (0);
 
 		[Caption ("Cell Radius")]
-		[MinimumValue (4), MaximumValue (100)]
+		[MinimumValue (4), MaximumValue (100), IncrementValue (1)]
 		public double CellRadius { get; set; } = 32;
 
 		// TODO: Show points

--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -132,23 +132,24 @@ public sealed class DentsEffect : BaseEffect
 
 public sealed class DentsData : EffectData, Warp.IEffectData
 {
-	[MinimumValue (1), MaximumValue (200)]
+	[MinimumValue (1), MaximumValue (200), IncrementValue (1)]
 	public double Scale { get; set; } = 25;
 
-	[MinimumValue (0), MaximumValue (200)]
+	[MinimumValue (0), MaximumValue (200), IncrementValue (1)]
 	public double Refraction { get; set; } = 50;
 
-	[MinimumValue (0), MaximumValue (100)]
+	[MinimumValue (0), MaximumValue (100), IncrementValue (1)]
 	public double Roughness { get; set; } = 10;
 
 	[Caption ("Turbulence")]
-	[MinimumValue (0), MaximumValue (100)]
+	[MinimumValue (0), MaximumValue (100), IncrementValue (1)]
 	public double Tension { get; set; } = 10;
 
 	[MinimumValue (0), MaximumValue (255)]
 	public RandomSeed Seed { get; set; } = new (0);
 
-	[Caption ("Quality"), MinimumValue (1), MaximumValue (5)]
+	[Caption ("Quality")]
+	[MinimumValue (1), MaximumValue (5)]
 	public int Quality { get; set; } = 2;
 
 	[Caption ("Center Offset")]

--- a/Pinta.Effects/Effects/DentsEffect.cs
+++ b/Pinta.Effects/Effects/DentsEffect.cs
@@ -74,20 +74,20 @@ public sealed class DentsEffect : BaseEffect
 		EffectData = new DentsData ();
 	}
 
-	protected override void Render (ImageSurface src, ImageSurface dst, RectangleI roi)
+	protected override void Render (ImageSurface source, ImageSurface destination, RectangleI roi)
 	{
 		Warp.Settings settings = Warp.CreateSettings (
 			Data,
 			live_preview.RenderBounds,
 			palette);
 
-		Span<ColorBgra> dst_data = dst.GetPixelData ();
-		ReadOnlySpan<ColorBgra> src_data = src.GetReadOnlyPixelData ();
-		foreach (var pixel in Tiling.GeneratePixelOffsets (roi, src.GetSize ()))
+		Span<ColorBgra> dst_data = destination.GetPixelData ();
+		ReadOnlySpan<ColorBgra> src_data = source.GetReadOnlyPixelData ();
+		foreach (var pixel in Tiling.GeneratePixelOffsets (roi, source.GetSize ()))
 			dst_data[pixel.memoryOffset] = Warp.GetPixelColor (
 				settings,
 				InverseTransform,
-				src,
+				source,
 				src_data[pixel.memoryOffset],
 				pixel);
 	}

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -154,13 +154,16 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 	public sealed class JuliaFractalData : EffectData
 	{
-		[Caption ("Factor"), MinimumValue (1), MaximumValue (10)]
+		[Caption ("Factor")]
+		[MinimumValue (1), MaximumValue (10)]
 		public int Factor { get; set; } = 4;
 
-		[Caption ("Quality"), MinimumValue (1), MaximumValue (5)]
+		[Caption ("Quality")]
+		[MinimumValue (1), MaximumValue (5)]
 		public int Quality { get; set; } = 2;
 
-		[Caption ("Zoom"), MinimumValue (0), MaximumValue (50)]
+		[Caption ("Zoom")]
+		[MinimumValue (0), MaximumValue (50), IncrementValue (0.5)]
 		public double Zoom { get; set; } = 1;
 
 		[Caption ("Color Scheme Source")]

--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -53,10 +53,10 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 	private static readonly Julia fractal = new (maxSquared: 10_000);
 
-	protected override void Render (ImageSurface src, ImageSurface dst, RectangleI roi)
+	protected override void Render (ImageSurface source, ImageSurface destination, RectangleI roi)
 	{
-		JuliaSettings settings = CreateSettings (dst);
-		Span<ColorBgra> dst_data = dst.GetPixelData ();
+		JuliaSettings settings = CreateSettings (destination);
+		Span<ColorBgra> dst_data = destination.GetPixelData ();
 		foreach (var pixel in Tiling.GeneratePixelOffsets (roi, settings.canvasSize))
 			dst_data[pixel.memoryOffset] = GetPixelColor (settings, pixel.coordinates);
 	}
@@ -72,15 +72,14 @@ public sealed class JuliaFractalEffect : BaseEffect
 		Matrix3x2D rotation,
 		int factor,
 		ColorGradient<ColorBgra> colorGradient);
-	private JuliaSettings CreateSettings (ImageSurface dst)
+	private JuliaSettings CreateSettings (ImageSurface destination)
 	{
 		// Reference to effect data, to prevent repeated casting
 		// TODO: Remove if and when reading the property doesn't require casting
 		var data = Data;
 
-		Size canvasSize = dst.GetSize ();
-		var count = data.Quality * data.Quality + 1;
-		RadiansAngle angleTheta = data.Angle.ToRadians ();
+		Size canvasSize = destination.GetSize ();
+		int count = data.Quality * data.Quality + 1;
 
 		var baseGradient =
 			GradientHelper

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -72,7 +72,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		int factor,
 		bool invertColors,
 		ColorGradient<ColorBgra> colorGradient);
-	private MandelbrotSettings CreateSettings (ImageSurface dst)
+	private MandelbrotSettings CreateSettings (ImageSurface destination)
 	{
 		const double ZOOM_FACTOR = 20.0;
 
@@ -80,7 +80,7 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		// TODO: Remove if and when reading the property doesn't require casting
 		var data = Data;
 
-		Size canvasSize = new (dst.Width, dst.Height);
+		Size canvasSize = new (destination.Width, destination.Height);
 		double zoom = 1 + ZOOM_FACTOR * data.Zoom;
 		int count = data.Quality * data.Quality + 1;
 
@@ -115,15 +115,15 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 		);
 	}
 
-	protected override void Render (ImageSurface src, ImageSurface dst, RectangleI roi)
+	protected override void Render (ImageSurface source, ImageSurface destination, RectangleI roi)
 	{
-		MandelbrotSettings settings = CreateSettings (dst);
-		Span<ColorBgra> dst_data = dst.GetPixelData ();
+		MandelbrotSettings settings = CreateSettings (destination);
+		Span<ColorBgra> dst_data = destination.GetPixelData ();
 		foreach (var pixel in Tiling.GeneratePixelOffsets (roi, settings.canvasSize))
 			dst_data[pixel.memoryOffset] = GetPixelColor (settings, pixel.coordinates);
 
 		if (settings.invertColors)
-			invert_effect.Render (dst, dst, [roi]);
+			invert_effect.Render (destination, destination, [roi]);
 	}
 
 	private static ColorBgra GetPixelColor (MandelbrotSettings settings, PointI target)

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -174,13 +174,16 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 	public sealed class MandelbrotFractalData : EffectData
 	{
-		[Caption ("Factor"), MinimumValue (1), MaximumValue (10)]
+		[Caption ("Factor")]
+		[MinimumValue (1), MaximumValue (10)]
 		public int Factor { get; set; } = 1;
 
-		[Caption ("Quality"), MinimumValue (1), MaximumValue (5)]
+		[Caption ("Quality")]
+		[MinimumValue (1), MaximumValue (5)]
 		public int Quality { get; set; } = 2;
 
-		[Caption ("Zoom"), MinimumValue (0), MaximumValue (100)]
+		[Caption ("Zoom")]
+		[MinimumValue (0), MaximumValue (100), IncrementValue (0.5)]
 		public double Zoom { get; set; } = 10;
 
 		[Caption ("Angle")]

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -52,7 +52,7 @@ public sealed class PolarInversionEffect : BaseEffect
 		EffectData = new PolarInversionData ();
 	}
 
-	protected override void Render (ImageSurface source, ImageSurface destination, RectangleI rect)
+	protected override void Render (ImageSurface source, ImageSurface destination, RectangleI roi)
 	{
 		Warp.Settings settings = Warp.CreateSettings (
 			Data,
@@ -62,7 +62,7 @@ public sealed class PolarInversionEffect : BaseEffect
 		Span<ColorBgra> dst_data = destination.GetPixelData ();
 		ReadOnlySpan<ColorBgra> src_data = source.GetReadOnlyPixelData ();
 
-		foreach (var pixel in Tiling.GeneratePixelOffsets (rect, source.GetSize ()))
+		foreach (var pixel in Tiling.GeneratePixelOffsets (roi, source.GetSize ()))
 			dst_data[pixel.memoryOffset] = Warp.GetPixelColor (
 				settings,
 				InverseTransform,

--- a/Pinta.Effects/Effects/PolarInversionEffect.cs
+++ b/Pinta.Effects/Effects/PolarInversionEffect.cs
@@ -86,10 +86,11 @@ public sealed class PolarInversionEffect : BaseEffect
 
 public sealed class PolarInversionData : EffectData, Warp.IEffectData
 {
-	[MinimumValue (-4), MaximumValue (4)]
+	[MinimumValue (-4), MaximumValue (4), IncrementValue (0.1)]
 	public double Amount { get; set; } = 0;
 
-	[Caption ("Quality"), MinimumValue (1), MaximumValue (5)]
+	[Caption ("Quality")]
+	[MinimumValue (1), MaximumValue (5)]
 	public int Quality { get; set; } = 2;
 
 	[Caption ("Center Offset")]


### PR DESCRIPTION
The default increment, 0.01, is too small for certain parameters, making the arrow buttons annoying to use.

As a thought, would it be a good idea to allow the user to configure the increment size, or would that complicate the user interface too much?