### PR TITLE
Fix calls to Translations.GetString() with arguments that aren't string literals

### DIFF
--- a/Pinta.Core/Actions/EffectsActions.cs
+++ b/Pinta.Core/Actions/EffectsActions.cs
@@ -1,21 +1,21 @@
-// 
+//
 // EffectsActions.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -47,7 +47,7 @@ public sealed class EffectsActions
 
 		if (!Menus.ContainsKey (category)) {
 			var category_menu = Gio.Menu.New ();
-			effects_menu.AppendMenuItemSorted (Gio.MenuItem.NewSubmenu (Translations.GetString (category), category_menu));
+			effects_menu.AppendMenuItemSorted (Gio.MenuItem.NewSubmenu (category, category_menu));
 			Menus.Add (category, category_menu);
 		}
 

--- a/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
+++ b/Pinta.Gui.Widgets/Widgets/ColorPickerDialog.cs
@@ -510,7 +510,7 @@ public sealed class ColorPickerDialog : Gtk.Dialog
 
 		SetTitlebar (titleBar);
 
-		Title = Translations.GetString (windowTitle);
+		Title = windowTitle;
 		TransientFor = parentWindow;
 		Modal = false;
 		IconName = Resources.Icons.ImageResizeCanvas;


### PR DESCRIPTION
This is incorrect to do, because the translatable strings won't be automatically discovered.

- In the color picker dialog, this was unnecessary since the callers were already providing translated strings
- In the effect manager, this could cause confusing behaviour and produce duplicate submenus if an add-in provided an effect category string that was not translated but matched one of the factory categories, as in the referenced bug report. 

Bug: #1933