### PR TITLE
Improve logic for when user is asked to flatten image on save

### DIFF
--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -124,11 +124,9 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 		// If we already have a format, set it to the default.
 		// If not, default to jpeg
 		FormatDescriptor? format_desc = null;
-		FormatDescriptor? previous_format_desc = null;
 
 		if (document.HasFile) {
-			previous_format_desc = image_formats.GetFormatByFile (document.DisplayName);
-			format_desc = previous_format_desc;
+			format_desc = image_formats.GetFormatByFile (document.DisplayName);
 		}
 
 		if (format_desc is null || !format_desc.IsExportAvailable ())


### PR DESCRIPTION
This PR changes the logic for when the user is asked whether to flatten the image when saving.

The previous logic only asked this when the file had previously been saved in a non-flat format, but now in a flat format. This logic could lead to unexpected data loss: for example, if the user opened an existing PNG, created another layer, then saved and closed Pinta, the layer information would be lost. The same applies if the user was creating a new file with several layers, then saved it as a flat format. It's not good that the user ever loses layer information without being aware of this.

After these changes, the user is asked on any save of an image with multiple layers to a flat format whether they want to flatten it.