### PR TITLE
Adds F12 shortcut for toggling the side panel visibility

### DIFF
--- a/Pinta.Core/Actions/Command.cs
+++ b/Pinta.Core/Actions/Command.cs
@@ -91,14 +91,16 @@ public sealed class ToggleCommand : Command
 		string name,
 		string label,
 		string? tooltip,
-		string? stock_id
+		string? stock_id,
+		IReadOnlyList<string>? shortcuts = null
 	)
 		: base (
 			name,
 			label,
 			tooltip,
 			stock_id,
-			GLib.Variant.NewBoolean (false)
+			GLib.Variant.NewBoolean (false),
+			shortcuts
 		)
 	{
 		Activated += (_, _) => {

--- a/Pinta.Core/Actions/ViewActions.cs
+++ b/Pinta.Core/Actions/ViewActions.cs
@@ -117,7 +117,8 @@ public sealed class ViewActions
 			"ToolWindows",
 			Translations.GetString ("Tool Windows"),
 			null,
-			null);
+			null,
+			shortcuts: ["F12"]);
 
 		EditCanvasGrid = new Command (
 			"EditCanvasGrid",


### PR DESCRIPTION
Sometimes, we want to see the whole picture, and the side panels can get in the way, specially when zoomed in. This makes it easier to quickly toggle their visibility, as we avoid having to go to View > Show/Hide > Tool Windows.

We have many other programs that also do the same with the F12 key, as every browser uses it to show/hide the devtools, and Inkscape also does the same with their side panels (which they call Dialogs), so users should feel at home.

This was something I proposed on #1471, but didn't open a separate issue at the time:

> Also, Inkscape has shortcuts for hiding the toolbar (Shift+F11) and side panels (F12), maybe if we implement something similar here (which would be good for quickly looking at the canvas without distractions), then they'd fit pretty well on the View menu, as F11 fullscreen is already there, for example.
> 
> _Originally posted by @pedropaulosuzuki in https://github.com/PintaProject/Pinta/issues/1471#issuecomment-2899570164_

This patch also allows us to add shortcuts to ToggleCommands, as before it lacked a parameter in the constructor to pass it to the base Command constructor.