### PR TITLE
Fix the color difference comparison's handling of alpha

### DIFF
--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -94,20 +94,6 @@ public static class Utility
 		return unionsAggregate;
 	}
 
-	public static int ColorDifferenceSquared (in ColorBgra a, in ColorBgra b)
-	{
-		int r_diff = a.R - b.R;
-		int g_diff = a.G - b.G;
-		int b_diff = a.B - b.B;
-
-		int diffSq =
-			  (r_diff * r_diff)
-			+ (g_diff * g_diff)
-			+ (b_diff * b_diff);
-
-		return diffSq / 3;
-	}
-
 	public static string GetStaticName (Type type)
 	{
 		var pi = type.GetProperty ("StaticName", BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty);
@@ -423,12 +409,12 @@ public static class Utility
 	];
 
 	/// <summary>Gets the nearest step angle in radians.</summary>
-	/// 
+	///
 	/// <returns>The nearest step angle in radians.</returns>
-	/// 
+	///
 	/// <param name="angle">Angle in radians.</param>
 	/// <param name="steps">Number of steps to divide the circle.</param>
-	/// 
+	///
 	public static RadiansAngle GetNearestStepAngle (RadiansAngle angle, int steps)
 	{
 		ArgumentOutOfRangeException.ThrowIfLessThan (steps, 1);

--- a/Pinta.Core/Classes/Color/ColorBgra.Comparison.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.Comparison.cs
@@ -16,9 +16,9 @@ partial struct ColorBgra
 		int diffB = a.B - b.B;
 		int diffA = a.A - b.A;
 
-		int summandR = (1 + diffR * diffR) * a.A / 256;
-		int summandG = (1 + diffG * diffG) * a.A / 256;
-		int summandB = (1 + diffB * diffB) * a.A / 256;
+		int summandR = diffR * diffR;
+		int summandG = diffG * diffG;
+		int summandB = diffB * diffB;
 		int summandA = diffA * diffA;
 
 		int sum = summandR + summandG + summandB + summandA;


### PR DESCRIPTION
- If ColorBgra is using premultiplied alpha, this doesn't need to scale by alpha again and can just compute a Euclidean distance as-is

- Remove unused ColorDifferenceSquared() method

Bug: #1553