### PR TITLE
feat: add quality configuration for saving WebP images

### DIFF
--- a/Pinta.Core/ImageFormats/WebPFormat.cs
+++ b/Pinta.Core/ImageFormats/WebPFormat.cs
@@ -1,0 +1,36 @@
+using System;
+
+using GdkPixbuf;
+
+namespace Pinta.Core;
+
+public sealed class WebPFormat : GdkPixbufFormat
+{
+	private const int DefaultQuality = 80;
+
+	public WebPFormat ()
+		: base ("webp")
+	{
+	}
+
+	protected override void DoSave (Pixbuf pb, Gio.File file, string fileType, Gtk.Window parent)
+	{
+		int level = PintaCore.Settings.GetSetting<int> (SettingNames.WEBP_QUALITY, DefaultQuality);
+
+		if (!PintaCore.Workspace.ActiveDocument.HasBeenSavedInSession) {
+			level = PintaCore.Actions.File.RaiseModifyCompression (level, parent);
+
+			if (level == -1)
+				throw new OperationCanceledException ();
+		}
+
+		PintaCore.Settings.PutSetting (SettingNames.WEBP_QUALITY, level);
+
+		using var stream = file.Replace ();
+		try {
+			pb.SaveToStreamv (stream, fileType, ["quality"], [level.ToString ()], null);
+		} finally {
+			stream.Close (null);
+		}
+	}
+}

--- a/Pinta.Core/Managers/ImageConverterManager.cs
+++ b/Pinta.Core/Managers/ImageConverterManager.cs
@@ -87,6 +87,8 @@ public sealed class ImageConverterManager
 		IImageExporter? exporter;
 		if (formatName == "jpeg")
 			exporter = importer = new JpegFormat ();
+		else if (formatName == "webp")
+			exporter = importer = new WebPFormat ();
 		else if (formatName == "tga")
 			exporter = new TgaExporter ();
 		else if (format.IsWritable ())

--- a/Pinta.Core/SettingNames.cs
+++ b/Pinta.Core/SettingNames.cs
@@ -6,6 +6,8 @@ internal static class SettingNames
 
 	internal const string JPG_QUALITY = "jpg-quality";
 
+	internal const string WEBP_QUALITY = "webp-quality";
+
 	internal const string SELECTION_COMBINE_MODE = "selection-combine-mode";
 
 	internal const string SHOW_CANVAS_GRID = "show-canvas-grid";

--- a/Pinta/Actions/File/ModifyCompressionAction.cs
+++ b/Pinta/Actions/File/ModifyCompressionAction.cs
@@ -48,7 +48,7 @@ internal sealed class ModifyCompressionAction : IActionHandler
 
 	private void Activated (object? sender, ModifyCompressionEventArgs e)
 	{
-		JpegCompressionDialog dlg = new (e.Quality, e.ParentWindow);
+		QualityDialog dlg = new (e.Quality, e.ParentWindow);
 
 		if (dlg.RunBlocking () == Gtk.ResponseType.Ok)
 			e.Quality = dlg.CompressionLevel;

--- a/Pinta/Dialogs/JpegCompressionDialog.cs
+++ b/Pinta/Dialogs/JpegCompressionDialog.cs
@@ -43,7 +43,7 @@ public sealed class JpegCompressionDialog : Gtk.Dialog
 
 		// --- Initialization (Gtk.Window)
 
-		Title = Translations.GetString ("JPEG Quality");
+		Title = Translations.GetString ("Image Quality");
 		TransientFor = parent;
 		Modal = true;
 

--- a/Pinta/Dialogs/QualityDialog.cs
+++ b/Pinta/Dialogs/QualityDialog.cs
@@ -1,6 +1,6 @@
-// 
-// JpegCompressionDialog.cs
-//  
+//
+// QualityDialog.cs
+//
 // Author:
 //       Maia Kozheva <sikon@ubuntu.com>
 // 
@@ -28,11 +28,11 @@ using Pinta.Core;
 
 namespace Pinta;
 
-public sealed class JpegCompressionDialog : Gtk.Dialog
+public sealed class QualityDialog : Gtk.Dialog
 {
 	private readonly Gtk.Scale compression_level;
 
-	public JpegCompressionDialog (int defaultQuality, Gtk.Window parent)
+	public QualityDialog (int defaultQuality, Gtk.Window parent)
 	{
 		Gtk.Label qualityLabel = Gtk.Label.New (Translations.GetString ("Quality: "));
 		qualityLabel.Xalign = 0;


### PR DESCRIPTION
Adds quality dialog for WebP saves following the JPEG pattern. Closes #1571.

This contribution was developed with AI assistance (Claude Code).