### PR TITLE
Fixed bug in point picker for `PointI`

### DIFF
--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -483,7 +483,7 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 		PointPickerWidget widget = new (
 			workspace,
 			initialPoint,
-			adjustToWidgetSize: initialPoint == default
+			adjustToWidgetSize: initialPoint == default // If point is (0,0) assume it's first run
 		) { Label = caption };
 
 		widget.PointPicked += (_, _) => SetAndNotify (

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -480,7 +480,11 @@ public sealed class SimpleEffectDialog : Gtk.Dialog
 			? p
 			: default;
 
-		PointPickerWidget widget = new (workspace, initialPoint) { Label = caption };
+		PointPickerWidget widget = new (
+			workspace,
+			initialPoint,
+			adjustToWidgetSize: initialPoint == default
+		) { Label = caption };
 
 		widget.PointPicked += (_, _) => SetAndNotify (
 			settings.reflector,

--- a/Pinta.Gui.Widgets/Widgets/PointPickerWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/PointPickerWidget.cs
@@ -46,7 +46,7 @@ public sealed class PointPickerWidget : Gtk.Box
 
 	bool active = true;
 
-	public PointPickerWidget (IWorkspaceService workspace, PointI initialPoint)
+	public PointPickerWidget (IWorkspaceService workspace, PointI initialPoint, bool adjustToWidgetSize = true)
 	{
 		// --- Build
 
@@ -62,7 +62,10 @@ public sealed class PointPickerWidget : Gtk.Box
 			orientation: Gtk.Orientation.Vertical,
 			spacing: SPACING);
 
-		adjusted_initial_point = AdjustToWidgetSize (imageSize, initialPoint);
+		adjusted_initial_point =
+			adjustToWidgetSize
+			? AdjustToWidgetSize (imageSize, initialPoint)
+			: initialPoint;
 
 		// --- Section label + line
 


### PR DESCRIPTION
To see the bug:
- Start Pinta
- Run the vignette effect. The point picker will have the coordinates of the center of the canvas
- Without changing anything, close the dialog
- Run the vignette effect again. The point picker will be at the bottom-right corner
With this change, the point will be where the user left it before closing it, with the only exception being (0, 0)

This new behavior is saner, but it could be inconsistent with the behavior of the offset picker, which always starts at the center when one opens the dialog (you can see it with, say, the zoom blur effect). I would like to make their behavior consistent, but I would leave that for a future pull request.