### PR TITLE
Use AdwWrapBox instead of FlowBox in ToolBoxWidget

### DIFF
--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -40,7 +40,7 @@ public sealed partial class ToolBoxWidget
 		Gtk.ToggleButton button = Gtk.ToggleButton.New ();
 		button.IconName = tool.Icon;
 		button.Name = tool.Name;
-		button.CanFocus = false;
+		button.FocusOnClick = false;
 
 		button.SetCssClasses ([Resources.Styles.ToolBoxButton, AdwaitaStyles.Flat]);
 

--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -62,7 +62,15 @@ public sealed partial class ToolBoxWidget
 		toolButton.OnClicked += (_, _) => HandleToolButtonClicked (tool);
 		tool_buttons[tool] = toolButton;
 
-		Append (toolButton);
+		List<BaseTool> toolList = tools.ToList ();
+		int prevIndex = toolList.IndexOf (tool) - 1;
+		if (prevIndex >= 0) {
+			BaseTool prevTool = toolList[prevIndex];
+			Widget? prevSibling = tool_buttons[prevTool];
+			InsertChildAfter (toolButton, prevSibling);	
+		} else {
+			Prepend (toolButton);
+		}
 	}
 
 	private void HandleToolButtonClicked (BaseTool tool)

--- a/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
+++ b/Pinta.Gui.Widgets/Widgets/ToolBoxWidget.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
+using Gtk;
 using Pinta.Core;
 
 namespace Pinta.Gui.Widgets;
 
-[GObject.Subclass<Gtk.FlowBox>]
+[GObject.Subclass<Adw.WrapBox>]
 public sealed partial class ToolBoxWidget
 {
 	private ToolManager tools = null!; // NRT - set in factory method
@@ -16,9 +17,6 @@ public sealed partial class ToolBoxWidget
 	partial void Initialize ()
 	{
 		SetOrientation (Gtk.Orientation.Vertical);
-		MinChildrenPerLine = 8; // Pinta 3 has 22 default tools, meaning a max of 3 columns regardless of size, smaller values don't lead to better use of visual space.
-		MaxChildrenPerLine = 1024; // Allow for single column if there's sufficient space to do so.
-		SelectionMode = Gtk.SelectionMode.None; // Don't allow the buttons to be selected.
 	}
 
 	public static ToolBoxWidget New (ToolManager tools)
@@ -64,8 +62,7 @@ public sealed partial class ToolBoxWidget
 		toolButton.OnClicked += (_, _) => HandleToolButtonClicked (tool);
 		tool_buttons[tool] = toolButton;
 
-		int index = tools.ToList ().IndexOf (tool);
-		Insert (toolButton, index);
+		Append (toolButton);
 	}
 
 	private void HandleToolButtonClicked (BaseTool tool)


### PR DESCRIPTION
### Description of Changes
Use [Adw.WrapBox](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/class.WrapBox.html) instead of Gtk.FlowBox as the basis of ToolBoxWidget, this
- completely removes the awkward FlowBoxChild highlights surrounding the tool buttons. (see #1369, #2095)
- makes the tool box more compact (can be adjusted if not desired)
- allows for functional keyboard navigation in the tool box

Tool insertion order logic has been simplified though which may cause regressions, but the order seems the same as before with the default set of tools.

### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
