### PR TITLE
Added keyboard shortcuts for flipping layer

### DIFF
--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -95,14 +95,14 @@ public sealed class LayerActions
 			Translations.GetString ("Flip Horizontal"),
 			null,
 			Resources.Icons.LayerFlipHorizontal,
-			shortcuts: ["<Shift>H"]);
+			shortcuts: ["<Primary>F"]);
 
 		FlipVertical = new Command (
 			"fliplayervertical",
 			Translations.GetString ("Flip Vertical"),
 			null,
 			Resources.Icons.LayerFlipVertical,
-			shortcuts: ["<Shift>V"]);
+			shortcuts: ["<Shift>F"]);
 
 
 		RotateZoom = new Command (

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -94,13 +94,16 @@ public sealed class LayerActions
 			"fliplayerhorizontal",
 			Translations.GetString ("Flip Horizontal"),
 			null,
-			Resources.Icons.LayerFlipHorizontal);
+			Resources.Icons.LayerFlipHorizontal,
+			shortcuts: ["<Primary>F"]);
 
 		FlipVertical = new Command (
 			"fliplayervertical",
 			Translations.GetString ("Flip Vertical"),
 			null,
-			Resources.Icons.LayerFlipVertical);
+			Resources.Icons.LayerFlipVertical,
+			shortcuts: ["<Primary><Shift>F"]);
+
 
 		RotateZoom = new Command (
 			"RotateZoom",

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -104,7 +104,6 @@ public sealed class LayerActions
 			Resources.Icons.LayerFlipVertical,
 			shortcuts: ["<Shift>F"]);
 
-
 		RotateZoom = new Command (
 			"RotateZoom",
 			Translations.GetString ("Rotate / Zoom Layer..."),

--- a/Pinta.Core/Actions/LayerActions.cs
+++ b/Pinta.Core/Actions/LayerActions.cs
@@ -95,14 +95,14 @@ public sealed class LayerActions
 			Translations.GetString ("Flip Horizontal"),
 			null,
 			Resources.Icons.LayerFlipHorizontal,
-			shortcuts: ["<Primary>F"]);
+			shortcuts: ["<Shift>H"]);
 
 		FlipVertical = new Command (
 			"fliplayervertical",
 			Translations.GetString ("Flip Vertical"),
 			null,
 			Resources.Icons.LayerFlipVertical,
-			shortcuts: ["<Primary><Shift>F"]);
+			shortcuts: ["<Shift>V"]);
 
 
 		RotateZoom = new Command (


### PR DESCRIPTION
### Description of Changes
  Added keyboard shortcuts for flipping current layer vertically and horizontally.
  Primary + F = flip horizontally
  Shift + F = flip vertically

  resolves #2243 and #2235 
### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
