### PR TITLE
[History] Match text for layer visibility toggle for checkbox and dialog

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/Layers/LayersListViewItemWidget.cs
@@ -97,7 +97,7 @@ public sealed partial class LayersListViewItem
 
 		UpdateLayerPropertiesHistoryItem historyItem = new (
 			visible ? Resources.StandardIcons.ViewReveal : Resources.StandardIcons.ViewConceal,
-			visible ? Translations.GetString ("Layer Shown") : Translations.GetString ("Layer Hidden"),
+			visible ? Translations.GetString ("Show Layer") : Translations.GetString ("Hide Layer"),
 			doc.Layers.IndexOf (UserLayer),
 			initial,
 			updated);

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -113,7 +113,7 @@ internal sealed class LayerPropertiesAction : IActionHandler
 		}
 
 		if (updated.Hidden != initial.Hidden) {
-			ret = (updated.Hidden) ? Translations.GetString ("Hide Layer") : Translations.GetString ("Show Layer");
+			ret = (updated.Hidden) ? Translations.GetString ("Layer Hidden") : Translations.GetString ("Layer Shown");
 			count++;
 		}
 

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -113,7 +113,7 @@ internal sealed class LayerPropertiesAction : IActionHandler
 		}
 
 		if (updated.Hidden != initial.Hidden) {
-			ret = (updated.Hidden) ? Translations.GetString ("Layer Hidden") : Translations.GetString ("Layer Shown");
+			ret = (updated.Hidden) ? Translations.GetString ("Hide Layer") : Translations.GetString ("Show Layer");
 			count++;
 		}
 

--- a/Pinta/Actions/Layers/LayerPropertiesAction.cs
+++ b/Pinta/Actions/Layers/LayerPropertiesAction.cs
@@ -62,14 +62,7 @@ internal sealed class LayerPropertiesAction : IActionHandler
 			Gtk.ResponseType response = await dialog.RunAsync ();
 
 			if (response == Gtk.ResponseType.Ok && dialog.AreLayerPropertiesUpdated) {
-
-				string historyMessage = GetLayerPropertyUpdateMessage (
-					dialog.InitialLayerProperties,
-					dialog.UpdatedLayerProperties);
-
-				UpdateLayerPropertiesHistoryItem historyItem = new (
-					Resources.Icons.LayerProperties,
-					historyMessage,
+				UpdateLayerPropertiesHistoryItem historyItem = GetLayerUpdateHistoryItem (
 					active.Layers.CurrentUserLayerIndex,
 					dialog.InitialLayerProperties,
 					dialog.UpdatedLayerProperties);
@@ -77,9 +70,7 @@ internal sealed class LayerPropertiesAction : IActionHandler
 				active.History.PushNewItem (historyItem);
 
 				workspace.ActiveWorkspace.Invalidate ();
-
 			} else {
-
 				Layer layer = active.Layers.CurrentUserLayer;
 				Layer selectionLayer = active.Layers.SelectionLayer;
 				LayerProperties initial = dialog.InitialLayerProperties;
@@ -96,30 +87,39 @@ internal sealed class LayerPropertiesAction : IActionHandler
 		}
 	}
 
-	private static string GetLayerPropertyUpdateMessage (LayerProperties initial, LayerProperties updated)
+	private static UpdateLayerPropertiesHistoryItem GetLayerUpdateHistoryItem (
+		int layer,
+		LayerProperties initial,
+		LayerProperties updated)
 	{
 
-		string? ret = null;
+		string? message = null;
+		string icon = Resources.Icons.LayerProperties;
 		int count = 0;
 
 		if (updated.Opacity != initial.Opacity) {
-			ret = Translations.GetString ("Layer Opacity");
+			message = Translations.GetString ("Layer Opacity");
+			icon = Resources.Icons.LayerProperties;
 			count++;
 		}
 
 		if (updated.Name != initial.Name) {
-			ret = Translations.GetString ("Rename Layer");
+			message = Translations.GetString ("Rename Layer");
+			icon = Resources.Icons.LayerProperties;
 			count++;
 		}
 
 		if (updated.Hidden != initial.Hidden) {
-			ret = (updated.Hidden) ? Translations.GetString ("Hide Layer") : Translations.GetString ("Show Layer");
+			message = initial.Hidden ? Translations.GetString ("Show Layer") : Translations.GetString ("Hide Layer");
+			icon = initial.Hidden ? Resources.StandardIcons.ViewReveal : Resources.StandardIcons.ViewConceal;
 			count++;
 		}
 
-		if (ret == null || count > 1)
-			ret = Translations.GetString ("Layer Properties");
+		if (message == null || count > 1) {
+			message = Translations.GetString ("Layer Properties");
+			icon = Resources.Icons.LayerProperties;
+		}
 
-		return ret;
+		return new UpdateLayerPropertiesHistoryItem (icon, message, layer, initial, updated);
 	}
 }


### PR DESCRIPTION
Toggling the layer visibility with the dialog and the checkbox created different history strings. Not sure which of those is the best string to use, so making this a draft.

<img width="302" height="195" alt="image" src="https://github.com/user-attachments/assets/2eb53c46-b0a4-458e-9663-ee1612e79cc1" />

We should also refactor this to make this be defined only once, to avoid duplication and future mismatches. I also need to the patch the icon before merging.

Continuation of #2098 (which I only noticed today)