### PR TITLE
TextEngine: fix incorrect location when pressing Left at the start of a line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Thanks to the following contributors who worked on this release:
 - Fixed bug where the text tool could incorrectly display a default cursor (#1707)
 - Fixed drifting when holding Shift while expanding a rectangle selection using the vertical or horizontal handles (#1733)
 - Fixed issue where icons were missing from the top bar (#1814)
+- Fixed a potential error in the text tool when pressing Left at the beginning of a line (#1824)
 
 ## [3.0.5](https://github.com/PintaProject/Pinta/release/tag/3.0.5) - 2025/11/24
 

--- a/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
+++ b/Pinta.Core/Classes/Re-editable/Text/TextEngine.cs
@@ -281,7 +281,7 @@ public sealed partial class TextEngine
 		} else if (current_pos.Offset == 0 && current_pos.Line > 0) {
 			current_pos = new (
 				line: current_pos.Line - 1,
-				offset: lines[current_pos.Line].Length);
+				offset: lines[current_pos.Line - 1].Length);
 		}
 
 		if (!shift)

--- a/tests/Pinta.Core.Tests/TextEngineTest.cs
+++ b/tests/Pinta.Core.Tests/TextEngineTest.cs
@@ -177,7 +177,7 @@ internal sealed class TextEngineTest
 	[Test]
 	public void PerformLeftRight ()
 	{
-		TextEngine engine = new (test_snippet);
+		TextEngine engine = new (test_snippet.Append ("a longer line"));
 
 		engine.SetCursorPosition (new TextPosition (0, 3), true);
 		engine.PerformRight (false, false);
@@ -201,13 +201,18 @@ internal sealed class TextEngineTest
 
 		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 6)));
 
+		// Test bug #1824, when going from a longer line up to a shorter line
+		engine.SetCursorPosition (new TextPosition (3, 0), true); ;
+		engine.PerformLeft (false, false);
+		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (2, 6)));
+
 		// Should stay at the beginning / end when attempting to advance further.
 		engine.SetCursorPosition (new TextPosition (0, 0), true);
 		engine.PerformLeft (false, false);
 
 		Assert.That (engine.CurrentPosition, Is.EqualTo (new TextPosition (0, 0)));
 
-		TextPosition endPosition = new (test_snippet.Count - 1, test_snippet.Last ().Length);
+		TextPosition endPosition = new (engine.LineCount - 1, engine.Lines.Last ().Length);
 		engine.SetCursorPosition (endPosition, true);
 		engine.PerformRight (false, false);
 


### PR DESCRIPTION
Fixes: #1824