### PR TITLE
Restore missing default palette colors

### DIFF
--- a/Pinta.Core/Extensions/PaletteHelper.cs
+++ b/Pinta.Core/Extensions/PaletteHelper.cs
@@ -69,45 +69,59 @@ public static class PaletteHelper
 		yield return new (48 / 255f, 48 / 255f, 48 / 255f);
 
 		yield return new (255 / 255f, 0 / 255f, 0 / 255f);
+		yield return new (127 / 255f, 0 / 255f, 0 / 255f);
 		yield return new (255 / 255f, 127 / 255f, 127 / 255f);
 
 		yield return new (255 / 255f, 106 / 255f, 0 / 255f);
+		yield return new (127 / 255f, 51 / 255f, 0 / 255f);
 		yield return new (255 / 255f, 178 / 255f, 127 / 255f);
 
 		yield return new (255 / 255f, 216 / 255f, 0 / 255f);
+		yield return new (127 / 255f, 106 / 255f, 0 / 255f);
 		yield return new (255 / 255f, 233 / 255f, 127 / 255f);
 
 		yield return new (182 / 255f, 255 / 255f, 0 / 255f);
+		yield return new (91 / 255f, 127 / 255f, 0 / 255f);
 		yield return new (218 / 255f, 255 / 255f, 127 / 255f);
 
 		yield return new (76 / 255f, 255 / 255f, 0 / 255f);
+		yield return new (38 / 255f, 127 / 255f, 0 / 255f);
 		yield return new (165 / 255f, 255 / 255f, 127 / 255f);
 
 		yield return new (0 / 255f, 255 / 255f, 33 / 255f);
+		yield return new (0 / 255f, 127 / 255f, 14 / 255f);
 		yield return new (127 / 255f, 255 / 255f, 142 / 255f);
 
 		yield return new (0 / 255f, 255 / 255f, 144 / 255f);
+		yield return new (0 / 255f, 127 / 255f, 70 / 255f);
 		yield return new (127 / 255f, 255 / 255f, 197 / 255f);
 
 		yield return new (0 / 255f, 255 / 255f, 255 / 255f);
+		yield return new (0 / 255f, 127 / 255f, 127 / 255f);
 		yield return new (127 / 255f, 255 / 255f, 255 / 255f);
 
 		yield return new (0 / 255f, 148 / 255f, 255 / 255f);
+		yield return new (0 / 255f, 74 / 255f, 127 / 255f);
 		yield return new (127 / 255f, 201 / 255f, 255 / 255f);
 
 		yield return new (0 / 255f, 38 / 255f, 255 / 255f);
+		yield return new (0 / 255f, 19 / 255f, 127 / 255f);
 		yield return new (127 / 255f, 146 / 255f, 255 / 255f);
 
 		yield return new (72 / 255f, 0 / 255f, 255 / 255f);
+		yield return new (33 / 255f, 0 / 255f, 127 / 255f);
 		yield return new (161 / 255f, 127 / 255f, 255 / 255f);
 
 		yield return new (178 / 255f, 0 / 255f, 255 / 255f);
+		yield return new (87 / 255f, 0 / 255f, 127 / 255f);
 		yield return new (214 / 255f, 127 / 255f, 255 / 255f);
 
 		yield return new (255 / 255f, 0 / 255f, 220 / 255f);
+		yield return new (127 / 255f, 0 / 255f, 110 / 255f);
 		yield return new (255 / 255f, 127 / 255f, 237 / 255f);
 
 		yield return new (255 / 255f, 0 / 255f, 110 / 255f);
+		yield return new (127 / 255f, 0 / 255f, 55 / 255f);
 		yield return new (255 / 255f, 127 / 255f, 182 / 255f);
 	}
 }

--- a/tests/Pinta.Core.Tests/PaletteHelperTests.cs
+++ b/tests/Pinta.Core.Tests/PaletteHelperTests.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace Pinta.Core.Tests;
+
+[TestFixture]
+internal sealed class PaletteHelperTests
+{
+	[Test]
+	public void DefaultPaletteHasExpectedColorCount ()
+	{
+		Assert.That (PaletteHelper.EnumerateDefaultColors ().Count (), Is.EqualTo (48));
+	}
+}


### PR DESCRIPTION
This restores the 14 darker colors that were missing from the default palette, bringing `PaletteHelper.EnumerateDefaultColors()` back to 48 colors.

The restored colors are inserted alongside their matching hue groups so the palette remains ordered consistently with the current layout while recovering the older default palette coverage.

A focused unit test was added to verify that the default palette contains 48 colors.

Fixes #812.

Tested:
- `dotnet test tests/Pinta.Core.Tests/Pinta.Core.Tests.csproj --filter DefaultPaletteHasExpectedColorCount`

This PR was prepared with AI assistance using OpenAI Codex and manually reviewed before submission.