### PR TITLE
Refactor how the DocumentSelection bounds are tracked

### DIFF
--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Geometry.cs
@@ -293,14 +293,14 @@ partial class CairoExtensions
 		return result;
 	}
 
-	public static void TransformPoint (
+	public static PointD TransformPoint (
 		this Matrix m,
-		ref PointD p)
+		in PointD p)
 	{
 		double newX = p.X;
 		double newY = p.Y;
 		m.TransformPoint (ref newX, ref newY);
-		p = new PointD (newX, newY);
+		return new (newX, newY);
 	}
 
 	private static void GetRectangle (this Region region, int i, out CairoRectangleInt rect)

--- a/Pinta.Tools/Tools/SelectTool.cs
+++ b/Pinta.Tools/Tools/SelectTool.cs
@@ -121,8 +121,7 @@ public abstract class SelectTool : BaseTool
 
 			SelectionModeHandler.PerformSelectionMode (document, combine_mode, document.Selection.SelectionPolygons);
 
-			document.Selection.Origin = handle.Rectangle.Location ();
-			document.Selection.End = handle.Rectangle.EndLocation ();
+			document.Selection.HandleBounds = handle.Rectangle;
 			document.Workspace.Invalidate (last_dirty.Union (dirty));
 			last_dirty = dirty;
 
@@ -228,7 +227,7 @@ public abstract class SelectTool : BaseTool
 	private void LoadFromDocument (Document document)
 	{
 		DocumentSelection selection = document.Selection;
-		handle.Rectangle = RectangleD.FromPoints (selection.Origin, selection.End);
+		handle.Rectangle = selection.HandleBounds;
 		ShowHandles (document.Selection.Visible && tools.CurrentTool == this);
 	}
 }


### PR DESCRIPTION
- Store a rectangle rather than separate origin / end points. This is simpler, and for PR #1515 this will likely be extended further to also store an orientation

- Clarify that the bounds are only used for interactive manipulation by tools, and might not reflect the selection's entire bounds when e.g. using intersection modes

- Adjust the `TransformPoint()` signature to be easier to use