### PR TITLE
Fix select-all-text (CTRL+A)

### DIFF
--- a/Pinta.Tools/Tools/TextTool.cs
+++ b/Pinta.Tools/Tools/TextTool.cs
@@ -781,7 +781,7 @@ public sealed class TextTool : BaseTool
 								UpdateFont ();
 							} else if (e.Key.Value == Gdk.Constants.KEY_a) {
 								// Select all of the text.
-								CurrentTextEngine.PerformHome (false, false);
+								CurrentTextEngine.PerformHome (true, false);
 								CurrentTextEngine.PerformEnd (true, true);
 							} else {
 								//Ignore command shortcut.


### PR DESCRIPTION
Currently, CTRL+A selects text from the beginning of the current line until the end. Now the complete text gets selected.