### PR TITLE
Refactor the New Image dialog's preview widget

### DIFF
--- a/Pinta.Core/Extensions/Cairo/CairoExtensions.Samples.cs
+++ b/Pinta.Core/Extensions/Cairo/CairoExtensions.Samples.cs
@@ -346,4 +346,26 @@ partial class CairoExtensions
 
 		return Gdk.Functions.PixbufGetFromSurface (rgbSurface, 0, 0, width, height)!;
 	}
+
+	/// <summary>
+	/// Convert a Cairo surface to a Gdk.Texture.
+	/// This can optionally be configured to act as an update to a region of an existing texture.
+	/// </summary>
+	public static Gdk.Texture ToTexture (this Cairo.ImageSurface surface, Gdk.Texture? updateTexture = null, Cairo.Region? updateRegion = null)
+	{
+		GLib.Bytes bytes = GLib.Bytes.New (surface.GetData ());
+
+		Gdk.MemoryTextureBuilder builder = new () {
+			Bytes = bytes,
+			Stride = (ulong) surface.Stride,
+			Width = surface.Width,
+			Height = surface.Height,
+			Format = Gdk.MemoryFormat.B8g8r8a8Premultiplied,
+			UpdateTexture = updateTexture,
+			UpdateRegion = updateRegion ?? CairoExtensions.CreateRegion (RectangleI.Zero)
+
+		};
+
+		return builder.Build ();
+	}
 }

--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -341,5 +341,19 @@ partial class GtkExtensions
 			return false;
 		}));
 	}
+
+	/// <summary>
+	/// Helper method for displaying a repeated tiling texture.
+	/// </summary>
+	public static void AppendRepeatingTexture (this Gtk.Snapshot snapshot, Gdk.Texture texture, Graphene.Rect bounds)
+	{
+		snapshot.PushRepeat (bounds, childBounds: null);
+
+		Graphene.Rect patternBounds = Graphene.Rect.Alloc ();
+		patternBounds.Init (0, 0, texture.Width, texture.Height);
+		snapshot.AppendTexture (texture, patternBounds);
+
+		snapshot.Pop ();
+	}
 }
 

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -163,41 +163,15 @@ public sealed class PintaCanvas : Gtk.Picture
 		QueueDraw ();
 	}
 
-	private static Gdk.Texture CreateTextureFromSurface (
-		Cairo.ImageSurface surface,
-		Gdk.Texture? updateTexture = null,
-		Cairo.Region? updateRegion = null)
-	{
-		// TODO - can we avoid copying the full image into GLib.Bytes on each update?
-		GLib.Bytes bytes = GLib.Bytes.New (surface.GetData ());
-		Gdk.MemoryTextureBuilder builder = new () {
-			Bytes = bytes,
-			Stride = (ulong) surface.Stride,
-			Width = surface.Width,
-			Height = surface.Height,
-			Format = Gdk.MemoryFormat.B8g8r8a8Premultiplied,
-			UpdateTexture = updateTexture,
-			UpdateRegion = updateRegion ?? CairoExtensions.CreateRegion (RectangleI.Zero)
-		};
-
-		return builder.Build ();
-	}
-
 	private static Gdk.Texture CreateTransparentPatternTexture () =>
-		CreateTextureFromSurface (CairoExtensions.CreateTransparentBackgroundSurface (size: 16));
+		CairoExtensions.CreateTransparentBackgroundSurface (size: 16).ToTexture ();
 
 	/// <summary>
-	/// Draw the transparent checkboard background by tiling a small pattern.
+	/// Draw the transparent checkerboard background by tiling a small pattern.
 	/// </summary>
 	private void DrawTransparentBackground (Gtk.Snapshot snapshot, Graphene.Rect canvasViewBounds)
 	{
-		snapshot.PushRepeat (canvasViewBounds, childBounds: null);
-
-		Graphene.Rect patternBounds = Graphene.Rect.Alloc ();
-		patternBounds.Init (0, 0, transparent_pattern_texture.Width, transparent_pattern_texture.Height);
-		snapshot.AppendTexture (transparent_pattern_texture, patternBounds);
-
-		snapshot.Pop ();
+		snapshot.AppendRepeatingTexture (transparent_pattern_texture, canvasViewBounds);
 	}
 
 	private void DrawCanvasTexture (Gtk.Snapshot snapshot, RectangleI? modifiedArea, Graphene.Rect canvasViewBounds)
@@ -227,7 +201,7 @@ public sealed class PintaCanvas : Gtk.Picture
 			Cairo.Region? updateRegion = (updateTexture is not null)
 				? CairoExtensions.CreateRegion (modifiedArea.Value)
 				: null;
-			canvas_texture = CreateTextureFromSurface (canvas_surface, updateTexture, updateRegion);
+			canvas_texture = canvas_surface.ToTexture (updateTexture, updateRegion);
 		}
 
 		if (canvas_texture is null)

--- a/Pinta.Resources/Resources/style.css
+++ b/Pinta.Resources/Resources/style.css
@@ -10,3 +10,7 @@
 #canvas {
     box-shadow: 0px 0px 2px 2px #7F7F7F;
 }
+
+#new-image-preview {
+    box-shadow: 0px 0px 2px 2px #7F7F7F;
+}

--- a/Pinta.Resources/Styles.cs
+++ b/Pinta.Resources/Styles.cs
@@ -2,7 +2,6 @@ namespace Pinta.Resources;
 
 public static class Styles
 {
-	public const string Canvas = "canvas";
 	public const string ToolBoxButton = "tool-box-button";
 	public const string ToolBarScale = "tool-bar-scale";
 }

