### PR TITLE
Fix potential errors from the swap layers history item

### DIFF
--- a/Pinta.Core/HistoryItems/SwapLayersHistoryItem.cs
+++ b/Pinta.Core/HistoryItems/SwapLayersHistoryItem.cs
@@ -1,21 +1,21 @@
-// 
+//
 // SwapLayersHistoryItem.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -63,11 +63,13 @@ public sealed class SwapLayersHistoryItem : BaseHistoryItem
 		UserLayer layer1 = doc.Layers[l1];
 		UserLayer layer2 = doc.Layers[l2];
 
+		// Note we shift one layer at a time to ensure the document doesn't temporarily
+		// end up in an invalid state with no layers.
 		doc.Layers.DeleteLayer (l1);
-		doc.Layers.DeleteLayer (l2 - 1);
+		doc.Layers.Insert (layer1, l2 - 1);
 
+		doc.Layers.DeleteLayer (l2);
 		doc.Layers.Insert (layer2, l1);
-		doc.Layers.Insert (layer1, l2);
 
 		doc.Layers.SetCurrentUserLayer (selected);
 	}


### PR DESCRIPTION
The previous implementation removed both layers before inserting them at the new locations. If there were only two layers this left the document temporarily in an invalid state, which could produce errors in event handlers for the LayerRemoved events

Fixes: #2139