### PR TITLE
feat: show hex color code on palette swatch hover

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs
@@ -311,16 +311,23 @@ public sealed class StatusBarColorPaletteWidget : Gtk.DrawingArea
 
 		switch (GetElementAtPoint (point)) {
 			case WidgetElement.Palette:
-				if (PaletteWidget.GetSwatchAtLocation (palette, point, palette_rect) >= 0) {
+				int paletteIndex = PaletteWidget.GetSwatchAtLocation (palette, point, palette_rect);
+				if (paletteIndex >= 0) {
+					string hex = $"#{palette.CurrentPalette.Colors[paletteIndex].ToHex (false)}";
 					// Translators: {0} is 'Ctrl', or a platform-specific key such as 'Command' on macOS.
-					text = Translations.GetString ("Left click to set primary color. Right click to set secondary color. Middle click or press {0} and left click to choose palette color.",
+					string hint = Translations.GetString ("Left click to set primary color. Right click to set secondary color. Middle click or press {0} and left click to choose palette color.",
 						system.CtrlLabel ());
+					text = $"{hex}\n{hint}";
 				}
 
 				break;
 			case WidgetElement.RecentColorsPalette:
-				if (PaletteWidget.GetSwatchAtLocation (palette, point, recent_palette_rect, true) >= 0)
-					text = Translations.GetString ("Left click to set primary color. Right click to set secondary color.");
+				int recentIndex = PaletteWidget.GetSwatchAtLocation (palette, point, recent_palette_rect, true);
+				if (recentIndex >= 0) {
+					string hex = $"#{palette.RecentlyUsedColors[recentIndex].ToHex (false)}";
+					string hint = Translations.GetString ("Left click to set primary color. Right click to set secondary color.");
+					text = $"{hex}\n{hint}";
+				}
 				break;
 			case WidgetElement.PrimaryColor:
 				text = Translations.GetString ("Click to select primary color.");


### PR DESCRIPTION
## Summary
Shows the hex color code in the tooltip when hovering over palette swatches.

## Why this matters
The palette tooltip only showed mouse button hints. Now it also shows the hex code (e.g. #FF0000) for the color under the cursor. Handy when you need to know the exact color value.

## Changes
- Modified `HandleQueryTooltip` in `Pinta.Gui.Widgets/Widgets/StatusBarColorPaletteWidget.cs`
- For palette swatches: gets the color at the swatch index, formats as `#RRGGBB` via `ToHex(false)`, prepends to tooltip
- For recent color swatches: same pattern using `RecentlyUsedColors`

## Testing
- Hover over a palette swatch to see hex code + mouse button hints
- Hover over a recent color swatch to see hex code + hints

Closes #2068

This contribution was developed with AI assistance (Codex CLI + Claude Code).