### PR TITLE
Add window with catalog of keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Thanks to the following contributors who worked on this release:
 
 ### Changed
 - Upgraded the minimum required .NET version to 10.0 (#2081)
+- Updated dependencies to require libadwaita 1.8+
 - Effect dialogs now hide options that are not currently relevant (#1960)
 - Fixed several minor UX issues in the color dialog (#1795)
 - The text tool now provides a separate adjustment for the font size and font variant, which doesn't require opening the font dialog (#1947, #1961, #2043, #1965)

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -44,11 +44,11 @@ public sealed class AppActions
 			null,
 			Resources.StandardIcons.HelpAbout);
 		Preferences = new Command (
-			"preferences",
-			Translations.GetString ("Preferences"),
-			null,
-			"preferences-system-symbolic",
-			shortcuts: ["<Primary>comma"]);
+		        "preferences",
+		        Translations.GetString ("Keyboard Shortcuts"),
+		        null,
+		        "preferences-system-symbolic",
+		        shortcuts: ["<Primary>comma"]);
 		Exit = new Command (
 			"quit",
 			Translations.GetString ("Quit"),

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -31,7 +31,7 @@ namespace Pinta.Core;
 public sealed class AppActions
 {
 	public Command About { get; }
-	public Command Preferences { get; }
+	public Command KeyboardShortcuts { get; }
 	public Command Exit { get; }
 
 	public event EventHandler? BeforeQuit;
@@ -43,7 +43,7 @@ public sealed class AppActions
 			Translations.GetString ("About"),
 			null,
 			Resources.StandardIcons.HelpAbout);
-		Preferences = new Command (
+		KeyboardShortcuts = new Command (
 			"preferences",
 			Translations.GetString ("Keyboard Shortcuts"),
 			null,
@@ -61,7 +61,7 @@ public sealed class AppActions
 	{
 		app.AddCommands ([
 			About,
-			Preferences,
+			KeyboardShortcuts,
 			Exit]);
 	}
 

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -47,7 +47,7 @@ public sealed class AppActions
 			"preferences",
 			Translations.GetString ("Keyboard Shortcuts"),
 			null,
-			"preferences-system-symbolic",
+			Resources.StandardIcons.KeyboardShortcuts,
 			shortcuts: ["<Primary>comma"]);
 		Exit = new Command (
 			"quit",

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -31,6 +31,7 @@ namespace Pinta.Core;
 public sealed class AppActions
 {
 	public Command About { get; }
+	public Command Preferences { get; }
 	public Command Exit { get; }
 
 	public event EventHandler? BeforeQuit;
@@ -42,6 +43,12 @@ public sealed class AppActions
 			Translations.GetString ("About"),
 			null,
 			Resources.StandardIcons.HelpAbout);
+		Preferences = new Command (
+			"preferences",
+			Translations.GetString ("Preferences"),
+			null,
+			"preferences-system-symbolic",
+			shortcuts: ["<Primary>comma"]);
 		Exit = new Command (
 			"quit",
 			Translations.GetString ("Quit"),
@@ -54,6 +61,7 @@ public sealed class AppActions
 	{
 		app.AddCommands ([
 			About,
+			Preferences,
 			Exit]);
 	}
 

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -44,11 +44,11 @@ public sealed class AppActions
 			null,
 			Resources.StandardIcons.HelpAbout);
 		Preferences = new Command (
-		        "preferences",
-		        Translations.GetString ("Keyboard Shortcuts"),
-		        null,
-		        "preferences-system-symbolic",
-		        shortcuts: ["<Primary>comma"]);
+			"preferences",
+			Translations.GetString ("Keyboard Shortcuts"),
+			null,
+			"preferences-system-symbolic",
+			shortcuts: ["<Primary>comma"]);
 		Exit = new Command (
 			"quit",
 			Translations.GetString ("Quit"),

--- a/Pinta.Core/Actions/AppActions.cs
+++ b/Pinta.Core/Actions/AppActions.cs
@@ -44,7 +44,7 @@ public sealed class AppActions
 			null,
 			Resources.StandardIcons.HelpAbout);
 		KeyboardShortcuts = new Command (
-			"preferences",
+			"keyboardshortcuts",
 			Translations.GetString ("Keyboard Shortcuts"),
 			null,
 			Resources.StandardIcons.KeyboardShortcuts,

--- a/Pinta.Core/Actions/HelpActions.cs
+++ b/Pinta.Core/Actions/HelpActions.cs
@@ -72,6 +72,12 @@ public sealed class HelpActions
 	public void RegisterActions (Gtk.Application application, Gio.Menu menu)
 	{
 		menu.AppendItem (Contents.CreateMenuItem ());
+
+		if (system.OperatingSystem != OS.Mac) {
+			application.AddCommand (app.KeyboardShortcuts);
+		}
+		menu.AppendItem (app.KeyboardShortcuts.CreateMenuItem ());
+
 		menu.AppendItem (Website.CreateMenuItem ());
 		menu.AppendItem (Bugs.CreateMenuItem ());
 		menu.AppendItem (Translate.CreateMenuItem ());

--- a/Pinta.Resources/Icons.cs
+++ b/Pinta.Resources/Icons.cs
@@ -61,6 +61,8 @@ public static class StandardIcons
 	public const string ImageGeneric = "image-x-generic-symbolic";
 	public const string ImageMissing = "image-missing-symbolic";
 
+	public const string KeyboardShortcuts = "preferences-system-symbolic";
+
 	public const string LayerMoveUp = "pan-up-symbolic";
 	public const string LayerMoveDown = "pan-down-symbolic";
 

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -93,7 +93,7 @@ public sealed class ActionHandlers
 
 			// Help
 			new AboutDialogAction (actions.App, chrome, applicationVersion),
-			new PreferencesDialogAction (actions.App, actions, chrome),
+			new PreferencesDialogAction (actions.App, actions, chrome, tools),
 		];
 		// Initialize each action handler
 		foreach (var action in action_handlers)

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -93,8 +93,8 @@ public sealed class ActionHandlers
 
 			// Help
 			new AboutDialogAction (actions.App, chrome, applicationVersion),
+			new PreferencesDialogAction (actions.App, actions, chrome),
 		];
-
 		// Initialize each action handler
 		foreach (var action in action_handlers)
 			action.Initialize ();

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -95,6 +95,7 @@ public sealed class ActionHandlers
 			new AboutDialogAction (actions.App, chrome, applicationVersion),
 			new KeyboardShortcutsDialogAction (actions.App, actions, chrome, tools),
 		];
+
 		// Initialize each action handler
 		foreach (var action in action_handlers)
 			action.Initialize ();

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -93,7 +93,7 @@ public sealed class ActionHandlers
 
 			// Help
 			new AboutDialogAction (actions.App, chrome, applicationVersion),
-			new PreferencesDialogAction (actions.App, actions, chrome, tools),
+			new KeyboardShortcutsDialogAction (actions.App, actions, chrome, tools),
 		];
 		// Initialize each action handler
 		foreach (var action in action_handlers)

--- a/Pinta/Actions/Help/KeyboardShortcutsDialogAction.cs
+++ b/Pinta/Actions/Help/KeyboardShortcutsDialogAction.cs
@@ -1,5 +1,5 @@
 //
-// PreferencesDialogAction.cs
+// KeyboardShortcutsDialogAction.cs
 //
 
 using System;
@@ -9,14 +9,14 @@ using Pinta.Core;
 
 namespace Pinta.Actions;
 
-internal sealed class PreferencesDialogAction : IActionHandler
+internal sealed class KeyboardShortcutsDialogAction : IActionHandler
 {
 	private readonly AppActions app;
 	private readonly ActionManager actions;
 	private readonly ChromeManager chrome;
 	private readonly ToolManager tools;
 
-	internal PreferencesDialogAction (
+	internal KeyboardShortcutsDialogAction (
 		AppActions app,
 		ActionManager actions,
 		ChromeManager chrome,

--- a/Pinta/Actions/Help/KeyboardShortcutsDialogAction.cs
+++ b/Pinta/Actions/Help/KeyboardShortcutsDialogAction.cs
@@ -30,12 +30,12 @@ internal sealed class KeyboardShortcutsDialogAction : IActionHandler
 
 	void IActionHandler.Initialize ()
 	{
-		app.Preferences.Activated += Activated;
+		app.KeyboardShortcuts.Activated += Activated;
 	}
 
 	void IActionHandler.Uninitialize ()
 	{
-		app.Preferences.Activated -= Activated;
+		app.KeyboardShortcuts.Activated -= Activated;
 	}
 
 	private void Activated (object sender, EventArgs e)

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -66,7 +66,7 @@ internal sealed class PreferencesDialogAction : IActionHandler
 				return;
 
 			Adw.ShortcutsSection section = new ();
-			section.Title = Translations.GetString (title);
+			section.Title = title;
 
 			foreach (var cmd in validCommands) {
 				Adw.ShortcutsItem item = new ();
@@ -99,17 +99,17 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		dialog.Add (toolShortcutsSection);
 
 		// 2. Layer Commands
-		AddSection ("Layers", GetCommands (actions.Layers));
+		AddSection (Translations.GetString ("Layers"), GetCommands (actions.Layers));
 
 		// 3. Menu Commands
-		AddSection ("File", GetCommands (actions.File));
-		AddSection ("Edit", GetCommands (actions.Edit));
-		AddSection ("View", GetCommands (actions.View));
-		AddSection ("Image", GetCommands (actions.Image));
-		AddSection ("Adjustments", actions.Adjustments.Actions);
-		AddSection ("Effects", actions.Effects.Actions);
-		AddSection ("Window", GetCommands (actions.Window));
-		AddSection ("Help", GetCommands (actions.Help));
+		AddSection (Translations.GetString ("File"), GetCommands (actions.File));
+		AddSection (Translations.GetString ("Edit"), GetCommands (actions.Edit));
+		AddSection (Translations.GetString ("View"), GetCommands (actions.View));
+		AddSection (Translations.GetString ("Image"), GetCommands (actions.Image));
+		AddSection (Translations.GetString ("Adjustments"), actions.Adjustments.Actions);
+		AddSection (Translations.GetString ("Effects"), actions.Effects.Actions);
+		AddSection (Translations.GetString ("Window"), GetCommands (actions.Window));
+		AddSection (Translations.GetString ("Help"), GetCommands (actions.Help));
 
 		dialog.Present (chrome.MainWindow);
 	}

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -60,7 +60,6 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		allCommands.AddRange (GetCommands (actions.Edit));
 		allCommands.AddRange (GetCommands (actions.View));
 		allCommands.AddRange (GetCommands (actions.Image));
-		allCommands.AddRange (GetCommands (actions.Layers));
 		allCommands.AddRange (GetCommands (actions.Window));
 		allCommands.AddRange (GetCommands (actions.Help));
 		allCommands.AddRange (GetCommands (actions.Addins));
@@ -83,7 +82,29 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		}
 		shortcutsPage.Add (menuShortcutsGroup);
 
-		// --- 2. Tool Shortcuts ---
+		// --- 2. Layer Shortcuts ---
+		Adw.PreferencesGroup layerShortcutsGroup = Adw.PreferencesGroup.New ();
+		layerShortcutsGroup.Title = Translations.GetString ("Layer Commands");
+
+		var layerCommands = GetCommands (actions.Layers)
+			.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
+			.OrderBy (c => c.Label);
+
+		foreach (var cmd in layerCommands) {
+			Adw.ActionRow row = Adw.ActionRow.New ();
+			row.Title = cmd.Label.Replace ("_", "");
+
+			if (cmd.IconName != null) {
+				row.IconName = cmd.IconName;
+			}
+
+			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
+			row.AddSuffix (shortcutLabel);
+			layerShortcutsGroup.Add (row);
+		}
+		shortcutsPage.Add (layerShortcutsGroup);
+
+		// --- 3. Tool Shortcuts ---
 		Adw.PreferencesGroup toolShortcutsGroup = Adw.PreferencesGroup.New ();
 		toolShortcutsGroup.Title = Translations.GetString ("Tools");
 

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -1,0 +1,100 @@
+//
+// PreferencesDialogAction.cs
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pinta.Core;
+
+namespace Pinta.Actions;
+
+internal sealed class PreferencesDialogAction : IActionHandler
+{
+	private readonly AppActions app;
+	private readonly ActionManager actions;
+	private readonly ChromeManager chrome;
+
+	internal PreferencesDialogAction (
+		AppActions app,
+		ActionManager actions,
+		ChromeManager chrome)
+	{
+		this.app = app;
+		this.actions = actions;
+		this.chrome = chrome;
+	}
+
+	void IActionHandler.Initialize ()
+	{
+		app.Preferences.Activated += Activated;
+	}
+
+	void IActionHandler.Uninitialize ()
+	{
+		app.Preferences.Activated -= Activated;
+	}
+
+	private async void Activated (object sender, EventArgs e)
+	{
+		using Adw.PreferencesWindow dialog = Adw.PreferencesWindow.New ();
+		dialog.TransientFor = chrome.MainWindow;
+		dialog.Title = Translations.GetString ("Preferences");
+		dialog.DefaultWidth = 600;
+		dialog.DefaultHeight = 800;
+
+		Adw.PreferencesPage shortcutsPage = Adw.PreferencesPage.New ();
+		shortcutsPage.Title = Translations.GetString ("Keyboard Shortcuts");
+		shortcutsPage.IconName = "keyboard-shortcuts-symbolic";
+
+		Adw.PreferencesGroup shortcutsGroup = Adw.PreferencesGroup.New ();
+		shortcutsGroup.Title = Translations.GetString ("Application Shortcuts");
+
+		// Gather all commands from Pinta's action manager
+		var allCommands = new List<Command> ();
+		allCommands.AddRange (GetCommands (actions.App));
+		allCommands.AddRange (GetCommands (actions.File));
+		allCommands.AddRange (GetCommands (actions.Edit));
+		allCommands.AddRange (GetCommands (actions.View));
+		allCommands.AddRange (GetCommands (actions.Image));
+		allCommands.AddRange (GetCommands (actions.Layers));
+		allCommands.AddRange (GetCommands (actions.Window));
+		allCommands.AddRange (GetCommands (actions.Help));
+		allCommands.AddRange (GetCommands (actions.Addins));
+
+		// Sort alphabetically by label and filter out commands without shortcuts
+		var commandsWithShortcuts = allCommands
+			.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
+			.OrderBy (c => c.Label);
+
+		foreach (var cmd in commandsWithShortcuts) {
+			Adw.ActionRow row = Adw.ActionRow.New ();
+			row.Title = cmd.Label.Replace ("_", ""); // Remove GTK mnemonic underscores
+
+			if (cmd.IconName != null) {
+				row.IconName = cmd.IconName;
+			}
+
+			// Use a Gtk.ShortcutLabel to display the keys nicely
+			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
+			row.AddSuffix (shortcutLabel);
+
+			shortcutsGroup.Add (row);
+		}
+
+		shortcutsPage.Add (shortcutsGroup);
+		dialog.Add (shortcutsPage);
+
+		await dialog.PresentAsync ();
+	}
+
+	private static IEnumerable<Command> GetCommands(object actionCollection)
+	{
+		// Simple reflection to grab all 'Command' properties from the action classes (FileActions, EditActions, etc.)
+		return actionCollection.GetType()
+			.GetProperties()
+			.Where(p => p.PropertyType == typeof(Command))
+			.Select(p => (Command)p.GetValue(actionCollection)!)
+			.Where(c => c != null);
+	}
+}

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -38,17 +38,9 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		app.Preferences.Activated -= Activated;
 	}
 
-	private async void Activated (object sender, EventArgs e)
+	private void Activated (object sender, EventArgs e)
 	{
-		using Adw.PreferencesWindow dialog = Adw.PreferencesWindow.New ();
-		dialog.TransientFor = chrome.MainWindow;
-		dialog.Title = Translations.GetString ("Keyboard Shortcuts");
-		dialog.DefaultWidth = 600;
-		dialog.DefaultHeight = 800;
-
-		Adw.PreferencesPage shortcutsPage = Adw.PreferencesPage.New ();
-		shortcutsPage.Title = Translations.GetString ("Keyboard Shortcuts");
-		shortcutsPage.IconName = "keyboard-shortcuts-symbolic";
+		using Adw.ShortcutsDialog dialog = new ();
 
 		// Helper to format the shortcut string for the current OS
 		string FormatShortcut (string shortcut)
@@ -62,8 +54,8 @@ internal sealed class PreferencesDialogAction : IActionHandler
 				.Replace ("<Ctrl>", "<Control>");
 		}
 
-		// Helper to create and populate a group
-		void AddGroup (string title, IEnumerable<Command> commands)
+		// Helper to create and populate a section and add it to the dialog
+		void AddSection (string title, IEnumerable<Command> commands)
 		{
 			var validCommands = commands
 				.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
@@ -73,29 +65,22 @@ internal sealed class PreferencesDialogAction : IActionHandler
 			if (validCommands.Count == 0)
 				return;
 
-			Adw.PreferencesGroup group = Adw.PreferencesGroup.New ();
-			group.Title = Translations.GetString (title);
+			Adw.ShortcutsSection section = new ();
+			section.Title = Translations.GetString (title);
 
 			foreach (var cmd in validCommands) {
-				Adw.ActionRow row = Adw.ActionRow.New ();
-				row.Title = cmd.Label.Replace ("_", "");
-
-				if (cmd.IconName != null) {
-					row.IconName = cmd.IconName;
-				}
-
-				string formattedShortcut = FormatShortcut (cmd.Shortcuts[0]);
-				Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (formattedShortcut);
-				row.AddSuffix (shortcutLabel);
-				group.Add (row);
+				Adw.ShortcutsItem item = new ();
+				item.Title = cmd.Label.Replace ("_", "");
+				item.Accelerator = FormatShortcut (cmd.Shortcuts[0]);
+				section.Add (item);
 			}
 
-			shortcutsPage.Add (group);
+			dialog.Add (section);
 		}
 
 		// 1. Tool Shortcuts
-		Adw.PreferencesGroup toolShortcutsGroup = Adw.PreferencesGroup.New ();
-		toolShortcutsGroup.Title = Translations.GetString ("Tools");
+		Adw.ShortcutsSection toolShortcutsSection = new ();
+		toolShortcutsSection.Title = Translations.GetString ("Tools");
 
 		// tool.ShortcutKey returns a Gdk.Key. We filter out the 'invalid/void' keys.
 		var toolsWithShortcuts = tools
@@ -103,34 +88,30 @@ internal sealed class PreferencesDialogAction : IActionHandler
 			.OrderBy (t => t.Name);
 
 		foreach (var tool in toolsWithShortcuts) {
-			Adw.ActionRow row = Adw.ActionRow.New ();
-			row.Title = tool.Name;
-			row.IconName = tool.Icon;
+			Adw.ShortcutsItem item = new ();
+			item.Title = tool.Name;
 
 			string keyName = ((char)tool.ShortcutKey.Value).ToString ().ToUpperInvariant ();
-			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (keyName);
-			row.AddSuffix (shortcutLabel);
-			toolShortcutsGroup.Add (row);
+			item.Accelerator = keyName;
+			toolShortcutsSection.Add (item);
 		}
 
-		shortcutsPage.Add (toolShortcutsGroup);
+		dialog.Add (toolShortcutsSection);
 
 		// 2. Layer Commands
-		AddGroup ("Layers", GetCommands (actions.Layers));
+		AddSection ("Layers", GetCommands (actions.Layers));
 
 		// 3. Menu Commands
-		AddGroup ("File", GetCommands (actions.File));
-		AddGroup ("Edit", GetCommands (actions.Edit));
-		AddGroup ("View", GetCommands (actions.View));
-		AddGroup ("Image", GetCommands (actions.Image));
-		AddGroup ("Adjustments", actions.Adjustments.Actions);
-		AddGroup ("Effects", actions.Effects.Actions);
-		AddGroup ("Window", GetCommands (actions.Window));
-		AddGroup ("Help", GetCommands (actions.Help));
+		AddSection ("File", GetCommands (actions.File));
+		AddSection ("Edit", GetCommands (actions.Edit));
+		AddSection ("View", GetCommands (actions.View));
+		AddSection ("Image", GetCommands (actions.Image));
+		AddSection ("Adjustments", actions.Adjustments.Actions);
+		AddSection ("Effects", actions.Effects.Actions);
+		AddSection ("Window", GetCommands (actions.Window));
+		AddSection ("Help", GetCommands (actions.Help));
 
-		dialog.Add (shortcutsPage);
-
-		await dialog.PresentAsync ();
+		dialog.Present (chrome.MainWindow);
 	}
 
 	private static IEnumerable<Command> GetCommands(object actionCollection)

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -50,61 +50,37 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		shortcutsPage.Title = Translations.GetString ("Keyboard Shortcuts");
 		shortcutsPage.IconName = "keyboard-shortcuts-symbolic";
 
-		// --- 1. Menu & Action Shortcuts ---
-		Adw.PreferencesGroup menuShortcutsGroup = Adw.PreferencesGroup.New ();
-		menuShortcutsGroup.Title = Translations.GetString ("Application Commands");
+		// Helper to create and populate a group
+		void AddGroup (string title, IEnumerable<Command> commands)
+		{
+			var validCommands = commands
+				.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
+				.OrderBy (c => c.Label)
+				.ToList ();
 
-		var allCommands = new List<Command> ();
-		allCommands.AddRange (GetCommands (actions.App));
-		allCommands.AddRange (GetCommands (actions.File));
-		allCommands.AddRange (GetCommands (actions.Edit));
-		allCommands.AddRange (GetCommands (actions.View));
-		allCommands.AddRange (GetCommands (actions.Image));
-		allCommands.AddRange (GetCommands (actions.Window));
-		allCommands.AddRange (GetCommands (actions.Help));
-		allCommands.AddRange (GetCommands (actions.Addins));
+			if (validCommands.Count == 0)
+				return;
 
-		var commandsWithShortcuts = allCommands
-			.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
-			.OrderBy (c => c.Label);
+			Adw.PreferencesGroup group = Adw.PreferencesGroup.New ();
+			group.Title = Translations.GetString (title);
 
-		foreach (var cmd in commandsWithShortcuts) {
-			Adw.ActionRow row = Adw.ActionRow.New ();
-			row.Title = cmd.Label.Replace ("_", "");
+			foreach (var cmd in validCommands) {
+				Adw.ActionRow row = Adw.ActionRow.New ();
+				row.Title = cmd.Label.Replace ("_", "");
 
-			if (cmd.IconName != null) {
-				row.IconName = cmd.IconName;
+				if (cmd.IconName != null) {
+					row.IconName = cmd.IconName;
+				}
+
+				Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
+				row.AddSuffix (shortcutLabel);
+				group.Add (row);
 			}
 
-			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
-			row.AddSuffix (shortcutLabel);
-			menuShortcutsGroup.Add (row);
+			shortcutsPage.Add (group);
 		}
-		shortcutsPage.Add (menuShortcutsGroup);
 
-		// --- 2. Layer Shortcuts ---
-		Adw.PreferencesGroup layerShortcutsGroup = Adw.PreferencesGroup.New ();
-		layerShortcutsGroup.Title = Translations.GetString ("Layer Commands");
-
-		var layerCommands = GetCommands (actions.Layers)
-			.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
-			.OrderBy (c => c.Label);
-
-		foreach (var cmd in layerCommands) {
-			Adw.ActionRow row = Adw.ActionRow.New ();
-			row.Title = cmd.Label.Replace ("_", "");
-
-			if (cmd.IconName != null) {
-				row.IconName = cmd.IconName;
-			}
-
-			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
-			row.AddSuffix (shortcutLabel);
-			layerShortcutsGroup.Add (row);
-		}
-		shortcutsPage.Add (layerShortcutsGroup);
-
-		// --- 3. Tool Shortcuts ---
+		// 1. Tool Shortcuts
 		Adw.PreferencesGroup toolShortcutsGroup = Adw.PreferencesGroup.New ();
 		toolShortcutsGroup.Title = Translations.GetString ("Tools");
 
@@ -118,13 +94,26 @@ internal sealed class PreferencesDialogAction : IActionHandler
 			row.Title = tool.Name;
 			row.IconName = tool.Icon;
 
-			// Gtk.ShortcutLabel natively understands strings like "B" or "M"
 			string keyName = ((char)tool.ShortcutKey.Value).ToString ().ToUpperInvariant ();
 			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (keyName);
 			row.AddSuffix (shortcutLabel);
 			toolShortcutsGroup.Add (row);
 		}
+
 		shortcutsPage.Add (toolShortcutsGroup);
+
+		// 2. Layer Commands
+		AddGroup ("Layers", GetCommands (actions.Layers));
+
+		// 3. Menu Commands
+		AddGroup ("File", GetCommands (actions.File));
+		AddGroup ("Edit", GetCommands (actions.Edit));
+		AddGroup ("View", GetCommands (actions.View));
+		AddGroup ("Image", GetCommands (actions.Image));
+		AddGroup ("Adjustments", actions.Adjustments.Actions);
+		AddGroup ("Effects", actions.Effects.Actions);
+		AddGroup ("Window", GetCommands (actions.Window));
+		AddGroup ("Help", GetCommands (actions.Help));
 
 		dialog.Add (shortcutsPage);
 

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -14,15 +14,18 @@ internal sealed class PreferencesDialogAction : IActionHandler
 	private readonly AppActions app;
 	private readonly ActionManager actions;
 	private readonly ChromeManager chrome;
+	private readonly ToolManager tools;
 
 	internal PreferencesDialogAction (
 		AppActions app,
 		ActionManager actions,
-		ChromeManager chrome)
+		ChromeManager chrome,
+		ToolManager tools)
 	{
 		this.app = app;
 		this.actions = actions;
 		this.chrome = chrome;
+		this.tools = tools;
 	}
 
 	void IActionHandler.Initialize ()
@@ -47,10 +50,10 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		shortcutsPage.Title = Translations.GetString ("Keyboard Shortcuts");
 		shortcutsPage.IconName = "keyboard-shortcuts-symbolic";
 
-		Adw.PreferencesGroup shortcutsGroup = Adw.PreferencesGroup.New ();
-		shortcutsGroup.Title = Translations.GetString ("Application Shortcuts");
+		// --- 1. Menu & Action Shortcuts ---
+		Adw.PreferencesGroup menuShortcutsGroup = Adw.PreferencesGroup.New ();
+		menuShortcutsGroup.Title = Translations.GetString ("Application Commands");
 
-		// Gather all commands from Pinta's action manager
 		var allCommands = new List<Command> ();
 		allCommands.AddRange (GetCommands (actions.App));
 		allCommands.AddRange (GetCommands (actions.File));
@@ -62,27 +65,46 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		allCommands.AddRange (GetCommands (actions.Help));
 		allCommands.AddRange (GetCommands (actions.Addins));
 
-		// Sort alphabetically by label and filter out commands without shortcuts
 		var commandsWithShortcuts = allCommands
 			.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
 			.OrderBy (c => c.Label);
 
 		foreach (var cmd in commandsWithShortcuts) {
 			Adw.ActionRow row = Adw.ActionRow.New ();
-			row.Title = cmd.Label.Replace ("_", ""); // Remove GTK mnemonic underscores
+			row.Title = cmd.Label.Replace ("_", "");
 
 			if (cmd.IconName != null) {
 				row.IconName = cmd.IconName;
 			}
 
-			// Use a Gtk.ShortcutLabel to display the keys nicely
 			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
 			row.AddSuffix (shortcutLabel);
-
-			shortcutsGroup.Add (row);
+			menuShortcutsGroup.Add (row);
 		}
+		shortcutsPage.Add (menuShortcutsGroup);
 
-		shortcutsPage.Add (shortcutsGroup);
+		// --- 2. Tool Shortcuts ---
+		Adw.PreferencesGroup toolShortcutsGroup = Adw.PreferencesGroup.New ();
+		toolShortcutsGroup.Title = Translations.GetString ("Tools");
+
+		// tool.ShortcutKey returns a Gdk.Key. We filter out the 'invalid/void' keys.
+		var toolsWithShortcuts = tools
+			.Where (t => t.ShortcutKey.Value != 0 && t.ShortcutKey.Value != Gdk.Constants.KEY_VoidSymbol)
+			.OrderBy (t => t.Name);
+
+		foreach (var tool in toolsWithShortcuts) {
+			Adw.ActionRow row = Adw.ActionRow.New ();
+			row.Title = tool.Name;
+			row.IconName = tool.Icon;
+
+			// Gtk.ShortcutLabel natively understands strings like "B" or "M"
+			string keyName = ((char)tool.ShortcutKey.Value).ToString ().ToUpperInvariant ();
+			Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (keyName);
+			row.AddSuffix (shortcutLabel);
+			toolShortcutsGroup.Add (row);
+		}
+		shortcutsPage.Add (toolShortcutsGroup);
+
 		dialog.Add (shortcutsPage);
 
 		await dialog.PresentAsync ();
@@ -90,7 +112,6 @@ internal sealed class PreferencesDialogAction : IActionHandler
 
 	private static IEnumerable<Command> GetCommands(object actionCollection)
 	{
-		// Simple reflection to grab all 'Command' properties from the action classes (FileActions, EditActions, etc.)
 		return actionCollection.GetType()
 			.GetProperties()
 			.Where(p => p.PropertyType == typeof(Command))

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -58,7 +58,7 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		void AddSection (string title, IEnumerable<Command> commands)
 		{
 			var validCommands = commands
-				.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty(c.Label))
+				.Where (c => c.Shortcuts.Length > 0 && !string.IsNullOrEmpty (c.Label))
 				.OrderBy (c => c.Label)
 				.ToList ();
 
@@ -91,7 +91,7 @@ internal sealed class PreferencesDialogAction : IActionHandler
 			Adw.ShortcutsItem item = new ();
 			item.Title = tool.Name;
 
-			string keyName = ((char)tool.ShortcutKey.Value).ToString ().ToUpperInvariant ();
+			string keyName = ((char) tool.ShortcutKey.Value).ToString ().ToUpperInvariant ();
 			item.Accelerator = keyName;
 			toolShortcutsSection.Add (item);
 		}
@@ -114,12 +114,12 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		dialog.Present (chrome.MainWindow);
 	}
 
