### PR TITLE
Fix infinite loop crash when Levels Gamma is set to 0

### DIFF
--- a/Pinta.Core/Algorithms/PixelOps/UnaryPixelOps.cs
+++ b/Pinta.Core/Algorithms/PixelOps/UnaryPixelOps.cs
@@ -297,6 +297,8 @@ public static class UnaryPixelOps
 	[Serializable]
 	public sealed class Level : ChannelCurve, ICloneable
 	{
+		public const float MinGamma = 0.1f;
+		public const float MaxGamma = 10.0f;
 		private ColorBgra color_in_low;
 		public ColorBgra ColorInLow {
 			get => color_in_low;
@@ -382,7 +384,7 @@ public static class UnaryPixelOps
 			if (index < 0 || index >= 3)
 				throw new ArgumentOutOfRangeException (nameof (index), index, "Index must be between 0 and 2");
 
-			gamma[index] = Math.Clamp (val, 0.1f, 10.0f);
+			gamma[index] = Math.Clamp (val, MinGamma, MaxGamma);
 			UpdateLookupTable ();
 		}
 
@@ -396,8 +398,8 @@ public static class UnaryPixelOps
 					(lo[i] < md[i] && md[i] < hi[i])
 					? Math.Clamp (
 						MathF.Log (0.5f, (md[i] - lo[i]) / (float) (hi[i] - lo[i])),
-						0.1f,
-						10.0f)
+						MinGamma,
+						MaxGamma)
 					: 1.0f;
 			}
 			return new Level (lo, hi, gamma, ColorBgra.Black, ColorBgra.White);

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -462,7 +462,7 @@ public partial class LevelsDialog : Gtk.Dialog
 
 	private void UpdateGammaByMask (float val)
 	{
-		val = Math.Clamp(val, 0.1f, 10.0f);
+		val = Math.Clamp (val, UnaryPixelOps.Level.MinGamma, UnaryPixelOps.Level.MaxGamma);
 		if (!(mask.R || mask.G || mask.B))
 			return;
 


### PR DESCRIPTION
Fixes #2035 

**Description**
This PR fixes a bug where the application permanently freezes if the user drags the gamma (midtones) slider down to 0.

The freeze was caused by an infinite do-while loop in {UpdateGammaByMask(float val)}. The UI allows the user to request a value of 0 , but the underlying engine strictly clamps Gamma to a minimum of 0.1 . Because the target value could never be reached, the loop never exited locking up the main thread.

**Changes**
Added 'val = Math.Clamp(val, 0.1f, 10.0f);' at the start of {UpdateGammaByMask} in Effects.LevelsDialog.cs to ensure the requested value matches the physical limits before the loop begins.

