### PR TITLE
Upgrade to gir.core 0.7.0-preview3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <GirCoreVersion>0.7.0-preview.2</GirCoreVersion>
+    <GirCoreVersion>0.7.0-preview.3</GirCoreVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="GirCore.Adw-1" Version="$(GirCoreVersion)" />

--- a/Pinta.Core/Extensions/GdkExtensions.cs
+++ b/Pinta.Core/Extensions/GdkExtensions.cs
@@ -265,4 +265,23 @@ public static class GdkExtensions
 	/// </summary>
 	public static Gdk.Cursor CursorFromName (string name)
 		=> Gdk.Cursor.NewFromName (name, null) ?? throw new ArgumentException ("Cursor does not exist", nameof (name));
+
+	/// <summary>
+	/// Convert from Gdk.RGBA to Cairo.Color.
+	/// </summary>
+	public static Cairo.Color ToCairoColor (this Gdk.RGBA color)
+		=> new (color.Red, color.Green, color.Blue, color.Alpha);
+
+	/// <summary>
+	/// Convert from Cairo.Color to Gdk.RGBA.
+	/// </summary>
+	public static Gdk.RGBA ToGdkRGBA (this Cairo.Color color)
+	{
+		return new Gdk.RGBA {
+			Red = (float) color.R,
+			Blue = (float) color.B,
+			Green = (float) color.G,
+			Alpha = (float) color.A
+		};
+	}
 }

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Dialog.cs
@@ -229,21 +229,4 @@ partial class GtkExtensions
 		this Gtk.Dialog dialog,
 		Gtk.ResponseType response
 	) => dialog.SetDefaultResponse ((int) response);
-
-	public static void SetColor (this Gtk.ColorChooserDialog dialog, Cairo.Color color)
-	{
-		dialog.SetRgba (new Gdk.RGBA {
-			Red = (float) color.R,
-			Blue = (float) color.B,
-			Green = (float) color.G,
-			Alpha = (float) color.A
-		});
-	}
-
-	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
-	public static void GetColor (this Gtk.ColorChooserDialog dialog, out Cairo.Color color)
-	{
-		ColorChooserGetRgba (dialog.Handle.DangerousGetHandle (), out var gdk_color);
-		color = new Cairo.Color (gdk_color.Red, gdk_color.Green, gdk_color.Blue, gdk_color.Alpha);
-	}
 }

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.External.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.External.cs
@@ -13,24 +13,6 @@ partial class GtkExtensions
 		out uint accelerator_key,
 		out Gdk.ModifierType accelerator_mods);
 
