### PR TITLE
Fix several minor UX issues in the color picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Thanks to the following contributors who worked on this release:
 
 ### Changed
 - Effect dialogs now hide options that are not currently relevant (#1960)
+- Fixed several minor UX issues in the color dialog (#1795)
 
 ### Fixed
 - Fixed a bug where duplicate submenus could be produced by add-ins with effect categories that were not translated (#1933, #1935)

--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -358,7 +358,7 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 			new PaletteColors (palette.PrimaryColor, palette.SecondaryColor),
 			primarySelected,
 			true,
-			Translations.GetString ("Color Picker"));
+			Translations.GetString ("Choose Colors"));
 
 		Gtk.ResponseType response = await colorPicker.RunAsync ();
 


### PR DESCRIPTION
- Add tooltips for several widgets
- Change the dialog title when picking the primary / secondary colors to be consistent with the titles for picking colors in effects or for the palette
- Rename the reset button to just "Reset" since it affects all edited colors
- Fix focus issues preventing Enter from accepting the dialog
- Allow pressing Esc to cancel the dialog. This key was being consumed by the keyboard handler previously.
  - Also tidied up the exit code - removing event handlers in the close request works better since we don't need to handle multiple responses. When Esc is pressed, there is only a DeleteEvent sent so the handlers previously weren't being cleared.

Fixes: #1795