### PR TITLE
Scroll to the selected item in the layers / history panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Thanks to the following contributors who worked on this release:
 ### Fixed
 - Fixed a bug where duplicate submenus could be produced by add-ins with effect categories that were not translated (#1933, #1935)
 - Fixed crash when right-clicking on a layer in certain scenarios (#1940)
+- The layers and history panels now scroll automatically to the selected item after any updates (#1867, #1828)
 
 ## [3.1.1](https://github.com/PintaProject/Pinta/release/tag/3.1.1) - 2026/01/10
 

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -327,5 +327,19 @@ partial class GtkExtensions
 			return true;
 		return false;
 	}
+
+	/// <summary>
+	/// Helper method for scrolling to the selected item in a list view.
+	/// When a new item is added, immediately scrolling to the end doesn't scroll far enough (likely
+	/// because the widget's size hasn't updated). Performing the scroll after UI events have
+	/// been processed works well.
+	/// </summary>
+	public static void ScrollToSelectedItem (this Gtk.ListView view, Gtk.SingleSelection selection)
+	{
+		GLib.Functions.IdleAdd (GLib.Constants.PRIORITY_LOW, (() => {
+			view.ScrollTo (selection.Selected, Gtk.ListScrollFlags.None, null);
+			return false;
+		}));
+	}
 }
 

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListView.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListView.cs
@@ -35,6 +35,7 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 {
 	private readonly Gio.ListStore list_model;
 	private readonly Gtk.SingleSelection selection_model;
+	private readonly Gtk.ListView list_view;
 	private Document? active_document;
 	private bool changing_selection = false;
 
@@ -51,9 +52,9 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 		factory.OnSetup += HandleFactorySetup;
 		factory.OnBind += HandleFactoryBind;
 
-		Gtk.ListView view = Gtk.ListView.New (selectionModel, factory);
-		view.CanFocus = false;
-		view.OnActivate += HandleRowActivated;
+		Gtk.ListView listView = Gtk.ListView.New (selectionModel, factory);
+		listView.CanFocus = false;
+		listView.OnActivate += HandleRowActivated;
 
 		// --- Initialization (Gtk.Widget)
 
@@ -63,12 +64,13 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 		// --- Initialization (Gtk.ScrolledWindow)
 
 		SetPolicy (Gtk.PolicyType.Automatic, Gtk.PolicyType.Automatic);
-		SetChild (view);
+		SetChild (listView);
 
 		// --- References to keep
 
 		list_model = listModel;
 		selection_model = selectionModel;
+		list_view = listView;
 
 		// --- Other initialization (TODO: remove references to PintaCore)
 
@@ -160,6 +162,7 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 		// Update our selection to match the document's active layer.
 		int currentModelIndex = doc.Layers.Count () - 1 - doc.Layers.CurrentUserLayerIndex;
 		selection_model.SelectItem ((uint) currentModelIndex, unselectRest: true);
+		list_view.ScrollToSelectedItem (selection_model);
 
 		doc.History.HistoryItemAdded += HandleHistoryChanged;
 		doc.History.ActionUndone += HandleHistoryChanged;
@@ -188,6 +191,7 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 
 		int index = active_document.Layers.Count () - 1 - e.Index;
 		list_model.Insert ((uint) index, new LayersListViewItem (active_document, active_document.Layers[e.Index]));
+		list_view.ScrollToSelectedItem (selection_model);
 	}
 
 	private void HandleLayerRemoved (object? sender, IndexEventArgs e)
@@ -196,6 +200,7 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 
 		// Note: don't need to subtract 1 because the layer has already been removed from the document.
 		list_model.Remove ((uint) (active_document.Layers.Count () - e.Index));
+		list_view.ScrollToSelectedItem (selection_model);
 	}
 
 	private void HandleSelectedLayerChanged (object? sender, EventArgs e)
@@ -204,6 +209,7 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 
 		int index = active_document.Layers.Count () - 1 - active_document.Layers.CurrentUserLayerIndex;
 		selection_model.SelectItem ((uint) index, unselectRest: true);
+		list_view.ScrollToSelectedItem (selection_model);
 	}
 
 	private void HandleLayerPropertyChanged (object? sender, EventArgs e)


### PR DESCRIPTION
This is done after the list is rebuilt (e.g. when switching documents) or after adding / removing new items.

Bug: #1867, #1828