### PR TITLE
Enable sandboxing for the macOS app

### DIFF
--- a/installer/macos/Info.plist
+++ b/installer/macos/Info.plist
@@ -120,7 +120,7 @@
 	<key>CFBundleIconFile</key>
 	<string>pinta.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.ximian.pinta</string>
+	<string>com.github.PintaProject.Pinta</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/installer/macos/build_installer.sh
+++ b/installer/macos/build_installer.sh
@@ -53,6 +53,7 @@ cp hicolor.index.theme ${MAC_APP_SHARE_DIR}/icons/hicolor/index.theme
 
 cp Info.plist ${MAC_APP_DIR}/Contents
 cp pinta.icns ${MAC_APP_DIR}/Contents/Resources
+cp container-migration.plist ${MAC_APP_DIR}/Contents/Resources
 
 # Install the GTK dependencies.
 echo "Bundling GTK..."

--- a/installer/macos/container-migration.plist
+++ b/installer/macos/container-migration.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Move</key>
+    <array>
+        <string>${ApplicationSupport}/pinta</string>
+    </array>
+</dict>
+</plist>

--- a/installer/macos/entitlements.plist
+++ b/installer/macos/entitlements.plist
@@ -11,5 +11,21 @@
       <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
       <true/>
+
+    <!-- Enable sandboxing and whitelist launchservicesd which is required by GTK. -->
+    <key>com.apple.security.app-sandbox</key>
+      <true/>
+    <!-- Whitelist launchservicesd which is required by GTK. -->
+    <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+  	<array>
+  		<string>com.apple.coreservices.launchservicesd</string>
+  	</array>
+    <!-- Allow read/write for user-selected files and standard folders. -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+      <true/>
+    <key>com.apple.security.assets.pictures.read-write</key>
+      <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+      <true/>
   </dict>
 </plist>


### PR DESCRIPTION
### Description of Changes

- Enable sandboxing
- Add a migration to copy old preferences into the new container location
- Fix the application ID for consistency with how Pinta is packaged on other platforms.

Bug: #1018

### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