-	private static IEnumerable<Command> GetCommands(object actionCollection)
+	private static IEnumerable<Command> GetCommands (object actionCollection)
 	{
-		return actionCollection.GetType()
-			.GetProperties()
-			.Where(p => p.PropertyType == typeof(Command))
-			.Select(p => (Command)p.GetValue(actionCollection)!)
-			.Where(c => c != null);
+		return actionCollection.GetType ()
+			.GetProperties ()
+			.Where (p => p.PropertyType == typeof (Command))
+			.Select (p => (Command) p.GetValue (actionCollection)!)
+			.Where (c => c != null);
 	}
 }

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -50,6 +50,18 @@ internal sealed class PreferencesDialogAction : IActionHandler
 		shortcutsPage.Title = Translations.GetString ("Keyboard Shortcuts");
 		shortcutsPage.IconName = "keyboard-shortcuts-symbolic";
 
+		// Helper to format the shortcut string for the current OS
+		string FormatShortcut (string shortcut)
+		{
+			bool isMac = SystemManager.GetOperatingSystem () == OS.Mac;
+
+			// 1. Map <Primary> to the main modifier (Cmd on Mac, Ctrl on Win/Lin)
+			// 2. Normalize <Ctrl> to <Control> for GTK consistency
+			return shortcut
+				.Replace ("<Primary>", isMac ? "<Meta>" : "<Control>")
+				.Replace ("<Ctrl>", "<Control>");
+		}
+
 		// Helper to create and populate a group
 		void AddGroup (string title, IEnumerable<Command> commands)
 		{
@@ -72,7 +84,8 @@ internal sealed class PreferencesDialogAction : IActionHandler
 					row.IconName = cmd.IconName;
 				}
 
