### PR TITLE
feat: added ctrl key modifier to move pixels and selections by 10

### DIFF
--- a/Pinta.Tools/Tools/BaseTransformTool.cs
+++ b/Pinta.Tools/Tools/BaseTransformTool.cs
@@ -148,19 +148,20 @@ public abstract class BaseTransformTool : BaseTool
 
 		double dx = 0.0;
 		double dy = 0.0;
+		double coeff = e.IsControlPressed ? 10.0 : 1.0;
 
 		switch (e.Key.Value) {
 			case Gdk.Constants.KEY_Left:
-				dx = -1;
+				dx = -coeff;
 				break;
 			case Gdk.Constants.KEY_Right:
-				dx = 1;
+				dx = coeff;
 				break;
 			case Gdk.Constants.KEY_Up:
-				dy = -1;
+				dy = -coeff;
 				break;
 			case Gdk.Constants.KEY_Down:
-				dy = 1;
+				dy = coeff;
 				break;
 			default:
 				// Otherwise, let the key be handled elsewhere.


### PR DESCRIPTION
I have added the CTRL key as a modifier to move pixels and selections by 10.
* Created a coefficient that changes if the CTRL key is pressed.
* Replaced the offsets with the coefficient.
```C#
double coeff = e.IsControlPressed ? 10.0 : 1.0;

switch (e.Key.Value) {
	case Gdk.Constants.KEY_Left:
		dx = -coeff;
		break;
	// ...
}
```
The issues that might be not related are icons of some tools being small and the cursor disappearing in the canvas when hovering over the canvas while the Move Selected Pixels is active.