### PR TITLE
Work around errors saving JPEG files with the glycin pixbuf loader

### DIFF
--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Samples.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Samples.cs
@@ -329,11 +329,21 @@ partial class CairoExtensions
 		=> MemoryMarshal.Cast<byte, ColorBgra> (surface.GetData ());
 
 
-	public static GdkPixbuf.Pixbuf ToPixbuf (this ImageSurface sourceSurface)
-		=> Gdk.Functions.PixbufGetFromSurface (
-			sourceSurface,
-			0,
-			0,
-			sourceSurface.Width,
-			sourceSurface.Height)!;
+	public static GdkPixbuf.Pixbuf ToPixbuf (this ImageSurface sourceSurface, bool includeAlpha = true)
+	{
+		int width = sourceSurface.Width;
+		int height = sourceSurface.Height;
+
+		if (includeAlpha) {
+			return Gdk.Functions.PixbufGetFromSurface (sourceSurface, 0, 0, width, height)!;
+		}
+
+		// If we need a pixbuf without alpha, it's easiest to convert from a temporary RGB cairo surface.
+		using Cairo.ImageSurface rgbSurface = new (Format.Rgb24, width, height);
+		using Cairo.Context context = new (rgbSurface);
+		context.SetSourceSurface (sourceSurface, 0.0, 0.0);
+		context.Paint ();
+
+		return Gdk.Functions.PixbufGetFromSurface (rgbSurface, 0, 0, width, height)!;
+	}
 }

--- a/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
+++ b/Pinta.Core/ImageFormats/GdkPixbufFormat.cs
@@ -33,10 +33,12 @@ namespace Pinta.Core;
 public class GdkPixbufFormat : IImageImporter, IImageExporter
 {
 	private readonly string filetype;
+	private readonly bool supports_alpha;
 
-	public GdkPixbufFormat (string filetype)
+	public GdkPixbufFormat (string filetype, bool supportsAlpha = true)
 	{
 		this.filetype = filetype;
+		this.supports_alpha = supportsAlpha;
 	}
 
 	public Document Import (Gio.File file)
@@ -97,7 +99,10 @@ public class GdkPixbufFormat : IImageImporter, IImageExporter
 		Gtk.Window parent)
 	{
 		using ImageSurface flattenedImage = document.GetFlattenedImage ();
-		using Pixbuf pb = flattenedImage.ToPixbuf ();
+		// Note that some pixbuf formats will throw an error when saving an RGBA pixbuf
+		// if the image format doesn't actually store alpha
+		// (e.g. glycin does this for JPEG - bug #1774)
+		using Pixbuf pb = flattenedImage.ToPixbuf (includeAlpha: supports_alpha);
 		DoSave (pb, file, filetype, parent);
 	}
 }

--- a/Pinta.Core/ImageFormats/JpegFormat.cs
+++ b/Pinta.Core/ImageFormats/JpegFormat.cs
@@ -1,21 +1,21 @@
-// 
+//
 // JpegFormat.cs
-//  
+//
 // Author:
 //       Maia Kozheva <sikon@ubuntu.com>
-// 
+//
 // Copyright (c) 2010 Maia Kozheva <sikon@ubuntu.com>
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,7 +37,7 @@ public sealed class JpegFormat : GdkPixbufFormat
 	private const int DefaultQuality = 85;
 
 	public JpegFormat ()
-		: base ("jpeg")
+		: base ("jpeg", supportsAlpha: false)
 	{
 	}
 


### PR DESCRIPTION
This requires explicitly converting to a Gdk.Pixbuf which doesn't contain alpha.

Bug: #1774