### PR TITLE
[Shape Tool] Adds overridable BuildToolSpecificToolbar method

### DIFF
--- a/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/ArrowedEditEngine.cs
@@ -83,9 +83,9 @@ public abstract class ArrowedEditEngine : BaseEditEngine
 			settings.PutSetting (SettingNames.ArrowLength (toolPrefix), arrow_length_offset.GetValueAsInt ());
 	}
 
-	public override void HandleBuildToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
+	protected override void BuildShapeToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
 	{
-		base.HandleBuildToolBar (tb, settings, toolPrefix);
+		base.BuildShapeToolBar (tb, settings, toolPrefix);
 
 		this.settings = settings;
 		tool_prefix = toolPrefix;

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -314,6 +314,8 @@ public abstract class BaseEditEngine
 
 		tb.Append (shape_type_button);
 
+		BuildToolSpecificToolbar (tb, settings, toolPrefix);
+
 		fill_sep ??= GtkExtensions.CreateToolBarSeparator ();
 
 		tb.Append (fill_sep);
@@ -399,6 +401,8 @@ public abstract class BaseEditEngine
 			DrawActiveShape (false, false, true, false, false);
 		};
 	}
+
+	protected virtual void BuildToolSpecificToolbar (Gtk.Box tb, ISettingsService settings, string toolPrefix) {}
 
 	public virtual void HandleActivated ()
 	{

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -402,7 +402,7 @@ public abstract class BaseEditEngine
 		};
 	}
 
-	protected virtual void BuildToolSpecificToolbar (Gtk.Box tb, ISettingsService settings, string toolPrefix) {}
+	protected virtual void BuildToolSpecificToolbar (Gtk.Box tb, ISettingsService settings, string toolPrefix) { }
 
 	public virtual void HandleActivated ()
 	{

--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -259,7 +259,7 @@ public abstract class BaseEditEngine
 			settings.PutSetting (SettingNames.DashPattern (toolPrefix), dash_pattern_box.ComboBox.ComboBox.GetActiveText ()!);
 	}
 
-	public virtual void HandleBuildToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
+	public void HandleBuildToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
 	{
 		if (shape_type_label == null) {
 			string shapeTypeText = Translations.GetString ("Shape Type");
@@ -314,8 +314,11 @@ public abstract class BaseEditEngine
 
 		tb.Append (shape_type_button);
 
-		BuildToolSpecificToolbar (tb, settings, toolPrefix);
+		BuildShapeToolBar (tb, settings, toolPrefix);
+	}
 
+	protected virtual void BuildShapeToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
+	{
 		fill_sep ??= GtkExtensions.CreateToolBarSeparator ();
 
 		tb.Append (fill_sep);
@@ -401,8 +404,6 @@ public abstract class BaseEditEngine
 			DrawActiveShape (false, false, true, false, false);
 		};
 	}
-
-	protected virtual void BuildToolSpecificToolbar (Gtk.Box tb, ISettingsService settings, string toolPrefix) { }
 
 	public virtual void HandleActivated ()
 	{

--- a/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
@@ -75,10 +75,7 @@ public sealed class RoundedLineEditEngine : BaseEditEngine
 			settings.PutSetting (SettingNames.Radius (toolPrefix), (int) radius.Value);
 	}
 
-	protected override void BuildToolSpecificToolbar (
-		Gtk.Box tb,
-		ISettingsService settings,
-		string toolPrefix)
+	protected override void BuildShapeToolBar (Gtk.Box tb, ISettingsService settings, string toolPrefix)
 	{
 		radius_sep ??= GtkExtensions.CreateToolBarSeparator ();
 
@@ -86,7 +83,7 @@ public sealed class RoundedLineEditEngine : BaseEditEngine
 
 		if (radius_label == null) {
 			var radiusText = Translations.GetString ("Radius");
-			radius_label = Gtk.Label.New ($"  {radiusText}: ");
+			radius_label = Gtk.Label.New ($"{radiusText}: ");
 		}
 
 		tb.Append (radius_label);
@@ -101,6 +98,8 @@ public sealed class RoundedLineEditEngine : BaseEditEngine
 		}
 
 		tb.Append (radius);
+
+		base.BuildShapeToolBar (tb, settings, toolPrefix);
 	}
 
 	private readonly IWorkspaceService workspace;

--- a/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/RoundedLineEditEngine.cs
@@ -75,13 +75,11 @@ public sealed class RoundedLineEditEngine : BaseEditEngine
 			settings.PutSetting (SettingNames.Radius (toolPrefix), (int) radius.Value);
 	}
 
-	public override void HandleBuildToolBar (
+	protected override void BuildToolSpecificToolbar (
 		Gtk.Box tb,
 		ISettingsService settings,
 		string toolPrefix)
 	{
-		base.HandleBuildToolBar (tb, settings, toolPrefix);
-
 		radius_sep ??= GtkExtensions.CreateToolBarSeparator ();
 
 		tb.Append (radius_sep);

--- a/Pinta.Tools/Tools/FreeformShapeTool.cs
+++ b/Pinta.Tools/Tools/FreeformShapeTool.cs
@@ -54,9 +54,9 @@ public sealed class FreeformShapeTool : BaseBrushTool
 
 	protected override void OnBuildToolBar (Box tb)
 	{
-		tb.Append (Separator);
 		tb.Append (FillLabel);
 		tb.Append (FillDropDown);
+		tb.Append (Separator);
 		base.OnBuildToolBar (tb);
 
 		// TODO: This could be cleaner.


### PR DESCRIPTION
The idea is to allow shape tools to include toolbar items before the stroke controls, which can disappear and would behave better when at the end of the toolbar. One example is the Rounded Rectangle tool, that now has the Radius property right at the start, but just after the Shape Type dropdown.

I thought about only making the Stroke/Dash settings separate, but that would mean all implementations would have to call it anyway, so an optional overridable method seemed like a better choice.

Also fixes the Separator in the Freeform Shape Tool.

Closes #2012.