### PR TITLE
[Brush tool] Fix tooltip text

### DIFF
--- a/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
+++ b/Pinta.Tools/Editable/EditEngines/BaseEditEngine.cs
@@ -369,8 +369,8 @@ public abstract class BaseEditEngine
 			);
 			outline_width.TooltipText = Translations.GetString ("Change outline width.") + "\n"
 				+ "\n" + Translations.GetString ("Shortcut keys:")
-				+ "\n" + Translations.GetString ("Press {0} to decrease outline size", "\"[\"")
-				+ "\n" + Translations.GetString ("Press {0} to increase outline size", "\"]\"");
+				+ "\n" + Translations.GetString ("Press {0} to decrease outline width", "\"[\"")
+				+ "\n" + Translations.GetString ("Press {0} to increase outline width", "\"]\"");
 
 			outline_width.OnValueChanged += (o, e) => {
 

--- a/Pinta.Tools/Tools/BaseBrushTool.cs
+++ b/Pinta.Tools/Tools/BaseBrushTool.cs
@@ -46,8 +46,8 @@ public abstract class BaseBrushTool : BaseTool
 
 		BrushWidthSpinButton.TooltipText = Translations.GetString ("Change brush width.") + "\n"
 			+ "\n" + Translations.GetString ("Shortcut keys:")
-			+ "\n" + Translations.GetString ("Press {0} to decrease brush size", "\"[\"")
-			+ "\n" + Translations.GetString ("Press {0} to increase brush size", "\"]\"");
+			+ "\n" + Translations.GetString ("Press {0} to decrease brush width", "\"[\"")
+			+ "\n" + Translations.GetString ("Press {0} to increase brush width", "\"]\"");
 		BrushWidthSpinButton.OnValueChanged += (_, _) => OnBrushWidthChanged ();
 	}
 


### PR DESCRIPTION
> On the translation website there was a question (`what is the distinction between brush size and brush width`) which pointed out that we're using inconsistent words between the labels and the tooltips.
> 
> Any thoughts on which one we should pick?
I'd be inclined to use "width" everywhere since that's the existing user-facing label

_Originally posted by @cameronwhite in https://github.com/PintaProject/Pinta/issues/2112#issuecomment-4366514621_