### PR TITLE
Support ctrl+click to edit a palette color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Thanks to the following contributors who worked on this release:
 
 ### Added
 - The splatter brush now allows the minimum and maximum splatter size to be configured separately from the brush width
+- The status bar color palette now supports Ctrl+clicking to edit a color, in addition to middle clicking (#1436)
 
 ### Changed
 

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Interaction.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Interaction.cs
@@ -20,7 +20,7 @@ partial class GtkExtensions
 	/// Convert the "<Primary>" accelerator to the Ctrl or Command key, depending on the platform.
 	/// This was done automatically in GTK3, but does not happen in GTK4.
 	/// </summary>
-	private static string ConvertPrimaryKey (this SystemManager system, string accel) =>
+	private static string ConvertPrimaryKey (this ISystemService system, string accel) =>
 		accel.Replace ("<Primary>", system.OperatingSystem == OS.Mac ? "<Meta>" : "<Control>");
 
 	private static string ConvertPrimaryKey (string accel) =>
@@ -30,7 +30,7 @@ partial class GtkExtensions
 	/// Returns the platform-specific label for the "Primary" (Ctrl) key.
 	/// For example, this is the Cmd key on macOS.
 	/// </summary>
-	public static string CtrlLabel (this SystemManager system)
+	public static string CtrlLabel (this ISystemService system)
 	{
 		AcceleratorParse (
 			system.ConvertPrimaryKey ("<Primary>"),

--- a/Pinta.Core/Managers/SystemManager.cs
+++ b/Pinta.Core/Managers/SystemManager.cs
@@ -32,7 +32,8 @@ namespace Pinta.Core;
 
 public interface ISystemService
 {
-	int RenderThreads { get; set; }
+	int RenderThreads { get; }
+	OS OperatingSystem { get; }
 }
 
 public sealed class SystemManager : ISystemService

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -45,14 +45,16 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 	private readonly IChromeService chrome;
 	private readonly IPaletteService palette;
+	private readonly ISystemService system;
 
 	private RectangleD palette_rect;
 	private RectangleD recent_palette_rect;
 
-	public StatusBarColorPaletteWidget (IChromeService chrome, IPaletteService palette)
+	public StatusBarColorPaletteWidget (IChromeService chrome, IPaletteService palette, ISystemService system)
 	{
 		this.chrome = chrome;
 		this.palette = palette;
+		this.system = system;
 
 		HasTooltip = true;
 		OnQueryTooltip += HandleQueryTooltip;
@@ -71,13 +73,13 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 		Gtk.GestureClick click_gesture = Gtk.GestureClick.New ();
 		click_gesture.SetButton (0); // Listen for all mouse buttons.
 		click_gesture.OnReleased += (_, e) => {
-			HandleClick (new PointD (e.X, e.Y), click_gesture.GetCurrentButton ());
+			HandleClick (new PointD (e.X, e.Y), click_gesture.GetCurrentButton (), click_gesture.GetCurrentEventState ());
 			click_gesture.SetState (Gtk.EventSequenceState.Claimed);
 		};
 		AddController (click_gesture);
 	}
 
-	private async void HandleClick (PointD point, uint button)
+	private async void HandleClick (PointD point, uint button, Gdk.ModifierType state)
 	{
 		var element = GetElementAtPoint (point);
 
@@ -138,11 +140,13 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 				if (index < 0)
 					break;
 
+				bool isCtrlPressed = state.IsControlPressed ();
 				if (button == GtkExtensions.MOUSE_RIGHT_BUTTON) {
 					palette.SecondaryColor = palette.CurrentPalette.Colors[index];
-				} else if (button == GtkExtensions.MOUSE_LEFT_BUTTON) {
+				} else if (button == GtkExtensions.MOUSE_LEFT_BUTTON && !isCtrlPressed) {
 					palette.PrimaryColor = palette.CurrentPalette.Colors[index];
-				} else {
+				} else if (button == GtkExtensions.MOUSE_MIDDLE_BUTTON ||
+					   (button == GtkExtensions.MOUSE_LEFT_BUTTON && isCtrlPressed)) {
 					SingleColor pick = new (palette.CurrentPalette.Colors[index]);
 					var colors = await GetUserChosenColor (
 						pick,
@@ -307,8 +311,12 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 		switch (GetElementAtPoint (point)) {
 			case WidgetElement.Palette:
-				if (PaletteWidget.GetSwatchAtLocation (palette, point, palette_rect) >= 0)
-					text = Translations.GetString ("Left click to set primary color. Right click to set secondary color. Middle click to choose palette color.");
+				if (PaletteWidget.GetSwatchAtLocation (palette, point, palette_rect) >= 0) {
+					// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
+					text = Translations.GetString ("Left click to set primary color. Right click to set secondary color. Middle click or press {0} and left click to choose palette color.",
+						system.CtrlLabel ());
+				}
+
 				break;
 			case WidgetElement.RecentColorsPalette:
 				if (PaletteWidget.GetSwatchAtLocation (palette, point, recent_palette_rect, true) >= 0)

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -491,7 +491,8 @@ internal sealed class MainWindow
 		statusbar.Append (
 			new StatusBarColorPaletteWidget (
 				PintaCore.Chrome,
-				PintaCore.Palette) {
+				PintaCore.Palette,
+				PintaCore.System) {
 				Hexpand = true,
 				Halign = Gtk.Align.Fill,
 			}

--- a/tests/Pinta.Effects.Tests/Mocks/MockSystemService.cs
+++ b/tests/Pinta.Effects.Tests/Mocks/MockSystemService.cs
@@ -6,4 +6,5 @@ namespace Pinta.Effects;
 public class MockSystemService : ISystemService
 {
 	public int RenderThreads { get; set; } = Environment.ProcessorCount;
+	public OS OperatingSystem { get; } = OS.Other;
 }


### PR DESCRIPTION
This allows users without a middle mouse button (e.g. mac laptops) to still edit the palette color. 

Double-clicking was another alternative considered, but this doesn't work well since the single click action actually changes the current palette color

Mentioned in bug #1436