### PR TITLE
Fix bug with saving the axonometric grid angle

### DIFF
--- a/Pinta.Core/Managers/CanvasGridManager.cs
+++ b/Pinta.Core/Managers/CanvasGridManager.cs
@@ -94,7 +94,7 @@ public sealed class CanvasGridManager : ICanvasGridService
 
 		ShowAxonometricGrid = settings.GetSetting (SettingNames.SHOW_CANVAS_AXONOMETRIC_GRID, false);
 		AxonometricWidth = settings.GetSetting (SettingNames.CANVAS_AXONOMETRIC_WIDTH, 64);
-		AxonometricAngle = new (settings.GetSetting (SettingNames.CANVAS_AXONOMETRIC_ANGLE, 30));
+		AxonometricAngle = new (settings.GetSetting<double> (SettingNames.CANVAS_AXONOMETRIC_ANGLE, 30));
 	}
 
 	private void SetProperty<T> (ref T field, T value)

--- a/Pinta.Core/Managers/SettingsManager.cs
+++ b/Pinta.Core/Managers/SettingsManager.cs
@@ -1,21 +1,21 @@
-// 
+//
 // SettingsManager.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Jonathan Pobst
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -94,10 +94,15 @@ public sealed class SettingsManager : ISettingsService
 				continue;
 
 			// Kinda cheating because we know there are only a few types stored in here
-			switch (node.Attribute ("type")?.Value) {
+			string? value = node.Attribute ("type")?.Value;
+			switch (value) {
 				case "System.Int32":
 					if (int.TryParse (node.Value, out var i))
 						PutSetting (name, i);
+					break;
+				case "System.Double":
+					if (double.TryParse (node.Value, out double d))
+						PutSetting (name, d);
 					break;
 				case "System.Boolean":
 					if (bool.TryParse (node.Value, out var b))
@@ -106,6 +111,9 @@ public sealed class SettingsManager : ISettingsService
 				case "System.String":
 					if (node.Value is string s)
 						PutSetting (name, s);
+					break;
+				default:
+					System.Console.WriteLine ($"Unknown setting type {value} for {name}");
 					break;
 			}
 		}


### PR DESCRIPTION
- Add support for double when loading setting values, since the angle isn't limited to integers
- Log a warning if an unknown setting type is being loaded

Fixes: #2106