### PR TITLE
Disable selection in the toolbox widget's flowbox

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -14,6 +14,7 @@ public sealed class ToolBoxWidget : Gtk.FlowBox
 		SetOrientation (Gtk.Orientation.Vertical);
 		MinChildrenPerLine = 8; // Pinta 3 has 22 default tools, meaning a max of 3 columns regardless of size, smaller values don't lead to better use of visual space.
 		MaxChildrenPerLine = 1024; // Allow for single column if there's sufficient space to do so.
+		SelectionMode = Gtk.SelectionMode.None; // Don't allow the buttons to be selected.
 
 		// --- References to keep
 


### PR DESCRIPTION
The flowbox defaults to allowing single-selection, which is confusing here since it can make a tool look like it's active

Fixes: #1369