### PR TITLE
Fix regression with the selection handles becoming inverted

### DIFF
--- a/Pinta.Tools/Handles/RectangleHandle.cs
+++ b/Pinta.Tools/Handles/RectangleHandle.cs
@@ -159,6 +159,7 @@ public class RectangleHandle : IToolHandle
 		RectangleD rect = Rectangle;
 		start_pt = rect.Location ();
 		end_pt = rect.EndLocation ();
+		UpdateHandlePositions ();
 	}
 
 	/// <summary>


### PR DESCRIPTION
This happened to be revealed by b156b6b3, but the proper fix is to update the handle positions after fixing the inverted rectangle

Fixes: #1917