### PR TITLE
Fix crash in `LivePreviewManager` from using disposed `CancellationTokenSource`

### DIFF
--- a/Pinta.Core/Classes/RenderHandle.cs
+++ b/Pinta.Core/Classes/RenderHandle.cs
@@ -9,7 +9,7 @@ internal readonly record struct CompletionInfo (
 	bool WasCanceled,
 	IReadOnlyList<Exception> Errors);
 
-internal sealed class RenderHandle : IDisposable
+internal sealed class RenderHandle
 {
 	internal double Progress
 		=> get_progress ();
@@ -47,18 +47,4 @@ internal sealed class RenderHandle : IDisposable
 	}
 
 	internal delegate bool BoundsConsumer (out RectangleI bounds);
-
-	public void Dispose ()
-	{
-		Dispose (disposing: true);
-	}
-	private void Dispose (bool disposing)
-	{
-		cancellation.Dispose ();
-	}
-
-	~RenderHandle ()
-	{
-		Dispose (disposing: false);
-	}
 }

--- a/Pinta.Core/Managers/LivePreviewManager.cs
+++ b/Pinta.Core/Managers/LivePreviewManager.cs
@@ -196,8 +196,6 @@ public sealed class LivePreviewManager : ILivePreview
 			dialog.Hide ();
 
 			renderAlive = false;
-
-			renderHandle?.Dispose ();
 		}
 
 		// === Methods ===
@@ -213,7 +211,6 @@ public sealed class LivePreviewManager : ILivePreview
 			handlersInQueue++;
 			renderHandle.Cancel ();
 			await renderHandle.Task;
-			renderHandle.Dispose ();
 			handlersInQueue--;
 			if (handlersInQueue > 0) return;
 			renderHandle = AsyncEffectRenderer.Start (settings, effect, layer.Surface, LivePreviewSurface);


### PR DESCRIPTION
Fixes #1771 
The documentation of `CancellationTokenSource` says that the resources are freed by the finalizer, so we could remove the `Dispose` calls for now, at least until the structure is less confusing and makes it clear what happens before and what happens next.
https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.dispose