### PR TITLE
Use native gettext for Pinta's translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Thanks to the following contributors who worked on this release:
 - Updated dependencies to require libadwaita 1.8+
 - The macOS app is now sandboxed (#1018, #2249)
 - Migrated to the Tmds.DBus.Protocol library for compile-time code generation (#2199)
+- Removed dependency on the NGettext library. Instead, bindings to the native gettext library are now used (#2263)
 - Effect dialogs now hide options that are not currently relevant (#1960)
 - Fixed several minor UX issues in the color dialog (#1795)
 - The text tool now provides a separate adjustment for the font size and font variant, which doesn't require opening the font dialog (#1947, #1961, #2043, #1965)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="Mono.Addins" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.Setup" Version="1.4.2-alpha.4" />
     <PackageVersion Include="Mono.Addins.CecilReflector" Version="1.4.2-alpha.4" />
-    <PackageVersion Include="NGettext" Version="0.6.7" />
     <PackageVersion Include="ParagonClipper" Version="6.4.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.2" />

--- a/Pinta.Core/Classes/Translations.cs
+++ b/Pinta.Core/Classes/Translations.cs
@@ -24,37 +24,42 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Globalization;
-using NGettext;
 
 namespace Pinta.Core;
 
 public static class Translations
 {
-	private static ICatalog? catalog;
+	private const string PintaTextDomain = "pinta";
 
-	public static void Init (string domain, string locale_dir)
+	public static void Init (string localeDir)
 	{
 		CultureInfo cultureInfo = CultureInfo.CurrentUICulture;
-		catalog = new Catalog (domain, locale_dir, cultureInfo);
+		string lang = cultureInfo.Name.Replace ('-', '_'); // convert names like en-CA to en_CA
 
-		// The dotnet UI culture controls which translations are loaded for Pinta above.
-		// The GTK / libadwaita libraries use the native version of gettext for their translations
-		// (e.g. the About dialog), so here we set the LANG environment variable to be consistent.
+		// Follow the dotnet UI culture to choose which language is used by default.
+		// Pinta (along with GTK / libadwaita) use the native version of gettext for translations
+		// so here we set the LANG environment variable to make these consistent.
 		// Note we need to initialize the GLib module since this is called very early in startup,
 		// before GTK is initialized.
 		GLib.Module.Initialize ();
-		string lang = cultureInfo.Name.Replace ('-', '_'); // convert names like en-CA to en_CA
 		GLib.Functions.Setenv ("LANG", lang, overwrite: true);
+
+		// Initialize gettext for Pinta's translations.
+		IntlExtensions.BindTextDomain (PintaTextDomain, localeDir);
+		IntlExtensions.BindTextDomainCodeset (PintaTextDomain, "UTF-8");
+		IntlExtensions.TextDomain (PintaTextDomain);
 	}
 
 	public static string GetString (string text)
 	{
-		return catalog?.GetString (text) ?? text;
+		// Just use glib'c gettext wrapper for convenience instead of adding our own binding.
+		return GLib.Functions.Dgettext (PintaTextDomain, text);
 	}
 
 	public static string GetString (string text, params object[] args)
 	{
-		return catalog?.GetString (text, args) ?? text;
+		return string.Format (GetString (text), args);
 	}
 }

--- a/Pinta.Core/Extensions/IntlExtensions.cs
+++ b/Pinta.Core/Extensions/IntlExtensions.cs
@@ -32,4 +32,26 @@ public static partial class IntlExtensions
 			GLib.Internal.NonNullablePlatformStringUnownedHandle.Create (domain),
 			GLib.Internal.NonNullablePlatformStringUnownedHandle.Create (dir));
 	}
+
+	[LibraryImport (IntlLibraryName, EntryPoint = "bind_textdomain_codeset")]
+	private static partial IntPtr InternalBindTextDomainCodeset (
+		GLib.Internal.NonNullablePlatformStringHandle domain,
+		GLib.Internal.NonNullablePlatformStringHandle codeset);
+
+	public static void BindTextDomainCodeset (string domain, string codeset)
+	{
+		InternalBindTextDomainCodeset (
+			GLib.Internal.NonNullablePlatformStringUnownedHandle.Create (domain),
+			GLib.Internal.NonNullablePlatformStringUnownedHandle.Create (codeset));
+	}
+
+	[LibraryImport (IntlLibraryName, EntryPoint = "textdomain")]
+	private static partial IntPtr InternalTextDomain (
+		GLib.Internal.NonNullablePlatformStringHandle domain);
+
+	public static void TextDomain (string domain)
+	{
+		InternalTextDomain (
+			GLib.Internal.NonNullablePlatformStringUnownedHandle.Create (domain));
+	}
 }

--- a/Pinta.Core/Pinta.Core.csproj
+++ b/Pinta.Core/Pinta.Core.csproj
@@ -7,7 +7,6 @@
   <Import Project="../properties/ReferenceGirCorePangoCairo10.props" />
 
   <ItemGroup>
-    <PackageReference Include="NGettext" />
     <PackageReference Include="ParagonClipper" />
     <PackageReference Include="Mono.Addins" />
   </ItemGroup>

--- a/Pinta/Main.cs
+++ b/Pinta/Main.cs
@@ -42,10 +42,10 @@ internal sealed class MainClass
 			MacInterop.Environment.Init ();
 		}
 
-		string locale_dir = Path.Combine (SystemManager.GetDataRootDirectory (), "locale");
+		string localeDir = Path.Combine (SystemManager.GetDataRootDirectory (), "locale");
 
 		try {
-			Translations.Init ("pinta", locale_dir);
+			Translations.Init (localeDir);
 		} catch (Exception ex) {
 			Console.WriteLine (ex);
 		}
@@ -78,7 +78,7 @@ internal sealed class MainClass
 				parseResult.GetValue (threads_option),
 				parseResult.GetValue (files_arg) ?? [],
 				parseResult.GetValue (debug_option),
-				locale_dir);
+				localeDir);
 		});
 
 		return root_command.Parse (args).Invoke ();


### PR DESCRIPTION
- Related to PR #2261, using the native gettext library is the simplest way to also support translations for .ui files - no additional work is needed since GTK already calls dgettext() for any translatable strings when loading the xml file

- We already bundle libintl with Pinta (since it's required by GTK, libadwaita etc) so this doesn't require any additional packaging. I think the original motivation for using the managed Ngettext library was because we no longer had any bindings to gettext when porting to GTK3 - for GTK2 we used the Mono.Unix.Catalog wrapper for the native library

- Several of the native methods are already wrapped via GLib and have bindings available (e.g. GLib.Functions.Dgettext()) so this just requires a couple custom bindings for functions like textdomain(). We previously already had one binding for bindtextdomain() to configure libadwaita's translation directory for the macOS app bundle

### Description of Changes

### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
