### PR TITLE
Refactored several effects to use the `ColorBgra.Blend` method

### DIFF
--- a/Pinta.Effects/Effects/JuliaFractalEffect.cs
+++ b/Pinta.Effects/Effects/JuliaFractalEffect.cs
@@ -109,15 +109,12 @@ public sealed class JuliaFractalEffect : BaseEffect
 
 	private static ColorBgra GetPixelColor (JuliaSettings settings, PointI target)
 	{
-		int r = 0;
-		int g = 0;
-		int b = 0;
-		int a = 0;
+		Span<ColorBgra> samples = stackalloc ColorBgra[settings.count];
 
 		double baseTransfX = 2.0 * target.X - settings.canvasSize.Width;
 		double baseTransfY = 2.0 * target.Y - settings.canvasSize.Height;
 
-		for (double i = 0; i < settings.count; i++) {
+		for (int i = 0; i < settings.count; i++) {
 
 			PointD transformed = new (
 				X: (baseTransfX + (i * settings.invCount)) * settings.invH,
@@ -136,19 +133,10 @@ public sealed class JuliaFractalEffect : BaseEffect
 				settings.colorGradient.StartPosition,
 				settings.colorGradient.EndPosition);
 
-			ColorBgra colorAddend = settings.colorGradient.GetColor (c);
-
-			b += colorAddend.B;
-			g += colorAddend.G;
-			r += colorAddend.R;
-			a += colorAddend.A;
+			samples[i] = settings.colorGradient.GetColor (c);
 		}
 
-		return ColorBgra.FromBgra (
-			b: Utility.ClampToByte (b / settings.count),
-			g: Utility.ClampToByte (g / settings.count),
-			r: Utility.ClampToByte (r / settings.count),
-			a: Utility.ClampToByte (a / settings.count));
+		return ColorBgra.Blend (samples);
 	}
 
 	public sealed class JuliaFractalData : EffectData

--- a/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
+++ b/Pinta.Effects/Effects/MandelbrotFractalEffect.cs
@@ -128,17 +128,14 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 
 	private static ColorBgra GetPixelColor (MandelbrotSettings settings, PointI target)
 	{
-		int r = 0;
-		int g = 0;
-		int b = 0;
-		int a = 0;
+		Span<ColorBgra> samples = stackalloc ColorBgra[settings.count];
 
 		double baseU = ((2.0 * target.X) - settings.canvasSize.Width) * settings.invH;
 		double baseV = ((2.0 * target.Y) - settings.canvasSize.Height) * settings.invH;
 
 		double deltaU = settings.invCount * settings.invH;
 
-		for (double i = 0; i < settings.count; i++) {
+		for (int i = 0; i < settings.count; i++) {
 
 			PointD rel = new (
 				X: baseU + i * deltaU,
@@ -156,20 +153,10 @@ public sealed class MandelbrotFractalEffect : BaseEffect
 				settings.colorGradient.StartPosition,
 				settings.colorGradient.EndPosition);
 
-			ColorBgra colorAddend = settings.colorGradient.GetColor (c);
-
-			r += colorAddend.R;
-			g += colorAddend.G;
-			b += colorAddend.B;
-			a += colorAddend.A;
+			samples[i] = settings.colorGradient.GetColor (c);
 		}
 
-		return ColorBgra.FromBgra (
-			b: Utility.ClampToByte (b / settings.count),
-			g: Utility.ClampToByte (g / settings.count),
-			r: Utility.ClampToByte (r / settings.count),
-			a: Utility.ClampToByte (a / settings.count)
-		);
+		return ColorBgra.Blend (samples);
 	}
 
 	public sealed class MandelbrotFractalData : EffectData


### PR DESCRIPTION
The message for the second commit is wrong. It should be 'Mandelbrot fractal'.

These are the low-hanging fruits. There are many other effects (for example `OilPaintingEffect` and `GaussianBlurEffect`, among others) which are good candidates for this type of refactoring, but require a more thoughtful approach (perhaps by creating some `BgraAggregation` type? this has the added marginal benefit of requiring less space on the stack)