### PR TITLE
Fix detection of translatable strings in .ui files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,9 +64,11 @@ list:
 	fi
 
 #target: updatepotfiles - update the POTFILES.in file
+# Note that intltool needs the [type:] prefix to correctly handle .ui files
 updatepotfiles:
 	echo xdg/com.github.PintaProject.Pinta.desktop.in > po/POTFILES.in
 	echo xdg/com.github.PintaProject.Pinta.metainfo.xml.in >> po/POTFILES.in
+	find . -name \*.ui | sort | sed 's/^/[type: gettext\/glade]/' >> po/POTFILES.in
 	find \
 		Pinta \
 		Pinta.Core \


### PR DESCRIPTION
### Description of Changes

intltool needs an extra '[type: gettext/glade]' prefix in POTFILES.in, otherwise it just skips them

### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
