### PR TITLE
Add ARM64 installer for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
     # Build for both x64 and arm64
     strategy:
       matrix:
-        build: [ { dotnet_rid: win-x64, mingw_folder: "${MINGW_PREFIX}/../clang64", mingw_system: clang64, mingw_repo: clang-x86_64, runner: windows-2025 }, { dotnet_rid: win-arm64, mingw_folder: "${MINGW_PREFIX}/../clangarm64", mingw_system: clangarm64, mingw_repo: clang-aarch64, runner: windows-11-arm }]
+        build: [ { dotnet_rid: win-x64, mingw_folder: "${MINGW_PREFIX}/../clang64", mingw_system: clang64, mingw_repo: clang-x86_64, setup_arch: x64os, runner: windows-2025 }, { dotnet_rid: win-arm64, mingw_folder: "${MINGW_PREFIX}/../clangarm64", mingw_system: clangarm64, mingw_repo: clang-aarch64, setup_arch: arm64, runner: windows-11-arm }]
 
     name: build-windows (${{matrix.build.dotnet_rid}})
 
@@ -202,7 +202,7 @@ jobs:
         cp -r release/bin/icons release/bin/locale release/share/
         rm -rf release/bin/icons release/bin/locale
         cp installer/macos/hicolor.index.theme release/share/icons/hicolor/index.theme
-        iscc installer/windows/installer.iss
+        iscc -DProductArch="${{matrix.build.setup_arch}}" installer/windows/installer.iss
 
     - name: Upload Installer
       id: upload-unsigned-installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,14 @@ jobs:
         if-no-files-found: error
 
   build-windows:
-    runs-on: windows-2022
+    # Build for both x64 and arm64
+    strategy:
+      matrix:
+        build: [ { dotnet_rid: win-x64, mingw_folder: "${MINGW_PREFIX}/../clang64", mingw_system: clang64, mingw_repo: clang-x86_64, runner: windows-2025 }, { dotnet_rid: win-arm64, mingw_folder: "${MINGW_PREFIX}/../clangarm64", mingw_system: clangarm64, mingw_repo: clang-aarch64, runner: windows-11-arm }]
+
+    name: build-windows (${{matrix.build.dotnet_rid}})
+
+    runs-on: ${{matrix.build.runner}}
     defaults:
       run:
         shell: msys2 {0}
@@ -180,17 +187,18 @@ jobs:
       with:
         path-type: inherit # Inherit the path so that dotnet can be found
         update: true
-        install: mingw-w64-x86_64-libadwaita mingw-w64-x86_64-webp-pixbuf-loader
+        msystem: ${{matrix.build.mingw_system}}
+        install: mingw-w64-${{matrix.build.mingw_repo}}-libadwaita mingw-w64-${{matrix.build.mingw_repo}}-webp-pixbuf-loader
     - name: Build
-      run: dotnet build Pinta.sln -c Release -p:MinGWFolder=${MINGW_PREFIX}
+      run: dotnet build Pinta.sln -c Release -p:MinGWFolder=${{matrix.build.mingw_folder}}
     - name: Test
-      run: dotnet test Pinta.sln -c Release -p:MinGWFolder=${MINGW_PREFIX}
+      run: dotnet test Pinta.sln -c Release -p:MinGWFolder=${{matrix.build.mingw_folder}}
 
     # Note that msgfmt is already available from the Git for Windows installation!
     - name: Build Installer
       run: |
         choco install innosetup -y -v
-        dotnet publish Pinta/Pinta.csproj -p:BuildTranslations=true -p:MinGWFolder=${MINGW_PREFIX} -c Release -r win-x64 --self-contained true -p:PublishDir=../release/bin
+        dotnet publish Pinta/Pinta.csproj -p:BuildTranslations=true -p:MinGWFolder=${{matrix.build.mingw_folder}} -c Release -r ${{matrix.build.dotnet_rid}} --self-contained true -p:PublishDir=../release/bin
         cp -r release/bin/icons release/bin/locale release/share/
         rm -rf release/bin/icons release/bin/locale
         cp installer/macos/hicolor.index.theme release/share/icons/hicolor/index.theme