-	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
-	[StructLayout (LayoutKind.Sequential)]
-	private struct GdkRGBA
-	{
-		public float Red;
-		public float Green;
-		public float Blue;
-		public float Alpha;
-	}
-
-	[LibraryImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_style_context_get_color")]
-	private static partial void StyleContextGetColor (IntPtr handle, out GdkRGBA color);
-
-	[LibraryImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_color_chooser_get_rgba")]
-	private static partial void ColorChooserGetRgba (
-		IntPtr handle,
-		out GdkRGBA color);
-
 	// Manual binding for GetPreeditString
 	// TODO-GTK4 (bindings) - missing from gir.core: "opaque record parameter 'attrs' with direction != in not yet supported"
 	[DllImport (GTK_LIBRARY_NAME, EntryPoint = "gtk_im_context_get_preedit_string")]

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -295,13 +295,6 @@ partial class GtkExtensions
 		return result;
 	}
 
-	// TODO-GTK4 (bindings) - structs are not generated (https://github.com/gircore/gir.core/issues/622)
-	public static void GetColor (this Gtk.StyleContext context, out Cairo.Color color)
-	{
-		StyleContextGetColor (context.Handle.DangerousGetHandle (), out var gdk_color);
-		color = new Cairo.Color (gdk_color.Red, gdk_color.Green, gdk_color.Blue, gdk_color.Alpha);
-	}
-
 	/// <summary>
 	/// Checks whether the mousePos (which is relative to topwidget) is within the area and returns its relative position to the area.
 	/// </summary>

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -1,21 +1,21 @@
 //
 // CurvesDialog.cs
-//  
+//
 // Author:
 //      Krzysztof Marecki <marecki.krzysztof@gmail.com>
-// 
+//
 // Copyright (c) 2010 Krzysztof Marecki
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -449,9 +449,9 @@ public sealed class CurvesDialog : Gtk.Dialog
 	private IEnumerator<ControlPointDrawingInfo> GetDrawingInfos ()
 	{
 		if (Mode == ColorTransferMode.Luminosity) {
-			curves_drawing.GetStyleContext ().GetColor (out var fg_color);
+			curves_drawing.GetStyleContext ().GetColor (out Gdk.RGBA fg_color);
 			yield return new ControlPointDrawingInfo (
-				Color: fg_color,
+				Color: fg_color.ToCairoColor (),
 				IsActive: true);
 			yield break;
 		}
@@ -471,9 +471,9 @@ public sealed class CurvesDialog : Gtk.Dialog
 
 	private void HandleDrawingDrawnEvent (Context g)
 	{
-		curves_drawing.GetStyleContext ().GetColor (out var fg_color);
+		curves_drawing.GetStyleContext ().GetColor (out Gdk.RGBA fg_color);
 
-		g.SetSourceColor (fg_color);
+		g.SetSourceColor (fg_color.ToCairoColor ());
 
 		DrawBorder (g);
 		DrawPointerCross (g);

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -628,12 +628,12 @@ public partial class LevelsDialog : Gtk.Dialog
 
 		var ccd = Gtk.ColorChooserDialog.New (Translations.GetString ("Choose Color"), chrome.MainWindow);
 		ccd.UseAlpha = true;
-		ccd.SetColor (panel.CairoColor);
+		ccd.SetRgba (panel.CairoColor.ToGdkRGBA ());
 
 		var response = ccd.RunBlocking ();
 		if (response == Gtk.ResponseType.Ok) {
-			ccd.GetColor (out var cairo_color);
-			ColorBgra col = cairo_color.ToColorBgra ();
+			ccd.GetRgba (out Gdk.RGBA rgba);
+			ColorBgra col = rgba.ToCairoColor ().ToColorBgra ();
 
 			if (panel == colorpanel_in_low) {
 				Levels.ColorInLow = col;

--- a/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
+++ b/Pinta.Gui.Widgets/Widgets/AnglePickerGraphic.cs
@@ -94,7 +94,7 @@ public sealed class AnglePickerGraphic : Gtk.DrawingArea
 
 	private AngleGraphicSettings CreateSettings ()
 	{
-		GetStyleContext ().GetColor (out var color);
+		GetStyleContext ().GetColor (out Gdk.RGBA color);
 
 		RectangleD rect = GetDrawBounds ();
 
@@ -118,7 +118,7 @@ public sealed class AnglePickerGraphic : Gtk.DrawingArea
 
 		return new (
 			ellipseOutlineRect: ellipseRect,
-			color: color,
+			color: color.ToCairoColor (),
 			gripEllipseRect: new RectangleD (center.X - gripSize, center.Y - gripSize, gripSize * 2, gripSize * 2),
 			center: center,
 			endPoint: endPoint

--- a/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorGradientWidget.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ColorGradientWidget.cs
-//  
+//
 // Author:
 //      Krzysztof Marecki <marecki.krzysztof@gmail.com>
-// 
+//
 // Copyright (c) 2010 Krzysztof Marecki
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -278,8 +278,8 @@ public sealed class ColorGradientWidget : Gtk.DrawingArea
 
 	private void DrawTriangles (Context g)
 	{
-		GetStyleContext ().GetColor (out var hover_color);
-		Cairo.Color inactive_color = hover_color with { A = 0.5 };
+		GetStyleContext ().GetColor (out Gdk.RGBA hover_color);
+		Cairo.Color inactive_color = hover_color.ToCairoColor () with { A = 0.5 };
 
 		int px = last_mouse_pos.X;
 		int py = last_mouse_pos.Y;
@@ -294,7 +294,7 @@ public sealed class ColorGradientWidget : Gtk.DrawingArea
 			double val = vals[i];
 			double y = GetYFromValue (val);
 			bool hover = (index == i) && (all.ContainsPoint (px, py) || ValueIndex != -1);
-			Cairo.Color color = hover ? hover_color : inactive_color;
+			Cairo.Color color = hover ? hover_color.ToCairoColor () : inactive_color;
 
 			DrawLeftTriangle (g, rect, y, color);
 			DrawRightTriangle (g, rect, y, color);

--- a/Pinta.Gui.Widgets/Widgets/Ruler.cs
+++ b/Pinta.Gui.Widgets/Widgets/Ruler.cs
@@ -166,7 +166,7 @@ public sealed class Ruler : Gtk.DrawingArea
 
 	private RulerDrawSettings CreateSettings (Size preliminarySize)
 	{
-		GetStyleContext ().GetColor (out Color color);
+		GetStyleContext ().GetColor (out Gdk.RGBA color);
 
 		RectangleD rulerOuterLine = Orientation switch {
 
@@ -260,7 +260,7 @@ public sealed class Ruler : Gtk.DrawingArea
 			MarkerPosition: GetPositionOnRuler (Position, effectiveSize.Width),
 			RulerOuterLine: rulerOuterLine,
 			EffectiveSize: effectiveSize,
-			Color: color,
+			Color: color.ToCairoColor (),
 			Orientation: Orientation);
 	}
 

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -198,13 +198,14 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		g.DrawRectangle (primary_rect, new Color (0, 0, 0), 1);
 
 		// Draw the swap icon.
-		GetStyleContext ().GetColor (out var fg_color);
-		DrawSwapIcon (g, fg_color);
+		GetStyleContext ().GetColor (out Gdk.RGBA fg_color);
+		Cairo.Color cairo_fg_color = fg_color.ToCairoColor ();
+		DrawSwapIcon (g, cairo_fg_color);
 
 		// Draw the reset icon.
 		double square_size = 0.6 * reset_rect.Width;
-		g.DrawRectangle (new RectangleD (reset_rect.Location (), square_size, square_size), fg_color, 1);
-		g.FillRectangle (new RectangleD (reset_rect.Right - square_size, reset_rect.Bottom - square_size, square_size, square_size), fg_color);
+		g.DrawRectangle (new RectangleD (reset_rect.Location (), square_size, square_size), cairo_fg_color, 1);
+		g.FillRectangle (new RectangleD (reset_rect.Right - square_size, reset_rect.Bottom - square_size, square_size, square_size), cairo_fg_color);
 
 		// Draw recently used color swatches
 		var recent = palette.RecentlyUsedColors;


### PR DESCRIPTION
- There are now more bindings generated for functions with Gdk.RGBA parameters, so several manual bindings can be removed now

- Add conversion functions between Gdk.RGBA and Cairo.Color so that it's easy to use APIs that return a Gdk.RGBA