### PR TITLE
autosave

### DIFF
--- a/Pinta.Core/Classes/Document.cs
+++ b/Pinta.Core/Classes/Document.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Cairo;
 
@@ -140,6 +141,7 @@ public sealed class Document
 	/// <summary>
 	/// Whether the document is associated with a file on disk.
 	/// </summary>
+	[MemberNotNullWhen(true, nameof(File))]
 	public bool HasFile => file is not null;
 
 	/// Whether or not the document has been saved to the file that it is currently associated with in the
@@ -445,4 +447,15 @@ public sealed class Document
 	public event EventHandler? Renamed;
 	public event LayerCloneEvent? LayerCloned;
 	public event EventHandler? SelectionChanged;
+
+	private bool is_autosave_dirty;
+	public bool IsAutosaveDirty {
+		get => is_autosave_dirty;
+		set => is_autosave_dirty = value;
+	}
+	private uint autosave_files_index;
+	public uint AutosaveFilesIndex {
+		get => autosave_files_index;
+		set => autosave_files_index = value;
+	}
 }

--- a/Pinta.Core/Classes/DocumentHistory.cs
+++ b/Pinta.Core/Classes/DocumentHistory.cs
@@ -73,8 +73,10 @@ public sealed class DocumentHistory
 		history.Add (newItem);
 		Pointer = history.Count - 1;
 
-		if (newItem.CausesDirty)
+		if (newItem.CausesDirty) {
 			document.IsDirty = true;
+			document.IsAutosaveDirty = true;
+		}
 
 		HistoryItemAdded?.Invoke (this, new HistoryItemAddedEventArgs (newItem));
 	}

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -161,7 +161,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 	public WorkspaceManager (
 		SystemManager systemManager,
 		ChromeManager chromeManager,
-		ImageConverterManager imageFormats)
+		ImageConverterManager imageFormats,
+		SettingsManager settings)
 	{
 		open_documents = [];
 		OpenDocuments = new ReadOnlyCollection<Document> (open_documents);
@@ -169,6 +170,8 @@ public sealed class WorkspaceManager : IWorkspaceService
 
 		chrome_manager = chromeManager;
 		image_formats = imageFormats;
+
+		StartAutosaveTimer(settings);
 	}
 
 	public int ActiveDocumentIndex
@@ -463,6 +466,87 @@ public sealed class WorkspaceManager : IWorkspaceService
 		string details = Translations.GetString ("You do not have access to '{0}'.", filename);
 
 		return chrome_manager.ShowMessageDialog (parent, message, details);
+	}
+
+	private uint autosave_timer_id;
+	private uint autosave_files;
+	private int autosave_history;
+	private readonly HashSet<string> autosaveFiles = new();
+	private void StartAutosaveTimer (SettingsManager settings)
+	{
+		int interval = settings.GetSetting("autosave-interval", 0);
+		if (interval > 0) {
+			autosave_files = Math.Max(1, (uint)settings.GetSetting("autosave-files", 1));
+			autosave_history = settings.GetSetting("autosave-history", 0);
+			autosave_timer_id = GLib.Functions.TimeoutAdd(GLib.Constants.PRIORITY_DEFAULT, (uint)interval * 1000, OnAutosaveTick);
+		}
+	}
+	private bool OnAutosaveTick ()
+	{
+		if (!HasOpenDocuments)
+			return true;
+
+		var format = PintaCore.ImageFormats.GetFormatByExtension ("ora");
+		if (format?.Exporter is null) {
+			autosave_timer_id = 0;
+			return false;
+		}
+
+		foreach (var doc in OpenDocuments) {
+			if (!doc.HasFile)
+				continue;
+			if (!doc.IsAutosaveDirty)
+				continue;
+
+			string autosaveFile = doc.File.GetParseName() + ".pinta_autosave_" + doc.AutosaveFilesIndex + ".ora";
+			doc.AutosaveFilesIndex += 1;
+			if ( doc.AutosaveFilesIndex == autosave_files ) doc.AutosaveFilesIndex = 0;
+
+			format.Exporter.Export (doc, Gio.FileHelper.NewForPath (autosaveFile), PintaCore.Chrome.MainWindow);
+
+			autosaveFiles.Add(autosaveFile);
+			DumpLastHistorySteps(doc);
+			doc.IsAutosaveDirty = false;
+		}
+
+		return true;
+	}
+	public void StopAutosave () {
+		if (autosave_timer_id != 0)
+		{
+			GLib.Source.Remove(autosave_timer_id);
+		}
+		foreach (var file_string in autosaveFiles)
+		{
+			try
+			{
+				var file = Gio.FileHelper.NewForPath(file_string);
+				if (file.QueryExists(null))
+					file.Delete(null);
+			}
+			catch
+			{
+				// ignore cleanup failures
+			}
+		}
+		autosaveFiles.Clear();
+	}
+	private void DumpLastHistorySteps(Document doc)
+	{
+		if ( autosave_history != 0 ) {
+			Console.WriteLine("=== Last History Steps ===");
+
+			var history = doc.History;
+			var n = history.Items.Count();
+			for (var i = Math.Max(0, n - autosave_history); i < n; i++)
+			{
+				var item = history.Items.ElementAt(i);
+				Console.WriteLine($"[{i}] {item.Text}");
+			}
+
+			Console.WriteLine($"Date: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+			Console.WriteLine("==========================");
+		}
 	}
 
 	public event EventHandler? LayerAdded;

--- a/Pinta.Core/Managers/WorkspaceManager.cs
+++ b/Pinta.Core/Managers/WorkspaceManager.cs
@@ -508,6 +508,9 @@ public sealed class WorkspaceManager : IWorkspaceService
 			DumpLastHistorySteps(doc);
 			doc.IsAutosaveDirty = false;
 		}
