### PR TITLE
selection-animation

### DIFF
--- a/Pinta.Core/Actions/FileActions.cs
+++ b/Pinta.Core/Actions/FileActions.cs
@@ -38,6 +38,7 @@ public sealed class FileActions
 	public Command Close { get; }
 	public Command Save { get; }
 	public Command SaveAs { get; }
+	public Command SelectionSettings { get; }
 	public Command Print { get; }
 
 	public event EventHandler<ModifyCompressionEventArgs>? ModifyCompression;
@@ -97,6 +98,12 @@ public sealed class FileActions
 			Resources.StandardIcons.DocumentSaveAs,
 			shortcuts: ["<Primary><Shift>S"]);
 
+		SelectionSettings = new Command (
+			"selectionSettings",
+			Translations.GetString ("Selection Settings..."),
+			null,
+			null);
+
 		Print = new Command (
 			"print",
 			Translations.GetString ("Print"),
@@ -115,6 +122,9 @@ public sealed class FileActions
 		save_section.AppendItem (Save.CreateMenuItem ());
 		save_section.AppendItem (SaveAs.CreateMenuItem ());
 
+		var selection_settings_section = Gio.Menu.New ();
+		selection_settings_section.AppendItem (SelectionSettings.CreateMenuItem ());
+
 		Gio.Menu close_section = Gio.Menu.New ();
 		close_section.AppendItem (Close.CreateMenuItem ());
 		if (!isMac) close_section.AppendItem (app.Exit.CreateMenuItem ()); // This is part of the application menu on macOS
@@ -123,6 +133,7 @@ public sealed class FileActions
 		menu.AppendItem (NewScreenshot.CreateMenuItem ());
 		menu.AppendItem (Open.CreateMenuItem ());
 		menu.AppendSection (null, save_section);
+		menu.AppendSection (null, selection_settings_section);
 		menu.AppendSection (null, close_section);
 #if false
 		// Printing is disabled for now until it is fully functional.
@@ -136,6 +147,8 @@ public sealed class FileActions
 
 			Save,
 			SaveAs,
+
+			SelectionSettings,
 
 			Close]);
 

--- a/Pinta.Core/FriendAssemblies.cs
+++ b/Pinta.Core/FriendAssemblies.cs
@@ -3,3 +3,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo ("Pinta.Core.Tests")]
 [assembly: InternalsVisibleTo ("Pinta.Effects.Tests")]
 [assembly: InternalsVisibleTo ("PintaBenchmarks")]
+[assembly: InternalsVisibleTo ("Pinta.Gui.Widgets")]
+[assembly: InternalsVisibleTo ("Pinta")]

--- a/Pinta.Core/SettingNames.cs
+++ b/Pinta.Core/SettingNames.cs
@@ -25,4 +25,6 @@ internal static class SettingNames
 
 	internal static string ToolAlphaBlend (BaseTool tool)
 		=> $"{tool.GetType ().Name.ToLowerInvariant ()}-alpha-blend";
+
+	internal const string SELECTION_ANIMATION = "selection-animation";
 }

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -71,7 +71,7 @@ public sealed class PintaCanvas : Gtk.Picture
 		document.SelectionChanged += (_, _) => QueueSelectionUpdate ();
 
 		// Timer for selection outline animation
-		bool selectionAnimation = PintaCore.Settings.GetSetting ( "selection-animation", true);
+		bool selectionAnimation = PintaCore.Settings.GetSetting ( SettingNames.SELECTION_ANIMATION, true);
 		if (selectionAnimation)
 			selection_animation_timer_id = GLib.Functions.TimeoutAdd (GLib.Constants.PRIORITY_DEFAULT, 80, SelectionAnimationTick);
 

--- a/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
+++ b/Pinta.Gui.Widgets/Widgets/Canvas/PintaCanvas.cs
@@ -71,7 +71,9 @@ public sealed class PintaCanvas : Gtk.Picture
 		document.SelectionChanged += (_, _) => QueueSelectionUpdate ();
 
 		// Timer for selection outline animation
-		selection_animation_timer_id = GLib.Functions.TimeoutAdd (GLib.Constants.PRIORITY_DEFAULT, 80, SelectionAnimationTick);
+		bool selectionAnimation = PintaCore.Settings.GetSetting ( "selection-animation", true);
+		if (selectionAnimation)
+			selection_animation_timer_id = GLib.Functions.TimeoutAdd (GLib.Constants.PRIORITY_DEFAULT, 80, SelectionAnimationTick);
 
 		// If there is additional space available, keep the image centered and prevent stretching.
 		Hexpand = false;

