### PR TITLE
Making floating-point calculations consistent across platforms

### DIFF
--- a/tests/Pinta.Effects.Tests/EffectsTest.cs
+++ b/tests/Pinta.Effects.Tests/EffectsTest.cs
@@ -376,7 +376,6 @@ internal sealed class EffectsTest
 	}
 
 	[Test]
-	[Ignore ("Produces different results on some platforms for unknown reasons")]
 	public void MandelbrotFractal1 ()
 	{
 		MandelbrotFractalEffect effect = new (Utilities.CreateMockServices ());


### PR DESCRIPTION
A Mandelbrot test is annotated with `Ignore` because the generated image is slightly different across platforms "for unknown reasons". Could it just be that "native" floating-point operations give different results depending on the processor architecture, and it could be fixed by making them consistent, even if the calculations are less optimized?

I don't currently have any way to test Pinta locally on an ARM processor, so I will open this pull request and do the following:
- In the first commit, I will remove the `Ignore` attribute. I would expect this build to fail
- Then, in the second commit, I will add a configuration file for the runtime, turning off certain optimizations, and see how the build goes
- If the build for the second commit fails, I will update the tests and try again. After this, I would expect the tests to succeed, because the output would have changed, but it would be consistent across platforms?