### PR TITLE
Improved implementation of `GetHashCode` in several classes

### DIFF
--- a/Pinta.Core/Classes/BitMask.cs
+++ b/Pinta.Core/Classes/BitMask.cs
@@ -262,5 +262,19 @@ public sealed class BitMask
 	}
 
 	public override int GetHashCode ()
-		=> Width.GetHashCode () ^ Height.GetHashCode ();
+	{
+		HashCode hash = new ();
+
+		hash.Add (Width);
+		hash.Add (Height);
+
+		if (array.Length > 0) {
+			int[] ints = new int[(array.Length + 31) / 32];
+			array.CopyTo (ints, 0);
+			for (int i = 0; i < ints.Length; i++)
+				hash.Add (ints[i]);
+		}
+
+		return hash.ToHashCode ();
+	}
 }

--- a/Pinta.Core/Classes/Fraction.cs
+++ b/Pinta.Core/Classes/Fraction.cs
@@ -51,7 +51,7 @@ public readonly struct Fraction<TInt> where TInt : IBinaryInteger<TInt>
 	}
 
 	public override int GetHashCode ()
-		=> Numerator.GetHashCode () ^ Denominator.GetHashCode ();
+		=> HashCode.Combine (Numerator, Denominator);
 }
 
 public static class FractionExtensions

--- a/Pinta.Core/Classes/HsvColor.cs
+++ b/Pinta.Core/Classes/HsvColor.cs
@@ -49,12 +49,12 @@ public readonly struct HsvColor : IColor<HsvColor>
 	public static HsvColor FromColor (Color c) => c.ToHsv ();
 	public Color ToColor (double alpha = 1) => Color.FromHsv (this, alpha);
 	public static HsvColor FromBgra (ColorBgra c) => c.ToCairoColor ().ToHsv ();
-	public ColorBgra ToBgra () => this.ToColor ().ToColorBgra ();
+	public ColorBgra ToBgra () => ToColor ().ToColorBgra ();
 
 
 	public override readonly string ToString ()
 		=> $"({Hue:F2}, {Sat:F2}, {Val:F2})";
 
 	public override int GetHashCode ()
-		=> ((int) Hue + ((int) Sat << 8) + ((int) Val << 16)).GetHashCode ();
+		=> HashCode.Combine (Hue, Sat, Val);
 }

--- a/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextPosition.cs
@@ -11,15 +11,10 @@ using System;
 
 namespace Pinta.Core;
 
-public readonly struct TextPosition : IComparable<TextPosition>
+public readonly struct TextPosition (int line, int offset) : IComparable<TextPosition>
 {
-	public int Line { get; }
-	public int Offset { get; }
-	public TextPosition (int line, int offset)
-	{
-		Line = line;
-		Offset = offset;
-	}
+	public int Line { get; } = line;
+	public int Offset { get; } = offset;
 
 	public TextPosition WithLine (int line)
 		=> new (line, Offset);
@@ -31,7 +26,7 @@ public readonly struct TextPosition : IComparable<TextPosition>
 		=> obj is TextPosition position && this == position;
 
 	public override readonly int GetHashCode ()
-		=> new { Line, Offset }.GetHashCode ();
+		=> HashCode.Combine (Line, Offset);
 
 	public override readonly string ToString ()
 		=> $"({Line}, {Offset})";

--- a/Pinta.Core/Classes/Scanline.cs
+++ b/Pinta.Core/Classes/Scanline.cs
@@ -14,6 +14,7 @@ public readonly struct Scanline
 	public int X { get; }
 	public int Y { get; }
 	public int Length { get; }
+
 	public Scanline (int x, int y, int length)
 	{
 		ArgumentOutOfRangeException.ThrowIfNegative (length);
@@ -22,7 +23,8 @@ public readonly struct Scanline
 		Length = length;
 	}
 
-	public override readonly int GetHashCode () { unchecked { return Length.GetHashCode () + X.GetHashCode () + Y.GetHashCode (); } }
+	public override readonly int GetHashCode ()
+		=> HashCode.Combine (X, Y, Length);
 
 	public override readonly bool Equals (object? obj)
 		=> obj is Scanline rhs && X == rhs.X && Y == rhs.Y && Length == rhs.Length;


### PR DESCRIPTION
With the `HashCode` utility we don't have to roll our own `GetHashCode` implementations if they are just a combination of their properties