### PR TITLE
Fix "Operation not supported" error when dragging and dropping files on macOS (#2124)

### DIFF
--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -605,7 +605,17 @@ internal sealed class MainWindow
 		if (args.Value.GetBoxed (Gdk.FileList.GetGType ()) is not Gdk.FileList file_list)
 			return false;
 
-		foreach (Gio.File file in file_list.GetFilesHelper ()) {
+		foreach (Gio.File file_dropped in file_list.GetFilesHelper ()) {
+			Gio.File file = file_dropped;
+
+			// On macOS, GTK4 pasteboard currently provides malformed URIs where the scheme is URL-encoded
+			// (e.g., "file%3A///" instead of "file:///"). Because of this, GIO fails to recognize it as a local file.
+			string parseName = file_dropped.GetParseName ();
+			if (parseName.StartsWith ("file%3A///", StringComparison.OrdinalIgnoreCase)) {
+				string decodedUri = Uri.UnescapeDataString (parseName);
+				file = Gio.FileHelper.NewForUri (decodedUri);
+			}
+
 			PintaCore.Workspace.OpenFile (file);
 
 			if (file.GetUriScheme () is string scheme &&

--- a/Pinta/MainWindow.cs
+++ b/Pinta/MainWindow.cs
@@ -610,6 +610,7 @@ internal sealed class MainWindow
 
 			// On macOS, GTK4 pasteboard currently provides malformed URIs where the scheme is URL-encoded
 			// (e.g., "file%3A///" instead of "file:///"). Because of this, GIO fails to recognize it as a local file.
+			// This was fixed in GTK 4.23.1, so this workaround can be removed once Pinta requires GTK >= 4.23.1.
 			string parseName = file_dropped.GetParseName ();
 			if (parseName.StartsWith ("file%3A///", StringComparison.OrdinalIgnoreCase)) {
 				string decodedUri = Uri.UnescapeDataString (parseName);


### PR DESCRIPTION
Fixes a bug where dragging and dropping a local file from Finder into Pinta on macOS causes a GLib.GException: Operation not supported crash when the image importer tries to read the file.

When a file is dragged from the macOS pasteboard, the GTK4 backend provides a malformed URI where the colon in the scheme is URL-encoded (e.g., file%3A///... instead of file:///...), resulting in the "Operation not supported" exception.

 - Added logic to inspect the dropped file's ParseName. If it starts with the malformed macOS file%3A/// string, the method uses Uri.UnescapeDataString to decode it back into a valid file:/// URI.