@@ -200,7 +208,7 @@ jobs:
       id: upload-unsigned-installer
       uses: actions/upload-artifact@v4
       with:
-        name: "Pinta.exe"
+        name: "Pinta-${{matrix.build.dotnet_rid}}.exe"
         path: installer/windows/Pinta.exe
         if-no-files-found: error
 
@@ -223,7 +231,7 @@ jobs:
       id: upload-signed-installer
       uses: actions/upload-artifact@v4
       with:
-        name: "Pinta-signed.exe"
-        path: ./signed-artifacts/Pinta.exe
+        name: "Pinta-signed-${{matrix.build.dotnet_rid}}.exe"
+        path: ./signed-artifacts/Pinta-${{matrix.build.dotnet_rid}}.exe
         if-no-files-found: error
 

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -100,7 +100,8 @@ public sealed class SystemManager : ISystemService
 		// On Windows, the installed executable is under Pinta/bin and data is under Pinta/share.
 		if (GetOperatingSystem () == OS.Windows) {
 			string parentDir = Path.Combine (app_dir, "..");
-			bool develMode = Path.Exists (Path.Combine (parentDir, "Pinta.sln"));
+			// For development builds, we have a path like Pinta/build/bin
+			bool develMode = Path.Exists (Path.Combine (parentDir, "..", "Pinta.sln"));
 			if (!develMode)
 				return Path.Combine (parentDir, "share");
 		}

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -2,7 +2,7 @@
   <!-- Install GTK library dependencies on Windows, from the MSYS installation. -->
   <PropertyGroup>
     <!-- Note this can be overridden by an environment variable with the same name. -->
-    <MinGWFolder>C:\msys64\mingw64</MinGWFolder>
+    <MinGWFolder>C:\msys64\clang64</MinGWFolder>
     <MinGWBinFolder>$(MinGWFolder)\bin</MinGWBinFolder>
   </PropertyGroup>
 
@@ -17,8 +17,10 @@
     <GtkFile Include="$(MinGWBinFolder)\libcairo-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcairo-gobject-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcairo-script-interpreter-2.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libcrypto-3-x64.dll" />
+    <!-- Match against the arch-specific suffix, e.g. libcrypto-3-x64.dll -->
+    <GtkFile Include="$(MinGWBinFolder)\libcrypto-3-*.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcurl-4.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libc++.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libdatrie-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libdeflate.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libepoxy-0.dll" />
@@ -27,7 +29,6 @@
     <GtkFile Include="$(MinGWBinFolder)\libfontconfig-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libfreetype-6.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libfribidi-0.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libgcc_s_seh-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libgdk_pixbuf-2.0-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libgio-2.0-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libglib-2.0-0.dll" />
@@ -49,7 +50,7 @@
     <GtkFile Include="$(MinGWBinFolder)\libnghttp2-14.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libnghttp3-9.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libngtcp2-16.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libngtcp2_crypto_ossl.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libngtcp2_crypto_ossl-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpango-1.0-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpangocairo-1.0-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libpangoft2-1.0-0.dll" />
@@ -60,13 +61,14 @@
     <GtkFile Include="$(MinGWBinFolder)\libpsl-5.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libsharpyuv-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libssh2-1.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libssl-3-x64.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libstdc++-6.dll" />
+    <!-- Match against the arch-specific suffix, e.g. libssl-3-x64.dll -->
+    <GtkFile Include="$(MinGWBinFolder)\libssl-3-*.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libthai-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libtiff-6.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libunistring-5.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libunwind.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libwebp-7.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libwinpthread-1.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libxml2-16.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libxmlb-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libyaml-0-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libzstd.dll" />
@@ -75,7 +77,6 @@
     <!-- Additional dependencies for the SVG pixbuf loader. -->
     <GtkFile Include="$(MinGWBinFolder)\libcharset-1.dll" />
     <GtkFile Include="$(MinGWBinFolder)\librsvg-2-2.dll" />
