### PR TITLE
Added deselect on esc shortcut when selection tool active

### DIFF
--- a/Pinta.Core/Actions/EditActions.cs
+++ b/Pinta.Core/Actions/EditActions.cs
@@ -47,6 +47,7 @@ public sealed class EditActions
 	public Command OffsetSelection { get; }
 	public Command SelectAll { get; }
 	public Command Deselect { get; }
+	public Command DeselectSelection { get; }
 	public Command LoadPalette { get; }
 	public Command SavePalette { get; }
 	public Command ResetPalette { get; }
@@ -54,6 +55,8 @@ public sealed class EditActions
 
 	private Gio.File? last_palette_dir = null;
 	private Document? active_document = null;
+
+	private static readonly string[] selection_tools = ["Pinta.Tools.EllipseSelectTool", "Pinta.Tools.RectangleSelectTool", "Pinta.Tools.LassoSelectTool"];
 
 	private readonly ChromeManager chrome;
 	private readonly PaletteFormatManager palette_formats;
@@ -166,6 +169,13 @@ public sealed class EditActions
 			Resources.Icons.EditSelectionNone,
 			shortcuts: ["<Primary><Shift>A", "<Ctrl>D"]);
 
+		DeselectSelection = new Command (
+			"deselect",
+			Translations.GetString ("Deselect All"),
+			null,
+			Resources.Icons.EditSelectionNone,
+			shortcuts: ["Escape"]);
+
 		LoadPalette = new Command (
 			"loadpalette",
 			Translations.GetString ("Open..."),
@@ -250,6 +260,7 @@ public sealed class EditActions
 
 			SelectAll,
 			Deselect,
+			DeselectSelection,
 
 			EraseSelection,
 			FillSelection,
@@ -270,6 +281,7 @@ public sealed class EditActions
 	public void RegisterHandlers ()
 	{
 		Deselect.Activated += HandlePintaCoreActionsEditDeselectActivated;
+		DeselectSelection.Activated += HandlePintaCoreActionsEditDeselectSelectionActivated;
 		EraseSelection.Activated += HandlePintaCoreActionsEditEraseSelectionActivated;
 		SelectAll.Activated += HandlePintaCoreActionsEditSelectAllActivated;
 		FillSelection.Activated += HandlePintaCoreActionsEditFillSelectionActivated;
@@ -389,6 +401,16 @@ public sealed class EditActions
 
 		doc.History.PushNewItem (hist);
 		doc.Workspace.Invalidate ();
+	}
+
+	private void HandlePintaCoreActionsEditDeselectSelectionActivated (object sender, EventArgs e)
+	{
+
+		if (!selection_tools.Contains (tools.CurrentTool?.ToString ())) {
+			return;
+		}
+
+		HandlePintaCoreActionsEditDeselectActivated (sender,e);
 	}
 
 	private void HandlerPintaCoreActionsEditCopyActivated (object sender, EventArgs e)


### PR DESCRIPTION
Calls existing deselect function on escape key press, but only when a selection tool is active (EllipseSelect, RectangleSelect, LassoSelect).

Addresses  #1849.