### PR TITLE
Convert premultiplied alpha when converting between ColorBgra and Cairo.Color

### DIFF
--- a/Pinta.Core/Algorithms/Utility.cs
+++ b/Pinta.Core/Algorithms/Utility.cs
@@ -429,10 +429,10 @@ public static class Utility
 	/// <summary>
 	/// Checks if all of the pixels in the row match the specified color.
 	/// </summary>
-	private static bool IsConstantRow (ImageSurface surf, Cairo.Color color, RectangleI rect, int y)
+	private static bool IsConstantRow (ImageSurface surf, ColorBgra color, RectangleI rect, int y)
 	{
 		for (int x = rect.Left; x < rect.Right; ++x)
-			if (!color.Equals (surf.GetColorBgra (new (x, y)).ToCairoColor ()))
+			if (surf.GetColorBgra (new (x, y)) != color)
 				return false;
 
 		return true;
@@ -441,10 +441,10 @@ public static class Utility
 	/// <summary>
 	/// Checks if all of the pixels in the column (within the bounds of the rectangle) match the specified color.
 	/// </summary>
-	private static bool IsConstantColumn (ImageSurface surf, Cairo.Color color, RectangleI rect, int x)
+	private static bool IsConstantColumn (ImageSurface surf, ColorBgra color, RectangleI rect, int x)
 	{
 		for (int y = rect.Top; y < rect.Bottom; ++y)
-			if (!color.Equals (surf.GetColorBgra (new (x, y)).ToCairoColor ()))
+			if (surf.GetColorBgra (new (x, y)) != color)
 				return false;
 
 		return true;
@@ -455,7 +455,7 @@ public static class Utility
 		// Use the entire image bounds by default, or restrict to the provided search area.
 		RectangleI rect = searchArea ?? image.GetBounds ();
 		// Get the background color from the top-left pixel of the rectangle
-		Color borderColor = image.GetColorBgra (new PointI (rect.Left, rect.Top)).ToCairoColor ();
+		ColorBgra borderColor = image.GetColorBgra (new PointI (rect.Left, rect.Top));
 
 		// Top down.
 		for (int y = rect.Top; y < rect.Bottom; ++y) {

--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -268,7 +268,7 @@ public sealed class Document
 
 		foreach (var layer in Layers.GetLayersToPaint ()) {
 
-			Color color = layer.Surface.GetColorBgra (position).ToStraightAlpha ().ToCairoColor ();
+			Color color = layer.Surface.GetColorBgra (position).ToCairoColor ();
 
 			g.SetBlendMode (layer.BlendMode);
 			g.SetSourceColor (color);

--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Color.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Color.cs
@@ -46,19 +46,30 @@ partial class CairoExtensions
 			color.B,
 			color.A);
 
+	/// <summary>
+	/// Convert from Cairo.Color to ColorBgra.
+	/// </summary>
+	/// <remarks>This converts from straight to premultiplied alpha.</remarks>
 	public static ColorBgra ToColorBgra (this Cairo.Color color)
 		=> ColorBgra.FromBgra (
 			b: (byte) (color.B * 255),
 			g: (byte) (color.G * 255),
 			r: (byte) (color.R * 255),
-			a: (byte) (color.A * 255));
+			a: (byte) (color.A * 255)).ToPremultipliedAlpha ();
 
+	/// <summary>
+	/// Convert from ColorBgra to Cairo.Color
+	/// </summary>
+	/// <remarks>This converts from premultiplied to straight alpha.</remarks>
 	public static Cairo.Color ToCairoColor (this ColorBgra color)
-		=> new (
-			R: color.R / 255d,
-			G: color.G / 255d,
-			B: color.B / 255d,
-			A: color.A / 255d);
+	{
+		ColorBgra sc = color.ToStraightAlpha ();
+		return new (
+			R: sc.R / 255d,
+			G: sc.G / 255d,
+			B: sc.B / 255d,
+			A: sc.A / 255d);
+	}
 
 	public static void AddColorStop (
 		this Gradient gradient,

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -282,6 +282,7 @@ public partial class LevelsDialog : Gtk.Dialog
 		UpdateInputHistogram ();
 		Reset ();
 		UpdateLevels ();
+		MaskChanged ();
 
 		Gtk.Box CreateLabelledWidget (Gtk.Widget widget, string label)
 		{
@@ -584,17 +585,12 @@ public partial class LevelsDialog : Gtk.Dialog
 
 	private void MaskChanged ()
 	{
-		uint maxBgra =
-			ColorBgra.Black.BGRA
-			| (mask.R ? (uint) 0xFF0000 : 0)
-			| (mask.G ? (uint) 0xFF00 : 0)
-			| (mask.B ? (uint) 0xFF : 0);
-
-		ColorBgra max = ColorBgra.FromUInt32 (maxBgra);
-
-		Color maxcolor = max.ToCairoColor ();
-		gradient_input.MaxColor = maxcolor;
-		gradient_output.MaxColor = maxcolor;
+		Color maxColor = new (
+			r: mask.R ? 1 : 0,
+			g: mask.G ? 1 : 0,
+			b: mask.B ? 1 : 0);
+		gradient_input.MaxColor = maxColor;
+		gradient_output.MaxColor = maxColor;
 
 		for (int i = 0; i < 3; i++) {
 			histogram_input.SetSelected (i, mask[i]);

--- a/Pinta.Effects/Effects/OutlineObjectEffect.cs
+++ b/Pinta.Effects/Effects/OutlineObjectEffect.cs
@@ -47,8 +47,8 @@ public sealed class OutlineObjectEffect : BaseEffect
 		int threads = system.RenderThreads;
 		int tolerance = Data.Tolerance;
 
-		ColorBgra primaryColor = palette.PrimaryColor.ToColorBgra ().ToPremultipliedAlpha ();
-		ColorBgra secondaryColor = palette.SecondaryColor.ToColorBgra ().ToPremultipliedAlpha ();
+		ColorBgra primaryColor = palette.PrimaryColor.ToColorBgra ();
+		ColorBgra secondaryColor = palette.SecondaryColor.ToColorBgra ();
 
 		ConcurrentBag<PointI> borderPixels = [];
 

--- a/Pinta.Tools/Tools/ColorPickerTool.cs
+++ b/Pinta.Tools/Tools/ColorPickerTool.cs
@@ -145,7 +145,7 @@ public sealed class ColorPickerTool : BaseTool
 	{
 		var pixels = GetPixelsFromPoint (document, point);
 		var color = ColorBgra.Blend (pixels.AsSpan ());
-		return color.ToStraightAlpha ().ToCairoColor ();
+		return color.ToCairoColor ();
 	}
 
 	private ImmutableArray<ColorBgra> GetPixelsFromPoint (Document document, PointI point)

--- a/Pinta.Tools/Tools/GradientTool.cs
+++ b/Pinta.Tools/Tools/GradientTool.cs
@@ -103,11 +103,11 @@ public sealed class GradientTool : BaseTool
 		var gr = CreateGradientRenderer ();
 
 		if (button == MouseButton.Right) {
-			gr.StartColor = palette.SecondaryColor.ToColorBgra ().ToPremultipliedAlpha ();
-			gr.EndColor = palette.PrimaryColor.ToColorBgra ().ToPremultipliedAlpha ();
+			gr.StartColor = palette.SecondaryColor.ToColorBgra ();
+			gr.EndColor = palette.PrimaryColor.ToColorBgra ();
 		} else {
-			gr.StartColor = palette.PrimaryColor.ToColorBgra ().ToPremultipliedAlpha ();
-			gr.EndColor = palette.SecondaryColor.ToColorBgra ().ToPremultipliedAlpha ();
+			gr.StartColor = palette.PrimaryColor.ToColorBgra ();
+			gr.EndColor = palette.SecondaryColor.ToColorBgra ();
 		}
 
 		gr.StartPoint = startpoint;

--- a/Pinta.Tools/Tools/PaintBucketTool.cs
+++ b/Pinta.Tools/Tools/PaintBucketTool.cs
@@ -1,21 +1,21 @@
-// 
+//
 // PaintBucketTool.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -72,7 +72,7 @@ public sealed class PaintBucketTool : FloodTool
 		var hist = new SimpleHistoryItem (Icon, Name);
 		hist.TakeSnapshotOfLayer (document.Layers.CurrentUserLayer);
 
-		var color = fill_color.ToColorBgra ().ToPremultipliedAlpha ();
+		var color = fill_color.ToColorBgra ();
 		var width = surf.Width;
 		surf.Flush ();
 


### PR DESCRIPTION
- Did some initial cleanup to address more complex cases I found
  - Avoid unnecessary ColorBgra -> Cairo.Color conversions when auto-cropping
  - Eliminate conversion in the levels dialog
- Updated the conversion methods to also convert alpha, and removed explicit alpha conversions from the callers. Note there were some callers which were not converting alpha - this was typically either a bug (e.g. converting a palette color to ColorBgra without premultiplying), or was code which only generates opaque colors

Bug: #1553