### PR TITLE
Allow deletion of whole words with CTRL+BACKSPACE

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -710,7 +710,7 @@ public sealed class TextTool : BaseTool
 
 				switch (e.Key.Value) {
 					case Gdk.Constants.KEY_BackSpace:
-						CurrentTextEngine.PerformBackspace ();
+						CurrentTextEngine.PerformBackspace (e.IsControlPressed);
 						break;
 
 					case Gdk.Constants.KEY_Delete:
@@ -862,7 +862,7 @@ public sealed class TextTool : BaseTool
 	{
 		// Remove the previous preedit string.
 		for (int i = 0; i < preedit_string?.Length; ++i)
-			CurrentTextEngine.PerformBackspace ();
+			CurrentTextEngine.PerformBackspace (false);
 
 		// Insert the new string.
 		preedit_string = updated;

--- a/tests/Pinta.Core.Tests/ColorBgraTests.cs
+++ b/tests/Pinta.Core.Tests/ColorBgraTests.cs
@@ -15,6 +15,6 @@ internal sealed class ColorBgraTests
 
 	static readonly IReadOnlyList<TestCaseData> new_alpha_cases = [
 		new (ColorBgra.FromBgra (255, 0, 128, 255), 128, ColorBgra.FromBgra (128, 0, 64, 128)),
-		new(ColorBgra.Transparent, 255, ColorBgra.Black),
+		new (ColorBgra.Transparent, 255, ColorBgra.Black),
 	];
 }

--- a/tests/Pinta.Core.Tests/TextEngineTest.cs
+++ b/tests/Pinta.Core.Tests/TextEngineTest.cs
@@ -66,7 +66,7 @@ internal sealed class TextEngineTest
 	{
 		TextEngine engine = new (["foo", "bar"]);
 		engine.SetCursorPosition (new TextPosition (1, 0), true);
-		engine.PerformBackspace ();
+		engine.PerformBackspace (false);
 
 		Assert.That (engine.LineCount, Is.EqualTo (1));
 		Assert.That (engine.ToString (), Is.EqualTo ("foobar"));
@@ -80,24 +80,51 @@ internal sealed class TextEngineTest
 
 		// End of a line.
 		engine.SetCursorPosition (new TextPosition (0, 6), true);
-		engine.PerformBackspace ();
+		engine.PerformBackspace (false);
 
 		Assert.That (engine.Lines[0], Is.EqualTo ("a\u0304\u0308b"));
 		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 4)));
 
 		// First character of a line.
 		engine.SetCursorPosition (new TextPosition (1, 2), true);
-		engine.PerformBackspace ();
+		engine.PerformBackspace (false);
 
 		Assert.That (engine.Lines[1], Is.EqualTo ("ba\u0304\u0308"));
 		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (1, 0)));
 
 		// Middle of a line.
 		engine.SetCursorPosition (new TextPosition (2, 3), true);
-		engine.PerformBackspace ();
+		engine.PerformBackspace (false);
 
 		Assert.That (engine.Lines[2], Is.EqualTo ("ba\u0304\u0308"));
 		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (2, 1)));
+	}
+
+	[Test]
+	public void ControlBackspace ()
+	{
+		TextEngine engine = new ([string.Join ("  ", test_snippet)]);
+
+		engine.SetCursorPosition (new TextPosition (0, 19), true);
+		engine.PerformBackspace (true);
+
+		Assert.That (engine.Lines[0], Is.EqualTo ("a\u0304\u0308bc\u0327  c\u0327ba\u0304\u0308  a\u0304\u0308"));
+		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 16)));
+
+		engine.PerformBackspace (true);
+
+		Assert.That (engine.Lines[0], Is.EqualTo ("a\u0304\u0308bc\u0327  a\u0304\u0308"));
+		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 8)));
+
+		engine.PerformBackspace (true);
+
+		Assert.That (engine.Lines[0], Is.EqualTo ("a\u0304\u0308"));
+		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 0)));
+
+		engine.PerformBackspace (true);
+
+		Assert.That (engine.Lines[0], Is.EqualTo ("a\u0304\u0308"));
+		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 0)));
 	}
 
 	[Test]


### PR DESCRIPTION
I like to use Pinta as a digital white board for brain storming. However, it always annoys me that I can't delete text with CTRL+BACKSPACE like I can do in (almost) every other text editor. That's why I added it.