--- a/Pinta/Dialogs/NewImageDialog.cs
+++ b/Pinta/Dialogs/NewImageDialog.cs
@@ -189,12 +189,7 @@ public sealed class NewImageDialog : Gtk.Dialog
 
 		Gtk.Label previewLabel = Gtk.Label.New (Translations.GetString ("Preview"));
 
-		PreviewArea previewBox = new () {
-			Vexpand = true,
-			Valign = Gtk.Align.Fill,
-			Hexpand = true,
-			Halign = Gtk.Align.Fill,
-		};
+		PreviewArea previewBox = new ();
 
 		Gtk.Box previewVbox = GtkExtensions.BoxVertical ([
 			previewLabel,
@@ -563,66 +558,73 @@ public sealed class NewImageDialog : Gtk.Dialog
 			preset_dropdown.Selected = index;
 	}
 
-	private sealed class PreviewArea : Gtk.DrawingArea
+	private sealed class PreviewArea : Gtk.Box
 	{
+		private Gtk.Picture picture;
 		private Size size;
 		private Cairo.Color color;
 
 		private const int MAX_SIZE = 250;
 
+		private static readonly Gdk.Texture transparent_pattern_texture =
+			CairoExtensions.CreateTransparentBackgroundSurface (16).ToTexture ();
+
 		public PreviewArea ()
 		{
 			WidthRequest = 300;
-			SetDrawFunc ((area, context, width, height) => Draw (context, width, height));
+			Vexpand = true;
+			Valign = Gtk.Align.Fill;
+			Hexpand = true;
+			Halign = Gtk.Align.Fill;
+
+			// Center the paintable in an expanding box so that CSS can be used to draw
+			// the drop shadow around only the canvas area.
+			picture = Gtk.Picture.New ();
+			picture.Name = "new-image-preview";
+			picture.ContentFit = Gtk.ContentFit.ScaleDown;
+			picture.Hexpand = true;
+			picture.Vexpand = true;
+			picture.Halign = Gtk.Align.Center;
+			picture.Valign = Gtk.Align.Center;
+
+			Append (picture);
 		}
 
-		public void Update (Size size)
-		{
-			this.size = size;
-			QueueDraw ();
-		}
+		public void Update (Size newSize)
+			=> Update (newSize, color);
 
-		public void Update (Cairo.Color color)
-		{
-			this.color = color;
-			QueueDraw ();
-		}
+		public void Update (Cairo.Color newColor)
+			=> Update (size, newColor);
 
-		public void Update (Size size, Cairo.Color color)
+		public void Update (Size newSize, Cairo.Color newColor)
 		{
-			this.size = size;
-			this.color = color;
-			QueueDraw ();
-		}
+			size = newSize;
+			color = newColor;
 
-		private void Draw (Cairo.Context cr, int widget_width, int widget_height)
-		{
-			Size preview_size = GetPreviewSizeForDraw ();
+			Size previewSize = GetPreviewSizeForDraw (size);
 
-			RectangleD r = new (
-				(widget_width - preview_size.Width) / 2,
-				(widget_height - preview_size.Height) / 2,
-				preview_size.Width,
-				preview_size.Height);
+			Graphene.Rect bounds = Graphene.Rect.Alloc ();
+			bounds.Init (0, 0, previewSize.Width, previewSize.Height);
+
+			Gtk.Snapshot snapshot = Gtk.Snapshot.New ();
 
 			if (color.A == 0) {
 				// Fill with transparent checkerboard pattern
-				Cairo.Pattern pattern = CairoExtensions.CreateTransparentBackgroundPattern (16);
-				cr.FillRectangle (r, pattern);
+				snapshot.AppendRepeatingTexture (transparent_pattern_texture, bounds);
 			} else {
 				// Fill with selected color
-				cr.FillRectangle (r, color);
+				snapshot.AppendColor (color.ToGdkRGBA (), bounds);
 			}
 
-			// Draw our canvas drop shadow
-			cr.DrawRectangle (new RectangleD (r.X - 1, r.Y - 1, r.Width + 2, r.Height + 2), new Cairo.Color (.5, .5, .5), 1);
-			cr.DrawRectangle (new RectangleD (r.X - 2, r.Y - 2, r.Width + 4, r.Height + 4), new Cairo.Color (.8, .8, .8), 1);
-			cr.DrawRectangle (new RectangleD (r.X - 3, r.Y - 3, r.Width + 6, r.Height + 6), new Cairo.Color (.9, .9, .9), 1);
-
-			cr.Dispose ();
+			Gdk.Paintable? paintable = snapshot.ToPaintable (size: null);
+			if (paintable is not null)
+				picture.Paintable = paintable;
 		}
 
-		private Size GetPreviewSizeForDraw () // Figure out the dimensions of the preview to draw
+		/// <summary>
+		/// Figure out the dimensions of the preview to draw
+		/// </summary>
+		private static Size GetPreviewSizeForDraw (Size size)
 		{
 			if (size.Width <= MAX_SIZE && size.Height <= MAX_SIZE)
 				return size;


### PR DESCRIPTION
- Port to modern GTK widget rendering, using Gtk.Snapshot rather than cairo drawing area, and using CSS to add the border shadow

- Extract utility methods from the canvas widget for converting a Cairo surface to a Gdk.Texture, and for rendering a repeated tiled texture. This makes it easy to render checkerboard patterns which are used in several widgets.

- Remove unused constant from Styles.cs, which is for CSS classes that are used in several places, rather than object ids