### PR TITLE
Fix errors from saving the new image background setting with inconsistent types

### DIFF
--- a/Pinta/Actions/File/NewDocumentAction.cs
+++ b/Pinta/Actions/File/NewDocumentAction.cs
@@ -74,11 +74,11 @@ internal sealed class NewDocumentAction : IActionHandler
 
 		workspace.NewDocument (
 			newImageOptions.NewImageSize,
-			newImageOptions.NewImageBackground);
+			newImageOptions.NewImageBackgroundColor);
 
 		settings.PutSetting (SettingNames.NEW_IMAGE_WIDTH, newImageOptions.NewImageSize.Width);
 		settings.PutSetting (SettingNames.NEW_IMAGE_HEIGHT, newImageOptions.NewImageSize.Height);
-		settings.PutSetting (SettingNames.NEW_IMAGE_BACKGROUND, newImageOptions.NewImageBackground);
+		settings.PutSetting (SettingNames.NEW_IMAGE_BACKGROUND, newImageOptions.NewImageBackgroundType);
 	}
 
 	private async Task<NewImageDialogOptions> GetDialogOptions ()
@@ -129,7 +129,8 @@ internal sealed class NewDocumentAction : IActionHandler
 
 			return new (
 				dialog.NewImageSize,
-				dialog.NewImageBackground);
+				dialog.NewImageBackground,
+				dialog.NewImageBackgroundType);
 
 		} finally {
 			dialog.Destroy ();

--- a/Pinta/Messages/ActionOptions.cs
+++ b/Pinta/Messages/ActionOptions.cs
@@ -11,6 +11,6 @@ public enum BackgroundType
 }
 
 public readonly record struct NewImageDialogOptions (Size Size, BackgroundType Background, bool UsingClipboard);
-public readonly record struct NewImageOptions (Size NewImageSize, Color NewImageBackground);
+public readonly record struct NewImageOptions (Size NewImageSize, Color NewImageBackgroundColor, BackgroundType NewImageBackgroundType);
 public readonly record struct ResizeImageOptions (Size NewSize, ResamplingMode ResamplingMode);
 public readonly record struct ResizeCanvasOptions (Size NewSize, Anchor Anchor, CompoundHistoryItem? CompoundAction);


### PR DESCRIPTION
This was a regression from 88489ead which accidentally saved the background color value in the settings, rather than the background type setting.

Fixes: #1788