### PR TITLE
feat(ui): prevent effect dialogs from dimming canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Thanks to the following contributors who worked on this release:
 - The Clone Stamp tool now visualizes the position of the clone origin (#1923, #2190)
 
 ### Changed
+- Effect dialogs no longer dim the canvas during live previews (#1334, reported by @prokoudine)
 - Upgraded the minimum required .NET version to 10.0 (#2081)
 - Updated dependencies to require libadwaita 1.8+
 - Migrated to the Tmds.DBus.Protocol library for compile-time code generation (#2199)

--- a/Pinta.Effects/Dialogs/Effects.AlignmentDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.AlignmentDialog.cs
@@ -74,7 +74,9 @@ public sealed partial class AlignmentDialog
 		// --- Initialization (Gtk.Window)
 
 		Title = Translations.GetString ("Align Object");
-		Modal = true;
+		// Issue #1334 (reported by @prokoudine): do not dim the canvas while
+		// adjusting a live effect preview.
+		Modal = false;
 		Resizable = false;
 
 		// --- Initialization (Gtk.Dialog)

--- a/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.CurvesDialog.cs
@@ -136,7 +136,9 @@ public sealed partial class CurvesDialog
 
 		Title = Translations.GetString ("Curves");
 
-		Modal = true;
+		// Issue #1334 (reported by @prokoudine): do not dim the canvas while
+		// adjusting a live effect preview.
+		Modal = false;
 
 		Resizable = false;
 

--- a/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.LevelsDialog.cs
@@ -259,7 +259,9 @@ public sealed partial class LevelsDialog
 		// --- Initialization (Gtk.Window)
 
 		Title = Translations.GetString ("Levels Adjustment");
-		Modal = true;
+		// Issue #1334 (reported by @prokoudine): do not dim the canvas while
+		// adjusting a live effect preview.
+		Modal = false;
 		Resizable = false;
 
 		// --- Initialization (LevelsDialog)

--- a/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
+++ b/Pinta.Effects/Dialogs/Effects.PosterizeDialog.cs
@@ -52,7 +52,9 @@ public sealed partial class PosterizeDialog
 		DefaultHeight = 300;
 
 		Title = Translations.GetString ("Posterize");
-		Modal = true;
+		// Issue #1334 (reported by @prokoudine): do not dim the canvas while
+		// adjusting a live effect preview.
+		Modal = false;
 
 		Resizable = false;
 

--- a/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
+++ b/Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs
@@ -65,7 +65,10 @@ public sealed partial class SimpleEffectDialog
 	partial void Initialize ()
 	{
 		// --- Initialization (Gtk.Window)
-		Modal = true;
+		// Issue #1334 (reported by @prokoudine): modal effect dialogs dim the
+		// canvas on some desktop environments, changing the apparent colors
+		// while the live preview is being evaluated.
+		Modal = false;
 		WidthRequest = 400;
 		Resizable = false;
 


### PR DESCRIPTION
## Summary

Effect dialogs no longer dim the canvas during live previews.

Fixes #1334 (reported by @prokoudine).

## Description

When `SimpleEffectDialog` is set to `Modal = true`, some desktop environments dim the canvas behind the dialog. This changes the apparent colors of the image while evaluating live previews, making it difficult to accurately adjust effect parameters.

Setting `Modal = false` removes this dimming behavior while keeping the dialog functional.

## Changes

- **Pinta.Gui.Widgets/Dialogs/SimpleEffectDialog.cs** — Set `Modal = false` instead of `true`
- **CHANGELOG.md** — Added changelog entry under `Changed` section

## Related

Ported from [zbcoding/Impasto #1334](https://github.com/zbcoding/Impasto/pull/1334).