### PR TITLE
Use GirCore subclasses

### DIFF
--- a/Pinta.Core/Classes/BaseTool.cs
+++ b/Pinta.Core/Classes/BaseTool.cs
@@ -340,7 +340,7 @@ public abstract class BaseTool
 	private ToolBarDropDownButton AlphaBlendingDropDown {
 		get {
 			if (alphablending_button is null) {
-				alphablending_button = new ToolBarDropDownButton ();
+				alphablending_button = ToolBarDropDownButton.New ();
 
 				alphablending_button.AddItem (Translations.GetString ("Normal Blending"), Pinta.Resources.Icons.BlendingNormal, true);
 				alphablending_button.AddItem (Translations.GetString ("Overwrite"), Pinta.Resources.Icons.BlendingOverwrite, false);
@@ -357,7 +357,7 @@ public abstract class BaseTool
 	private ToolBarDropDownButton AntialiasingDropDown {
 		get {
 			if (antialiasing_button is null) {
-				antialiasing_button = new ToolBarDropDownButton ();
+				antialiasing_button = ToolBarDropDownButton.New ();
 
 				antialiasing_button.AddItem (Translations.GetString ("Antialiasing On"), Pinta.Resources.Icons.AntiAliasingEnabled, true);
 				antialiasing_button.AddItem (Translations.GetString ("Antialiasing Off"), Pinta.Resources.Icons.AntiAliasingDisabled, false);

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -5,6 +5,7 @@
 
   <Import Project="../properties/ReferenceGirCoreAdw1.props" />
   <Import Project="../properties/ReferenceGirCorePangoCairo10.props" />
+  <Import Project="../properties/ReferenceGirCoreGObject20Integration.props" />
 
   <ItemGroup>
     <PackageReference Include="NGettext" />

--- a/Pinta.Core/Widgets/ToolBarDropDownButton.cs
+++ b/Pinta.Core/Widgets/ToolBarDropDownButton.cs
@@ -1,26 +1,35 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Pinta.Core;
 
-public sealed class ToolBarDropDownButton : Gtk.MenuButton
+[GObject.Subclass<Gtk.MenuButton>]
+public sealed partial class ToolBarDropDownButton
 {
 	private const string ACTION_PREFIX = "tool";
 
-	private readonly bool show_label;
-	private readonly Gio.Menu dropdown;
-	private readonly Gio.SimpleActionGroup action_group;
+	private bool show_label;
+	private Gio.Menu dropdown;
+	private Gio.SimpleActionGroup action_group;
 	private ToolBarItem? selected_item;
 
-	private readonly List<ToolBarItem> items;
-	public ReadOnlyCollection<ToolBarItem> Items { get; }
+	private List<ToolBarItem> items;
+	public ReadOnlyCollection<ToolBarItem> Items { get; private set; }
 
-	public ToolBarDropDownButton (bool showLabel = false)
+	public static ToolBarDropDownButton New(bool showLabel = false)
 	{
-		show_label = showLabel;
+		var obj = NewWithProperties([]);
+		obj.show_label = showLabel;
 
+		return obj;
+	}
+
+	[MemberNotNull(nameof(items), nameof(Items), nameof(action_group), nameof(dropdown))]
+	partial void Initialize()
+	{
 		items = [];
 		Items = new ReadOnlyCollection<ToolBarItem> (items);
 		AlwaysShowArrow = true;

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -302,7 +302,7 @@ public abstract class BaseEditEngine
 		tb.Append (fill_label);
 
 		if (fill_button == null) {
-			fill_button = new ToolBarDropDownButton ();
+			fill_button = ToolBarDropDownButton.New ();
 
 			fill_button.AddItem (Translations.GetString ("Outline Shape"), Resources.Icons.FillStyleOutline, 0);
 			fill_button.AddItem (Translations.GetString ("Fill Shape"), Resources.Icons.FillStyleFill, 1);
@@ -328,7 +328,7 @@ public abstract class BaseEditEngine
 		tb.Append (shape_type_label);
 
 		if (shape_type_button == null) {
-			shape_type_button = new ToolBarDropDownButton ();
+			shape_type_button = ToolBarDropDownButton.New ();
 
 			shape_type_button.AddItem (Translations.GetString ("Open Line/Curve Series"), Resources.Icons.ToolLine, 0);
 			shape_type_button.AddItem (Translations.GetString ("Closed Line/Curve Series"), Resources.Icons.ToolRectangle, 1);


### PR DESCRIPTION
WIP and discussion

- This is a sample on how the current conversion to a GirCore would look like if there is no paramterless constructor anymore. 
- Please ignore the compiler errors: This is build for https://github.com/gircore/gir.core/pull/1437
- Readonly member / properties support is lost
- Initialize method can be used for non parametrized initialization. This would even work if the instance is created in C and not known to dotnet
- The `New` factory method is used to configure the instance in a certain way

Insights:
- All subclasses must be touched, there is no soft migration
- Certain dotnet compiler optimizations might be lost

Questions:
- Do we need support to install properties / construct properties inside GObject to (eventually) support read only properties? Should this be delivered later or is it a prerequisite? Partial properties are supported with dotnet 9 and could be handy for this case. As GirCore supports dotnet 8 this is available with dotnet 9. If this works `NewWithProperties` could be used to set those properties.
- Do we need a soft migration? This would lead to more in complete / seemingly buggy composite template support because eventually templates would not be initialized correctly if the instances are not known to C# (in case of hierarchical composite templates).