### PR TITLE
Unexportable file extension fix

### DIFF
--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -151,16 +151,6 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 				else // Somehow, no file filter was selected...
 					format = image_formats.GetDefaultSaveFormat ();
 			}
-			
-			if (!format.IsExportAvailable ()) {
-
-				await chrome.ShowMessageDialog (
-				chrome.MainWindow,
-				Translations.GetString ("Pinta does not support saving images in this file format."),
-				displayName);
-
-				return false;
-			}
 
 			if (!await ConfirmFlatten (document, format)) {
 				continue;
@@ -215,7 +205,8 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 			await chrome.ShowMessageDialog (
 				parent,
 				Translations.GetString ("Pinta does not support saving images in this file format."),
-				file.GetDisplayName ());
+				//Use this instead of file.GetDisplayName() in case file was not created
+				file.GetParent ()!.GetRelativePath (file)!);
 
 			return false;
 		}

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -145,11 +145,21 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 			// ie: if the user chooses to save a "jpeg" as "foo.png", we are going
 			// to assume they just didn't update the dropdown and really want png
 			FormatDescriptor? format = image_formats.GetFormatByFile (displayName);
-			if (format is null && format.IsExportAvailable ()) {
+			if (format is null) {
 				if (fcd.Filter is not null)
 					format = filetypes[fcd.Filter];
 				else // Somehow, no file filter was selected...
 					format = image_formats.GetDefaultSaveFormat ();
+			}
+			
+			if (!format.IsExportAvailable ()) {
+
+				await chrome.ShowMessageDialog (
+				chrome.MainWindow,
+				Translations.GetString ("Pinta does not support saving images in this file format."),
+				displayName);
+
+				return false;
 			}
 
 			if (!await ConfirmFlatten (document, format)) {

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -145,12 +145,13 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 			// ie: if the user chooses to save a "jpeg" as "foo.png", we are going
 			// to assume they just didn't update the dropdown and really want png
 			FormatDescriptor? format = image_formats.GetFormatByFile (displayName);
-			if (format is null) {
+			if (format is null && format.IsExportAvailable ()) {
 				if (fcd.Filter is not null)
 					format = filetypes[fcd.Filter];
 				else // Somehow, no file filter was selected...
 					format = image_formats.GetDefaultSaveFormat ();
 			}
+
 
 			if (!await ConfirmFlatten (document, format)) {
 				continue;

--- a/Pinta/Actions/File/SaveDocumentImplementationAction.cs
+++ b/Pinta/Actions/File/SaveDocumentImplementationAction.cs
@@ -152,7 +152,6 @@ internal sealed class SaveDocumentImplmentationAction : IActionHandler
 					format = image_formats.GetDefaultSaveFormat ();
 			}
 
-
 			if (!await ConfirmFlatten (document, format)) {
 				continue;
 			}


### PR DESCRIPTION
### Description of Changes
  Added the function to show an error when a file type cannot be exported in the SaveFileAs function.
  fixes #2176
### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