--- a/Pinta/ActionHandlers.cs
+++ b/Pinta/ActionHandlers.cs
@@ -26,6 +26,7 @@
 
 using System.Collections.Generic;
 using Pinta.Actions;
+using Pinta.Actions.File;
 using Pinta.Core;
 
 namespace Pinta;
@@ -58,6 +59,7 @@ public sealed class ActionHandlers
 			new SaveDocumentImplmentationAction (actions.File, actions.Image, chrome, imageFormats, recentFiles, tools),
 			new ModifyCompressionAction (actions.File),
 			//new PrintDocumentAction ();
+			new SelectionSettingsAction (chrome),
 			new CloseDocumentAction (actions, chrome, workspace, tools),
 			new ExitProgramAction (actions, chrome, workspace),
 

--- a/Pinta/Actions/File/SelectionSettingsAction.cs
+++ b/Pinta/Actions/File/SelectionSettingsAction.cs
@@ -1,0 +1,37 @@
+
+using System;
+using Pinta.Core;
+
+namespace Pinta.Actions.File;
+
+public sealed class SelectionSettingsAction : IActionHandler
+{
+	private readonly ChromeManager chrome;
+
+	public SelectionSettingsAction (
+		ChromeManager chrome)
+	{
+		this.chrome = chrome;
+	}
+
+	public void Initialize ()
+	{
+		PintaCore.Actions.File.SelectionSettings.Activated += OnActivated;
+	}
+
+	public void Uninitialize ()
+	{
+		PintaCore.Actions.File.SelectionSettings.Activated -= OnActivated;
+	}
+
+	private void OnActivated (object? sender, EventArgs e)
+	{
+		var dialog = new SelectionSettingsDialog (
+			PintaCore.Chrome,
+			PintaCore.Settings.GetSetting(
+				Pinta.Core.SettingNames.SELECTION_ANIMATION,
+				true));
+
+		dialog.Show ();
+	}
+}

--- a/Pinta/Dialogs/SelectionSettingsDialog.cs
+++ b/Pinta/Dialogs/SelectionSettingsDialog.cs
@@ -1,0 +1,48 @@
+using Pinta.Core;
+using Pinta.Gui.Widgets;
+
+namespace Pinta;
+
+public sealed class SelectionSettingsDialog : Gtk.Dialog
+{
+	public SelectionSettingsDialog (
+		ChromeManager chrome,
+		bool selectionAnimation)
+	{
+		var checkbox = Gtk.CheckButton.NewWithLabel (
+			Translations.GetString ("Marching Ants"));
+
+		checkbox.Active = selectionAnimation;
+
+		var label = Gtk.Label.New (
+			Translations.GetString (
+			"Restart Pinta to apply this setting."));
+
+		var box = this.GetContentAreaBox ();
+		box.SetAllMargins (12);
+		box.Append (checkbox);
+		box.Append (label);
+
+
+		Title = Translations.GetString ("Selection Settings");
+		TransientFor = chrome.MainWindow;
+		Modal = true;
+
+
+		this.AddCancelOkButtons ();
+		this.SetDefaultResponse (Gtk.ResponseType.Ok);
+
+
+		OnResponse += (o,args) =>
+		{
+			if (args.ResponseId == (int) Gtk.ResponseType.Ok)
+			{
+				PintaCore.Settings.PutSetting (
+					Pinta.Core.SettingNames.SELECTION_ANIMATION,
+					checkbox.Active);
+			}
+
+			Destroy();
+		};
+	}
+}


### PR DESCRIPTION
Removing the “marching ants” selection animation significantly reduces CPU usage on low-power devices such as Raspberry Pi.

No additional guard is needed when removing the GLib timer source, since GLib.Source.Remove(0) is defined as a safe no-op:

```GLib.Source.Remove(selection_animation_timer_id);```

A UI toggle was considered, but there is currently no clear place in the existing UI to expose a global preference of this type:

Selection tools (Rectangle / Ellipse / Lasso / Magic Wand) → too fragmented and tool-specific
Edit menu → closest conceptual match (selection-related operations already live there)
View menu → would be the most appropriate conceptually, but does not currently exist

For now, this is implemented as a configuration-level option.