-				Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (cmd.Shortcuts[0]);
+				string formattedShortcut = FormatShortcut (cmd.Shortcuts[0]);
+				Gtk.ShortcutLabel shortcutLabel = Gtk.ShortcutLabel.New (formattedShortcut);
 				row.AddSuffix (shortcutLabel);
 				group.Add (row);
 			}

--- a/Pinta/Actions/Help/PreferencesDialogAction.cs
+++ b/Pinta/Actions/Help/PreferencesDialogAction.cs
@@ -42,7 +42,7 @@ internal sealed class PreferencesDialogAction : IActionHandler
 	{
 		using Adw.PreferencesWindow dialog = Adw.PreferencesWindow.New ();
 		dialog.TransientFor = chrome.MainWindow;
-		dialog.Title = Translations.GetString ("Preferences");
+		dialog.Title = Translations.GetString ("Keyboard Shortcuts");
 		dialog.DefaultWidth = 600;
 		dialog.DefaultHeight = 800;
 

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AM_GLIB_GNU_GETTEXT
 pintalocaledir='${prefix}/${DATADIRNAME}/locale'
 AC_SUBST(pintalocaledir)
 
-PKG_CHECK_MODULES([ADW_1], [libadwaita-1 >= 1.7])
+PKG_CHECK_MODULES([ADW_1], [libadwaita-1 >= 1.8])
 PKG_CHECK_MODULES([GTK], [gtk4 >= 4.18])
 
 AC_CONFIG_FILES([

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ For building on the command line:
 - Install [.NET 10](https://dotnet.microsoft.com/) following the instructions for your Linux distribution.
 - Install other dependencies (instructions are for Ubuntu 22.10, but should be similar for other distros):
   - `sudo apt install autotools-dev autoconf-archive gettext intltool libadwaita-1-dev`
-  - Minimum library versions: `gtk` >= 4.18 and `libadwaita` >= 1.7
+  - Minimum library versions: `gtk` >= 4.18 and `libadwaita` >= 1.8
   - Optional dependencies: `webp-pixbuf-loader`
 - Build (option 1, for development and testing):
   - `dotnet build`


### PR DESCRIPTION
This addresses issue [1434](https://github.com/PintaProject/Pinta/issues/1434) by adding a dialog with all keyboard shortcuts and their actions. This dialog can be accessed via `Pinta > Settings` or via keyboard shortcut with `ctrl + comma`. The shortcuts are separated by category, such as tool shortcuts, layer shortcuts, and top bar menu items. The shortcuts are searchable by clicking the magnifying glass icon on top of the dialog.

<img width="800" height="460" alt="shortcuts" src="https://github.com/user-attachments/assets/5eb7f7cb-4578-42d2-85e4-9b66f656597b" />
