### PR TITLE
Checkerboard background for clear visualization of palette colors with transparency

### DIFF
--- a/Pinta.Core/Managers/PaletteManager.cs
+++ b/Pinta.Core/Managers/PaletteManager.cs
@@ -37,10 +37,12 @@ public interface IPaletteService
 	Color PrimaryColor { get; set; }
 	Color SecondaryColor { get; set; }
 	Palette CurrentPalette { get; }
+	int MaxRecentlyUsedColor { get; }
 	ReadOnlyCollection<Color> RecentlyUsedColors { get; }
 	void SetColor (bool setPrimary, Color color, bool addToRecent = true);
-	public event EventHandler? PrimaryColorChanged;
-	public event EventHandler? SecondaryColorChanged;
+	event EventHandler? PrimaryColorChanged;
+	event EventHandler? SecondaryColorChanged;
+	event EventHandler? RecentColorsChanged;
 }
 
 public sealed class PaletteManager : IPaletteService
@@ -69,10 +71,10 @@ public sealed class PaletteManager : IPaletteService
 
 	public Palette CurrentPalette { get; }
 
-	private readonly SettingsManager settings;
+	private readonly ISettingsService settings;
 	private readonly PaletteFormatManager palette_formats;
 	public PaletteManager (
-		SettingsManager settings,
+		ISettingsService settings,
 		PaletteFormatManager paletteFormats)
 	{
 		List<Color> recentlyUsed = new (MAX_RECENT_COLORS);

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -67,7 +67,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 
 	// hex + sliders
 	private readonly Gtk.Entry hex_entry;
-	private readonly PaletteManager palette;
+	private readonly IPaletteService palette;
 	private int slider_width = DEFAULT_SLIDER_WIDTH;
 	private readonly Gtk.Box sliders_box;
 	private readonly ColorPickerSlider hue_slider;
@@ -189,7 +189,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 	/// <param name="windowTitle">Title of the dialog.</param>
 	internal ColorPickerDialog (
 		Gtk.Window? parentWindow,
-		PaletteManager palette,
+		IPaletteService palette,
 		ColorPick adjustable,
 		bool primarySelected, // TODO: Get rid of this
 		bool livePalette,

--- a/Pinta.Gui.Widgets/Widgets/PaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/PaletteWidget.cs
@@ -10,7 +10,7 @@ internal static class PaletteWidget
 	internal const int PALETTE_MARGIN = 10;
 
 	public static int GetSwatchAtLocation (
-		PaletteManager palette,
+		IPaletteService palette,
 		PointD point,
 		RectangleD palette_bounds,
 		bool recentColorPalette = false)
@@ -29,7 +29,7 @@ internal static class PaletteWidget
 	}
 
 	public static RectangleD GetSwatchBounds (
-		PaletteManager palette,
+		IPaletteService palette,
 		int index,
 		RectangleD palette_bounds,
 		bool recentColorPalette = false)

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -28,6 +28,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Adw;
 using Cairo;
 using Pinta.Core;
 
@@ -201,18 +202,28 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 			CairoExtensions.CreateTransparentBackgroundPattern (TILE_SIZE);
 
 		for (int i = 0; i < recent.Count; i++) {
+
 			RectangleD swatchBounds = PaletteWidget.GetSwatchBounds (palette, i, recent_palette_rect, true);
-			g.FillRectangle (swatchBounds, checkeredPattern);
-			g.FillRectangle (swatchBounds, recent.ElementAt (i));
+			Color recentColor = recent.ElementAt (i);
+
+			if (recentColor.A < 1) // Only draw checkered pattern if there is transparency
+				g.FillRectangle (swatchBounds, checkeredPattern);
+
+			g.FillRectangle (swatchBounds, recentColor);
 		}
 
 		// Draw color swatches
 		var currentPalette = palette.CurrentPalette;
 
 		for (int i = 0; i < currentPalette.Colors.Count; i++) {
+
 			RectangleD swatchBounds = PaletteWidget.GetSwatchBounds (palette, i, palette_rect);
-			g.FillRectangle (swatchBounds, checkeredPattern);
-			g.FillRectangle (swatchBounds, currentPalette.Colors[i]);
+			Color paletteColor = currentPalette.Colors[i];
+
+			if (paletteColor.A < 1) // Only draw checkered pattern if there is transparency
+				g.FillRectangle (swatchBounds, checkeredPattern);
+
+			g.FillRectangle (swatchBounds, paletteColor);
 		}
 
 		g.Dispose ();

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -42,15 +42,13 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 	private readonly RectangleD swap_rect = new (27, 2, 15, 15);
 	private readonly RectangleD reset_rect = new (2, 27, 15, 15);
 
-	private readonly ChromeManager chrome;
-	private readonly PaletteManager palette;
+	private readonly IChromeService chrome;
+	private readonly IPaletteService palette;
 
 	private RectangleD palette_rect;
 	private RectangleD recent_palette_rect;
 
-	public StatusBarColorPaletteWidget (
-		ChromeManager chrome,
-		PaletteManager palette)
+	public StatusBarColorPaletteWidget (IChromeService chrome, IPaletteService palette)
 	{
 		this.chrome = chrome;
 		this.palette = palette;

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -175,12 +175,24 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 	private void Draw (Context g)
 	{
+		const int TILE_SIZE = 16;
+		using Pattern checkeredPattern =
+			CairoExtensions.CreateTransparentBackgroundPattern (TILE_SIZE);
+
 		// Draw Secondary color swatch
+
+		if (palette.SecondaryColor.A < 1)
+			g.FillRectangle (secondary_rect, checkeredPattern);
+
 		g.FillRectangle (secondary_rect, palette.SecondaryColor);
 		g.DrawRectangle (new RectangleD (secondary_rect.X + 1, secondary_rect.Y + 1, secondary_rect.Width - 2, secondary_rect.Height - 2), new Color (1, 1, 1), 1);
 		g.DrawRectangle (secondary_rect, new Color (0, 0, 0), 1);
 
 		// Draw Primary color swatch
+
+		if (palette.PrimaryColor.A < 1)
+			g.FillRectangle (primary_rect, checkeredPattern);
+
 		g.FillRectangle (primary_rect, palette.PrimaryColor);
 		g.DrawRectangle (new RectangleD (primary_rect.X + 1, primary_rect.Y + 1, primary_rect.Width - 2, primary_rect.Height - 2), new Color (1, 1, 1), 1);
 		g.DrawRectangle (primary_rect, new Color (0, 0, 0), 1);
@@ -196,10 +208,6 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 		// Draw recently used color swatches
 		var recent = palette.RecentlyUsedColors;
-
-		const int TILE_SIZE = 16;
-		using Pattern checkeredPattern =
-			CairoExtensions.CreateTransparentBackgroundPattern (TILE_SIZE);
 
 		for (int i = 0; i < recent.Count; i++) {
 

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -196,14 +196,24 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		// Draw recently used color swatches
 		var recent = palette.RecentlyUsedColors;
 
-		for (int i = 0; i < recent.Count; i++)
-			g.FillRectangle (PaletteWidget.GetSwatchBounds (palette, i, recent_palette_rect, true), recent.ElementAt (i));
+		const int TILE_SIZE = 16;
+		using Pattern checkeredPattern =
+			CairoExtensions.CreateTransparentBackgroundPattern (TILE_SIZE);
+
+		for (int i = 0; i < recent.Count; i++) {
+			RectangleD swatchBounds = PaletteWidget.GetSwatchBounds (palette, i, recent_palette_rect, true);
+			g.FillRectangle (swatchBounds, checkeredPattern);
+			g.FillRectangle (swatchBounds, recent.ElementAt (i));
+		}
 
 		// Draw color swatches
 		var currentPalette = palette.CurrentPalette;
 
-		for (int i = 0; i < currentPalette.Colors.Count; i++)
-			g.FillRectangle (PaletteWidget.GetSwatchBounds (palette, i, palette_rect), currentPalette.Colors[i]);
+		for (int i = 0; i < currentPalette.Colors.Count; i++) {
+			RectangleD swatchBounds = PaletteWidget.GetSwatchBounds (palette, i, palette_rect);
+			g.FillRectangle (swatchBounds, checkeredPattern);
+			g.FillRectangle (swatchBounds, currentPalette.Colors[i]);
+		}
 
 		g.Dispose ();
 	}

--- a/tests/Pinta.Effects.Tests/Mocks/MockPalette.cs
+++ b/tests/Pinta.Effects.Tests/Mocks/MockPalette.cs
@@ -7,8 +7,8 @@ namespace Pinta.Effects.Tests;
 
 internal sealed class MockPalette : IPaletteService
 {
-	public Color PrimaryColor { get; set; } = new (0, 0, 0); // Black
-	public Color SecondaryColor { get; set; } = new (1, 1, 1); // White
+	public Color PrimaryColor { get; set; } = Color.Black;
+	public Color SecondaryColor { get; set; } = Color.White;
 
 	public Palette CurrentPalette
 		=> throw new NotImplementedException ();

--- a/tests/Pinta.Effects.Tests/Mocks/MockPalette.cs
+++ b/tests/Pinta.Effects.Tests/Mocks/MockPalette.cs
@@ -13,13 +13,17 @@ internal sealed class MockPalette : IPaletteService
 	public Palette CurrentPalette
 		=> throw new NotImplementedException ();
 
+	public int MaxRecentlyUsedColor
+		=> throw new NotImplementedException ();
+
 	public ReadOnlyCollection<Color> RecentlyUsedColors
 		=> throw new NotImplementedException ();
 
-#pragma warning disable CS0067 // The event 'MockPalette.PrimaryColorChanged' is never used
+#pragma warning disable CS0067 // The event 'X' is never used
 	public event EventHandler? PrimaryColorChanged;
 	public event EventHandler? SecondaryColorChanged;
-#pragma warning restore CS0067 // The event 'MockPalette.PrimaryColorChanged' is never used
+	public event EventHandler? RecentColorsChanged;
+#pragma warning restore CS0067 // The event 'x' is never used
 
 	public void SetColor (bool setPrimary, Color color, bool addToRecent = true)
 	{

--- a/tests/PintaBenchmarks/Mocks/MockPalette.cs
+++ b/tests/PintaBenchmarks/Mocks/MockPalette.cs
@@ -12,13 +12,17 @@ internal sealed class MockPalette : IPaletteService
 	public Palette CurrentPalette
 		=> throw new NotImplementedException ();
 
+	public int MaxRecentlyUsedColor
+		=> throw new NotImplementedException ();
+
 	public ReadOnlyCollection<Color> RecentlyUsedColors
 		=> throw new NotImplementedException ();
 
-#pragma warning disable CS0067 // The event 'MockPalette.PrimaryColorChanged' is never used
+#pragma warning disable CS0067 // The event 'X' is never used
 	public event EventHandler? PrimaryColorChanged;
 	public event EventHandler? SecondaryColorChanged;
-#pragma warning restore CS0067 // The event 'MockPalette.PrimaryColorChanged' is never used
+	public event EventHandler? RecentColorsChanged;
+#pragma warning restore CS0067 // The event 'X' is never used
 
 	public void SetColor (bool setPrimary, Color color, bool addToRecent = true)
 	{

--- a/tests/PintaBenchmarks/Mocks/MockPalette.cs
+++ b/tests/PintaBenchmarks/Mocks/MockPalette.cs
@@ -6,8 +6,8 @@ namespace PintaBenchmarks;
 
 internal sealed class MockPalette : IPaletteService
 {
-	public Color PrimaryColor { get; set; } = new (0, 0, 0); // Black
-	public Color SecondaryColor { get; set; } = new (1, 1, 1); // White
+	public Color PrimaryColor { get; set; } = Color.Black;
+	public Color SecondaryColor { get; set; } = Color.White;
 
 	public Palette CurrentPalette
 		=> throw new NotImplementedException ();


### PR DESCRIPTION
The code corresponding to the feature can be examined in 4367073a92cc4e268bc66294538701096160c8af.

On the way I also changed `StatusBarColorPaletteWidget` (and related classes) to receive `IPaletteService` instead of `PaletteManager`.

I am selecting blue with an alpha of 128, and transparent. You can see the result by looking at the checkered spots:

<img width="225" height="53" alt="grafik" src="https://github.com/user-attachments/assets/9555154a-0225-44ea-a8d2-653acf361635" />

Before this change these spots would have looked (in the case of dark mode) dark blue and very dark gray, like the background.

Note: ~You will notice that I'm not showing a screenshot of the old behavior. I simply can't start Pinta anymore.~ If I try to run `dotnet run --project Pinta` the command returns with no output. I had to use the cloud build in order to run my changes, and even then I had to try in another computer, because neither 3.0.3 nor the development build would run of mine. And now neither of them runs on either computer. ~No combination of installing/uninstalling/restarting computer/building from source/cleaning .NET solution will get Pinta to run.~ I don't know what's going on. For context, both are Windows machines, one of them is Windows 10 and another one is Windows 11.

Update: I got Pinta to run by deleting `AppData/Roaming/Pinta`. This is what it looked like before this change, but after fixing the bug that prevented changing colors in the Palette (so 3.0.3 didn't work for this):

<img width="225" height="49" alt="grafik" src="https://github.com/user-attachments/assets/fe0257c8-cc0c-43f1-a202-84f9e147c60a" />

Update: Commit 9082e84256f18186bfca6bb60b7cfb97a1c9541f adds this feature to the primary/secondary color swatches, too