### PR TITLE
Configure menu buttons to show traditional submenus without sliding

### DIFF
--- a/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
+++ b/Pinta.Core/Extensions/Gtk/GtkExtensions.Widget.cs
@@ -171,6 +171,22 @@ partial class GtkExtensions
 		return spin;
 	}
 
+	/// <summary>
+	/// Creates a Gtk.MenuButton with the popover configured to show regular nested
+	/// menus rather than sliding menus.
+	/// </summary>
+	public static Gtk.MenuButton CreateMenuButton (Gio.MenuModel model, string iconName, string? tooltip = null)
+	{
+		Gtk.PopoverMenu popover = Gtk.PopoverMenu.NewFromModelFull (model, Gtk.PopoverMenuFlags.Nested);
+
+		Gtk.MenuButton menu = Gtk.MenuButton.New ();
+		menu.Popover = popover;
+		menu.IconName = iconName;
+		menu.TooltipText = tooltip;
+
+		return menu;
+	}
+
 	public static Gtk.Scale CreateToolBarSlider (
 		int min,
 		int max,

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -434,38 +434,33 @@ internal sealed class MainWindow
 	private void CreateMainToolBar ()
 	{
 		if (window_shell.HeaderBar is not null) {
-			var header_bar = window_shell.HeaderBar;
-			header_bar.PackEnd (new Gtk.MenuButton () {
-				MenuModel = this.menu_bar,
-				IconName = Resources.StandardIcons.OpenMenu,
-				TooltipText = Translations.GetString ("Main Menu"),
-			});
+			var headerBar = window_shell.HeaderBar;
+			headerBar.PackEnd (GtkExtensions.CreateMenuButton (
+				this.menu_bar,
+				Resources.StandardIcons.OpenMenu,
+				Translations.GetString ("Main Menu")));
 
-			header_bar.PackEnd (new Gtk.MenuButton () {
-				MenuModel = PintaCore.Chrome.EffectsMenu,
-				IconName = Resources.Icons.EffectsDefault,
-				TooltipText = Translations.GetString ("Effects"),
-			});
+			headerBar.PackEnd (GtkExtensions.CreateMenuButton (
+				PintaCore.Chrome.EffectsMenu,
+				Resources.Icons.EffectsDefault,
+				Translations.GetString ("Effects")));
 
-			header_bar.PackEnd (new Gtk.MenuButton () {
-				MenuModel = PintaCore.Chrome.AdjustmentsMenu,
-				IconName = Resources.Icons.AdjustmentsDefault,
-				TooltipText = Translations.GetString ("Adjustments"),
-			});
+			headerBar.PackEnd (GtkExtensions.CreateMenuButton (
+				PintaCore.Chrome.AdjustmentsMenu,
+				Resources.Icons.AdjustmentsDefault,
+				Translations.GetString ("Adjustments")));
 
-			header_bar.PackEnd (new Gtk.MenuButton () {
-				MenuModel = this.image_menu,
-				IconName = Resources.StandardIcons.ImageGeneric,
-				TooltipText = Translations.GetString ("Image"),
-			});
+			headerBar.PackEnd (GtkExtensions.CreateMenuButton (
+				this.image_menu,
+				Resources.StandardIcons.ImageGeneric,
+				Translations.GetString ("Image")));
 
-			header_bar.PackEnd (new Gtk.MenuButton () {
-				MenuModel = this.view_menu,
-				IconName = Resources.StandardIcons.ViewReveal,
-				TooltipText = Translations.GetString ("View"),
-			});
+			headerBar.PackEnd (GtkExtensions.CreateMenuButton (
+				this.view_menu,
+				Resources.StandardIcons.ViewReveal,
+				Translations.GetString ("View")));
 
-			PintaCore.Actions.CreateHeaderToolBar (header_bar);
+			PintaCore.Actions.CreateHeaderToolBar (headerBar);
 		} else {
 			var main_toolbar = window_shell.CreateToolBar ("main_toolbar");
 			PintaCore.Actions.CreateToolBar (main_toolbar);

--- a/Pinta/Pads/LayersPad.cs
+++ b/Pinta/Pads/LayersPad.cs
@@ -1,21 +1,21 @@
-// 
+//
 // LayersPad.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2011 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -63,10 +63,8 @@ internal sealed class LayersPad : IDockPad
 		hamburger_menu.AppendSection (null, flip_section);
 		hamburger_menu.AppendSection (null, prop_section);
 
-		Gtk.MenuButton hamburger_button = new Gtk.MenuButton () {
-			MenuModel = hamburger_menu,
-			IconName = Resources.StandardIcons.OpenMenu
-		};
+		Gtk.MenuButton hamburger_button = GtkExtensions.CreateMenuButton (
+			hamburger_menu, Resources.StandardIcons.OpenMenu);
 
 		hamburger_button.Direction = Gtk.ArrowType.Up;
 


### PR DESCRIPTION
This makes it easier to browse through nested menus like the effects without annoying sliding and extra clicks to go back. The only minor annoyance is that the menus sometimes pop out to the left side, depending on available space if Pinta's window is near the right edge, but overall it feels nicer IMO

<img width="386" height="615" alt="menus" src="https://github.com/user-attachments/assets/bb1d83f0-e4e8-4df7-9ab7-b00c4fd172a4" />