-    <GtkFile Include="$(MinGWBinFolder)\libxml2-2.dll" />
 
     <!-- Additional dependencies for the webp pixbuf loader. -->
     <GtkFile Include="$(MinGWBinFolder)\libwebp-7.dll" />

--- a/installer/windows/bundle_gtk.targets
+++ b/installer/windows/bundle_gtk.targets
@@ -18,7 +18,7 @@
     <GtkFile Include="$(MinGWBinFolder)\libcairo-gobject-2.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcairo-script-interpreter-2.dll" />
     <!-- Match against the arch-specific suffix, e.g. libcrypto-3-x64.dll -->
-    <GtkFile Include="$(MinGWBinFolder)\libcrypto-3-*.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libcrypto-3*.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libcurl-4.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libc++.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libdatrie-1.dll" />
@@ -62,7 +62,7 @@
     <GtkFile Include="$(MinGWBinFolder)\libsharpyuv-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libssh2-1.dll" />
     <!-- Match against the arch-specific suffix, e.g. libssl-3-x64.dll -->
-    <GtkFile Include="$(MinGWBinFolder)\libssl-3-*.dll" />
+    <GtkFile Include="$(MinGWBinFolder)\libssl-3*.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libthai-0.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libtiff-6.dll" />
     <GtkFile Include="$(MinGWBinFolder)\libunistring-5.dll" />

--- a/installer/windows/installer.iss
+++ b/installer/windows/installer.iss
@@ -1,6 +1,11 @@
 #define ProductName "Pinta"
 #define ProductVersion "3.1"
 
+; The architecture can be configured on the command line to build the arm64 or x64 installer
+#ifndef ProductArch
+  #define ProductArch "x64os"
+#endif
+
 [Setup]
 ; Adds option to skip creating start menu entries
 AllowNoIcons=yes
@@ -10,8 +15,8 @@ AppPublisher=Pinta Community
 AppPublisherURL=https://www.pinta-project.com/
 AppVerName={#ProductName} {#ProductVersion}
 AppVersion={#ProductVersion}
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed={#ProductArch}
+ArchitecturesInstallIn64BitMode={#ProductArch}
 Compression=lzma2
 DefaultDirName={autopf}\{#ProductName}
 DefaultGroupName={#ProductName}

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,9 @@ Used under [Creative Commons Attribution 3.0 License](http://creativecommons.org
 ## Building on Windows
 
 First, install the required GTK-related dependencies:
-- Install MinGW64 via [MSYS2](https://www.msys2.org)
-- From the MinGW64 terminal, run `pacman -S mingw-w64-x86_64-libadwaita mingw-w64-x86_64-webp-pixbuf-loader`.
+- Install [MSYS2](https://www.msys2.org)
+- From the CLANG64 terminal, run `pacman -S mingw-w64-clang-x86_64-libadwaita mingw-w64-clang-x86_64-webp-pixbuf-loader`.
+  - For ARM64 Windows, use the `CLANGARM64` terminal and replace `clang-x86_64` with `clang-aarch64`.
 
 Pinta can then be built by opening `Pinta.sln` in [Visual Studio](https://visualstudio.microsoft.com/).
 Ensure that .NET 8 is installed via the Visual Studio installer.


### PR DESCRIPTION
- Switch to using the `clang64` environment for x86_64 systems (previously we used the `mingw64` environment). For ARM we need to use the `clangarm64` environment, so this makes it easier to maintain the packaging scripts for both systems since the C++ runtime dlls, etc are consistent
- Fix errors with loading icons in local development builds on Windows, noticed while testing this out
 
Fixes: #1378