### PR TITLE
Fix how the layer list updates its widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Thanks to the following contributors who worked on this release:
 
 ### Fixed
 - Fixed a bug where duplicate submenus could be produced by add-ins with effect categories that were not translated (#1933, #1935)
+- Fixed crash when right-clicking on a layer in certain scenarios (#1940)
 
 ## [3.1.1](https://github.com/PintaProject/Pinta/release/tag/3.1.1) - 2026/01/10
 

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListView.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListView.cs
@@ -90,7 +90,7 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 		var list_item = (Gtk.ListItem) args.Object;
 		var model_item = (LayersListViewItem) list_item.GetItem ()!;
 		var widget = (LayersListViewItemWidget) list_item.GetChild ()!;
-		widget.Update (model_item);
+		widget.SetItem (model_item);
 	}
 
 	private void HandleSelectionChanged (
@@ -174,17 +174,12 @@ public sealed class LayersListView : Gtk.ScrolledWindow
 	{
 		ArgumentNullException.ThrowIfNull (active_document);
 
-		// Recreate all the widgets.
-		// This update should ideally be done by changing gobject properties instead, but we don't have the ability to add custom properties yet
-		uint selected_idx = selection_model.Selected;
+		// Update the list view items to refresh their corresponding widgets.
+		// This update should ideally be done through gobject property bindings instead, but we don't have the ability to add custom properties yet
 		for (uint i = 0; i < list_model.GetNItems (); ++i) {
-			int layer_idx = active_document.Layers.Count () - 1 - (int) i;
-			list_model.Remove (i);
-			list_model.Insert (i, new LayersListViewItem (active_document, active_document.Layers[layer_idx]));
+			LayersListViewItem item = (LayersListViewItem) list_model.GetObject (i)!;
+			item.NotifyLayerModified ();
 		}
-
-		// Restore the selection.
-		selection_model.Selected = selected_idx;
 	}
 
 	private void HandleLayerAdded (object? sender, IndexEventArgs e)

--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
@@ -106,6 +106,17 @@ public sealed partial class LayersListViewItem
 
 		doc.History.PushNewItem (historyItem);
 	}
+
+	public event EventHandler? LayerModified;
+
+	/// <summary>
+	/// Signal that the layer has been modified.
+	/// In the future this should be replaced by GObject properties and bindings.
+	/// </summary>
+	public void NotifyLayerModified ()
+	{
+		LayerModified?.Invoke (this, EventArgs.Empty);
+	}
 }
 
 public sealed class LayersListViewItemWidget : Gtk.Box
@@ -170,7 +181,10 @@ public sealed class LayersListViewItemWidget : Gtk.Box
 			return;
 
 		Document doc = PintaCore.Workspace.ActiveDocument;
-		doc.Layers.SetCurrentUserLayer (item.UserLayer); // Select layer before applying action
+		// Ensure this is the current layer before opening the menu, since the menu actions
+		// apply to the current layer.
+		if (doc.Layers.CurrentUserLayer != item.UserLayer)
+			doc.Layers.SetCurrentUserLayer (item.UserLayer);
 
 		LayerActions actions = PintaCore.Actions.Layers;
 
@@ -197,10 +211,34 @@ public sealed class LayersListViewItemWidget : Gtk.Box
 		popover.Popup ();
 	}
 
-	// Set the widget's contents to the provided layer.
-	public void Update (LayersListViewItem item)
+	/// <summary>
+	/// Bind the widget to a different LayersListViewItem.
+	/// </summary>
+	public void SetItem (LayersListViewItem newItem)
 	{
-		this.item = item;
+		if (item != null)
+			item.LayerModified -= OnLayerModified;
+
+		item = newItem;
+		item.LayerModified += OnLayerModified;
+		UpdateFromLayer ();
+	}
+
+	/// <summary>
+	/// Event handler for modifications to the item's layer.
+	/// </summary>
+	private void OnLayerModified (object? sender, EventArgs e)
+	{
+		UpdateFromLayer ();
+	}
+
+	/// <summary>
+	/// Update the widget to reflect the current state of the item's layer.
+	/// </summary>
+	private void UpdateFromLayer ()
+	{
+		if (item is null)
+			throw new InvalidOperationException ($"{nameof (item)} is null");
 
 		item_label.SetText (item.Label);
 		visible_button.SetActive (item.Visible);


### PR DESCRIPTION
Previously the list items were entirely rebuilt in order to update the UI. This was the root cause of the crash in the referenced bug report, because updating the current layer after a right click could finalize tools and rebuild the widgets (causing the popover menu to be attached to a widget that was about to be removed)

- Add an event to signal that the layer item has changed, allowing the widget to update itself. Using GObject properties and bindings is the "proper" way to update the widget, but currently we can't add properties for a managed subclass

- Avoid unnecessary calls to SetCurrentUserLayer if our layer is already current. This avoids some extra updates from selection change events.

Bug: #1940