### PR TITLE
Port ColorBgra.NewAlpha() to work with premultiplied alpha

### DIFF
--- a/Pinta.Core/Classes/Color/ColorBgra.Blending.cs
+++ b/Pinta.Core/Classes/Color/ColorBgra.Blending.cs
@@ -131,10 +131,14 @@ partial struct ColorBgra
 	}
 
 	/// <summary>
-	/// Returns a new ColorBgra with the same color values but with a new alpha component value.
-	/// <remarks>This assumes straight alpha!</remarks>
+	/// Returns a new ColorBgra with an updated alpha component.
+	/// <remarks>The color components are also adjusted since premultiplied alpha is used.</remarks>
 	/// </summary>
-	public readonly ColorBgra NewAlpha (byte newA) => FromBgra (B, G, R, newA);
+	public readonly ColorBgra NewAlpha (byte newA)
+	{
+		ColorBgra sc = ToStraightAlpha ();
+		return new ColorBgra (sc.B, sc.G, sc.R, newA).ToPremultipliedAlpha ();
+	}
 
 	/// <summary>
 	/// Brings the color channels from straight alpha in premultiplied alpha form.

--- a/Pinta.Core/Effects/GradientRenderer.cs
+++ b/Pinta.Core/Effects/GradientRenderer.cs
@@ -148,8 +148,7 @@ public abstract class GradientRenderer
 				byte lerpByte = ComputeByteLerp (x, y);
 				byte lerpAlpha = lerp_alphas[lerpByte];
 				ColorBgra original = row[x];
-				ColorBgra color = original.ToStraightAlpha ().NewAlpha (lerpAlpha);
-				row[x] = color.ToPremultipliedAlpha ();
+				row[x] = original.NewAlpha (lerpAlpha);
 			}
 		} else if (!AlphaOnly && (AlphaBlending && (startAlpha != 255 || endAlpha != 255))) {
 			// If we're doing all color channels, and we're doing alpha blending, and if alpha blending is necessary

--- a/Pinta.Core/Extensions/OtherExtensions.cs
+++ b/Pinta.Core/Extensions/OtherExtensions.cs
@@ -34,12 +34,11 @@ public static class OtherExtensions
 	{
 		Span<byte> colorBytes = stackalloc byte[4];
 		random.NextBytes (colorBytes);
-		uint unsignedInteger = BitConverter.ToUInt32 (colorBytes);
-		ColorBgra baseColor = ColorBgra.FromUInt32 (unsignedInteger);
+		ColorBgra baseColor = ColorBgra.FromBgr (colorBytes[0], colorBytes[1], colorBytes[2]);
 		return
 			includeAlpha
-			? baseColor
-			: baseColor.NewAlpha (255);
+			? baseColor.NewAlpha (colorBytes[3])
+			: baseColor;
 	}
 
 	public static IReadOnlyList<IReadOnlyList<PointI>> CreatePolygonSet (

--- a/Pinta.Effects/Effects/FeatherEffect.cs
+++ b/Pinta.Effects/Effects/FeatherEffect.cs
@@ -157,7 +157,7 @@ public sealed class FeatherEffect : BaseEffect
 					}
 
 					if (lowestAlpha < dst_data[pixel_index].A)
-						dst_data[pixel_index] = src_data[pixel_index].ToStraightAlpha ().NewAlpha (lowestAlpha).ToPremultipliedAlpha ();
+						dst_data[pixel_index] = src_data[pixel_index].NewAlpha (lowestAlpha);
 				}
 			}
 		);

--- a/Pinta.Effects/Effects/OutlineObjectEffect.cs
+++ b/Pinta.Effects/Effects/OutlineObjectEffect.cs
@@ -47,8 +47,8 @@ public sealed class OutlineObjectEffect : BaseEffect
 		int threads = system.RenderThreads;
 		int tolerance = Data.Tolerance;
 
-		ColorBgra primaryColor = palette.PrimaryColor.ToColorBgra ();
-		ColorBgra secondaryColor = palette.SecondaryColor.ToColorBgra ();
+		ColorBgra primaryColor = palette.PrimaryColor.ToColorBgra ().ToPremultipliedAlpha ();
+		ColorBgra secondaryColor = palette.SecondaryColor.ToColorBgra ().ToPremultipliedAlpha ();
 
 		ConcurrentBag<PointI> borderPixels = [];
 
@@ -186,12 +186,12 @@ public sealed class OutlineObjectEffect : BaseEffect
 					ColorBgra color = primaryColor;
 
 					if (Data.ColorGradient)
-						color = ColorBgra.Blend (secondaryColor, primaryColor, highestAlpha);
+						color = ColorBgra.Lerp (secondaryColor, primaryColor, highestAlpha);
 
 					if (!Data.AlphaGradient && highestAlpha != 0)
 						highestAlpha = 255;
 
-					outlineRow[x] = color.NewAlpha (highestAlpha).ToPremultipliedAlpha ();
+					outlineRow[x] = color.NewAlpha (highestAlpha);
 				}
 				// Performs alpha blending
 				new UserBlendOps.NormalBlendOp ().Apply (outlineRow, destRow);

--- a/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/HistogramWidget.cs
@@ -142,7 +142,7 @@ public sealed class HistogramWidget : Gtk.DrawingArea
 		}
 
 		byte intensity = selected[channel] ? (byte) 96 : (byte) 32;
-		ColorBgra pen_color = ColorBgra.Blend (ColorBgra.Black, color, intensity);
+		ColorBgra pen_color = ColorBgra.Lerp (ColorBgra.Black, color, intensity);
 		ColorBgra brush_color = color.NewAlpha (intensity);
 
 		g.LineWidth = 1;

--- a/tests/Pinta.Core.Tests/ColorBgraTests.cs
+++ b/tests/Pinta.Core.Tests/ColorBgraTests.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class ColorBgraTests
+{
+	[TestCaseSource (nameof (new_alpha_cases))]
+	public void NewAlpha (ColorBgra input, int newAlpha, ColorBgra expected)
+	{
+		Assert.That (input.NewAlpha ((byte) newAlpha), Is.EqualTo (expected));
+	}
+
+	static readonly IReadOnlyList<TestCaseData> new_alpha_cases = [
+		new (ColorBgra.FromBgra (255, 0, 128, 255), 128, ColorBgra.FromBgra (128, 0, 64, 128)),
+		new(ColorBgra.Transparent, 255, ColorBgra.Black),
+	];
+}


### PR DESCRIPTION
Also fixed some surrounding code which was not using premultiplied alpha

Bug: #1553