### PR TITLE
feat: Add single-instance mode to prevent multiple instances

### DIFF
--- a/Pinta/SettingNames.cs
+++ b/Pinta/SettingNames.cs
@@ -20,4 +20,5 @@ internal static class SettingNames
 	internal const string TOOLBOX_SHOWN = "toolbox-shown";
 	internal const string LAST_DIALOG_DIRECTORY = "last-dialog-directory";
 	internal const string LAST_SELECTED_TOOL = "last-selected-tool";
+	internal const string SINGLE_INSTANCE_MODE = "single-instance-mode";
 }


### PR DESCRIPTION
Solves #1906 

## Changes
1. Added Settings Constant (SettingNames.cs)
`internal const string SINGLE_INSTANCE_MODE = "single-instance-mode";`

2. Conditional Application Flags (Main.cs)
`// Check if single-instance mode is enabled
var settings = new SettingsManager ();
bool singleInstance = settings.GetSetting (SettingNames.SINGLE_INSTANCE_MODE, false);

// Use appropriate flags based on preference
var flags = singleInstance ? Gio.ApplicationFlags.HandlesOpen 
                           : Gio.ApplicationFlags.NonUnique;
var app = Adw.Application.New (PintaCore.ApplicationId, flags);`

3. OnOpen Event Handler (Main.cs)
`// Handle file opening in existing instance
if (singleInstance) {
    app.OnOpen += (_, args) => {
        main_window.Activate ();
        foreach (var file in args.Files)
            PintaCore.Workspace.OpenFile (file);
    };
}`

Behaviour

- Disabled (default): Multiple windows, backward compatible
- Enabled: All files open as tabs in one window
- Configuration: Edit ~/.config/Pinta/settings.xml:
  `<setting name="single-instance-mode" type="System.Boolean">True</setting>`
  
  

