### PR TITLE
Fix bug where AddNewLayer() emitted a LayerAdded event with the wrong index

### DIFF
--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -393,9 +393,6 @@ public sealed class LayerActions
 
 		UserLayer l = doc.Layers.AddNewLayer (string.Empty);
 
-		// Make new layer the current layer
-		doc.Layers.SetCurrentUserLayer (l);
-
 		AddLayerHistoryItem hist = new (
 			Resources.Icons.LayerNew,
 			Translations.GetString ("Add New Layer"),

--- a/Pinta.Core/Classes/DocumentLayers.cs
+++ b/Pinta.Core/Classes/DocumentLayers.cs
@@ -82,7 +82,7 @@ public sealed class DocumentLayers
 
 	/// <summary>
 	/// Creates a new layer and adds it to the Layer collection after the
-	/// currently selected layer.
+	/// currently selected layer, making it the new selected layer.
 	/// </summary>
 	public UserLayer AddNewLayer (string name)
 	{
@@ -91,14 +91,12 @@ public sealed class DocumentLayers
 			? CreateLayer ()
 			: CreateLayer (name);
 
-		user_layers.Insert (CurrentUserLayerIndex + 1, layer);
-
-		if (user_layers.Count == 1)
-			CurrentUserLayerIndex = 0;
+		user_layers.Insert (++CurrentUserLayerIndex, layer);
 
 		layer.PropertyChanged += RaiseLayerPropertyChangedEvent;
 
-		LayerAdded?.Invoke (this, new IndexEventArgs (user_layers.Count - 1));
+		LayerAdded?.Invoke (this, new IndexEventArgs (CurrentUserLayerIndex));
+		SelectedLayerChanged?.Invoke (this, EventArgs.Empty);
 
 		return layer;
 	}
@@ -218,6 +216,7 @@ public sealed class DocumentLayers
 		layer.PropertyChanged += RaiseLayerPropertyChangedEvent;
 
 		LayerAdded?.Invoke (this, new IndexEventArgs (CurrentUserLayerIndex));
+		SelectedLayerChanged?.Invoke (this, EventArgs.Empty);
 
 		return layer;
 	}

--- a/Pinta/Actions/Edit/PasteAction.cs
+++ b/Pinta/Actions/Edit/PasteAction.cs
@@ -1,22 +1,22 @@
-// 
+//
 // PasteAction.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
 //       Cameron White <cameronwhite91@gmail.com>
-// 
+//
 // Copyright (c) 2012 Jonathan Pobst, Cameron White
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -170,7 +170,6 @@ internal sealed class PasteAction : IActionHandler
 		// layer and record it's creation in the history
 		if (toNewLayer) {
 			var l = doc.Layers.AddNewLayer (string.Empty);
-			doc.Layers.SetCurrentUserLayer (l);
 			paste_action.Push (new AddLayerHistoryItem (Resources.Icons.LayerNew, Translations.GetString ("Add New Layer"), doc.Layers.IndexOf (l)));
 		}
 


### PR DESCRIPTION
The event was always fired with the index of the topmost layer, which is wrong if a different layer is selected. Also refactored a bit so that this method updates the selected layer and emits an event for the selection change , to be consistent with DuplicateLayer()

Since the layers list view uses this index to create list items which hold a reference to the UserLayer, the new item in the list would be referencing the wrong layer. In the bug report, this was why the third layer showed up with the name "Layer 2" rather than "Layer 3", and eventually led to the crash after layer 2 was removed.

Fixes: #2129