### PR TITLE
Reorder the layer item widgets to avoid issues with overlay scrollbars

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
@@ -162,9 +162,9 @@ public sealed class LayersListViewItemWidget : Gtk.Box
 
 		SetOrientation (Gtk.Orientation.Horizontal);
 
-		Append (itemThumbnail);
-		Append (itemLabel);
 		Append (visibleButton);
+		Append (itemLabel);
+		Append (itemThumbnail);
 
 		// --- References to keep
 


### PR DESCRIPTION
The visibility toggle now appears on the left so that overlay scrollbars don't block it from being clicked. The thumbnail takes its place on the right side.

Fixes: #1828