+		if ( autosave_history != 0 ) {
+			Console.WriteLine($"Date: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+		}
 
 		return true;
 	}
@@ -544,7 +547,6 @@ public sealed class WorkspaceManager : IWorkspaceService
 				Console.WriteLine($"[{i}] {item.Text}");
 			}
 
-			Console.WriteLine($"Date: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
 			Console.WriteLine("==========================");
 		}
 	}

--- a/Pinta.Core/PintaCore.cs
+++ b/Pinta.Core/PintaCore.cs
@@ -78,7 +78,7 @@ public static class PintaCore
 		// --- Services that depend on other services
 
 		ImageConverterManager imageFormats = new (settings);
-		WorkspaceManager workspace = new (system, chrome, imageFormats);
+		WorkspaceManager workspace = new (system, chrome, imageFormats, settings);
 		ToolManager tools = new (workspace, chrome);
 		PaletteManager palette = new (settings, paletteFormats);
 		ActionManager actions = new (chrome, imageFormats, paletteFormats, palette, recentFiles, system, tools, workspace);

--- a/Pinta/Actions/File/ExitAction.cs
+++ b/Pinta/Actions/File/ExitAction.cs
@@ -67,6 +67,8 @@ internal sealed class ExitProgramAction : IActionHandler
 				return;
 		}
 
+		PintaCore.Workspace.StopAutosave();
+
 		// Let everyone know we are quitting
 		actions.App.RaiseBeforeQuit ();
 


### PR DESCRIPTION
## Summary

This PR introduces an experimental autosave mechanism intended to reduce data loss in case of application instability or crashes (observed on Raspberry Pi builds running Ubuntu-based source builds).

The system periodically exports open documents to temporary `.ora` autosave files and cleans them up on normal application exit.

## Motivation

During testing on Raspberry Pi environments, I encountered occasional crashes leading to loss of unsaved work. This change is an initial mitigation step to improve recovery of work in progress.

## Current Behavior

* Autosave runs at a configurable interval (`autosave-interval`)
* Only exports documents that are marked as modified (`IsAutosaveDirty`)
* Generates rotating autosave files per document
* Cleans up autosave files on normal application exit (`StopAutosave`)

## Implementation Notes

* Extended `Document` with lightweight autosave tracking state
* Integrated autosave trigger into `DocumentHistory`
* Added periodic GLib-based autosave timer in `WorkspaceManager`
* Temporary `.ora` export files are written per document
* Basic rotation is supported via configurable file count
* Autosave state is reset after each successful export

## Limitations / Known Issues

* This is an experimental system and may be refined further
* No recovery UI is included yet (manual file inspection required)
* File rotation logic is simple and may be improved
* Additional validation and edge cases may be addressed in follow-up commits

## Future Work

* Investigate crash cases observed during testing (Raspberry Pi)
* Improve robustness of autosave triggering conditions
* Add recovery flow on application startup
* Potentially refine file rotation and storage strategy

## Follow-up

I will continue investigating the crash scenario to identify whether there is a reproducible issue. Based on findings, I will return with additional fixes or refinements to both stability and autosave behavior.
