### PR TITLE
Add animation to the selection outline

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -522,7 +522,7 @@ public sealed class PintaCanvas : Gtk.Picture
 	#region Selection outline animation
 	private bool SelectionAnimationTick ()
 	{
-		if (!document.Selection.Visible)
+		if (PintaCore.Workspace.ActiveDocument != document || !document.Selection.Visible)
 			return true;
 
 		selection_animation_dash_offset -= 1f;


### PR DESCRIPTION
This adds an animation to the selection outline, shifting the outline to the right to give a rotating look.
This should close #1521.