### PR TITLE
Improve the add-in info view

### DIFF
--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -11,6 +11,10 @@ internal sealed partial class AddinInfoView
 {
 	[Gtk.Connect (nameof (title_label))]
 	private Gtk.Label title_label;
+	[Gtk.Connect (nameof (category_label))]
+	private Gtk.Label category_label;
+	[Gtk.Connect (nameof (author_label))]
+	private Gtk.Label author_label;
 	[Gtk.Connect (nameof (version_label))]
 	private Gtk.Label version_label;
 	[Gtk.Connect (nameof (size_label))]
@@ -93,6 +97,8 @@ internal sealed partial class AddinInfoView
 
 		title_label.SetLabel (item.Name);
 		version_label.SetLabel (Translations.GetString ("Version: {0}", item.Version));
+		category_label.SetLabel (Translations.GetString ("Category: {0}", item.Category));
+		author_label.SetLabel (Translations.GetString ("Author: {0}", item.Author));
 		description_label.SetLabel (item.Description);
 
 		string? download_size = item.DownloadSize;

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -5,27 +5,42 @@ using Pinta.Core;
 
 namespace Pinta.Gui.Addins;
 
-[GObject.Subclass<Adw.Bin>]
+[GObject.Subclass<Adw.Bin> (qualifiedName: nameof (AddinInfoView))]
+[Gtk.Template<Gtk.AssemblyResource> ("AddinInfoView.ui")]
 internal sealed partial class AddinInfoView
 {
+	[Gtk.Connect (nameof (title_label))]
 	private Gtk.Label title_label;
+	[Gtk.Connect (nameof (version_label))]
 	private Gtk.Label version_label;
+	[Gtk.Connect (nameof (size_label))]
 	private Gtk.Label size_label;
+	[Gtk.Connect (nameof (repo_label))]
 	private Gtk.Label repo_label;
+	[Gtk.Connect (nameof (description_label))]
 	private Gtk.Label description_label;
 
+	[Gtk.Connect (nameof (info_button))]
 	private Gtk.Button info_button;
+	[Gtk.Connect (nameof (install_button))]
 	private Gtk.Button install_button;
+	[Gtk.Connect (nameof (update_button))]
 	private Gtk.Button update_button;
+	[Gtk.Connect (nameof (uninstall_button))]
 	private Gtk.Button uninstall_button;
 
+	[Gtk.Connect (nameof (enable_switch))]
 	private Gtk.Switch enable_switch;
 
+	[Gtk.Connect (nameof (content_box))]
 	private Gtk.Box content_box;
 
+	[Gtk.Connect (nameof (empty_page))]
 	private Adw.Bin empty_page;
 
+	[Gtk.Connect (nameof (view_stack))]
 	private Adw.ViewStack view_stack;
+
 	private AddinListViewItem? current_item;
 
 	/// <summary>
@@ -36,114 +51,17 @@ internal sealed partial class AddinInfoView
 	private SystemManager system = null!; // NRT - set by factory method.
 	private IChromeService chrome = null!;
 
-	[MemberNotNull (nameof (title_label))]
-	[MemberNotNull (nameof (version_label))]
-	[MemberNotNull (nameof (size_label))]
-	[MemberNotNull (nameof (repo_label))]
-	[MemberNotNull (nameof (description_label))]
-	[MemberNotNull (nameof (info_button))]
-	[MemberNotNull (nameof (install_button))]
-	[MemberNotNull (nameof (update_button))]
-	[MemberNotNull (nameof (uninstall_button))]
-	[MemberNotNull (nameof (enable_switch))]
-	[MemberNotNull (nameof (content_box))]
-	[MemberNotNull (nameof (empty_page))]
-	[MemberNotNull (nameof (view_stack))]
 	partial void Initialize ()
 	{
-		// --- Control creation
+		info_button.OnClicked += (_, _) => HandleInfoButtonClicked ();
+		install_button.OnClicked += (_, _) => HandleInstallButtonClicked ();
+		update_button.OnClicked += (_, _) => HandleUpdateButtonClicked ();
+		uninstall_button.OnClicked += (_, _) => HandleUninstallButtonClicked ();
 
-		Gtk.Label titleLabel = Gtk.Label.New (null);
-		titleLabel.Halign = Gtk.Align.Start;
-		titleLabel.AddCssClass (AdwaitaStyles.Title4);
-
-		Gtk.Label versionLabel = Gtk.Label.New (null);
-		versionLabel.Halign = Gtk.Align.Start;
-		versionLabel.AddCssClass (AdwaitaStyles.Heading);
-
-		Gtk.Label sizeLabel = Gtk.Label.New (null);
-		sizeLabel.Halign = Gtk.Align.Start;
-		sizeLabel.AddCssClass (AdwaitaStyles.Heading);
-
-		Gtk.Label repoLabel = Gtk.Label.New (null);
-		repoLabel.Halign = Gtk.Align.Start;
-		repoLabel.AddCssClass (AdwaitaStyles.Heading);
-
-		Gtk.Label descriptionLabel = CreateDescriptionLabel ();
-
-		Adw.Bin emptyPage = Adw.Bin.New ();
-
-		Gtk.Button infoButton = CreateInfoButton ();
-		Gtk.Button installButton = CreateInstallButton ();
-		Gtk.Button updateButton = CreateUpdateButton ();
-		Gtk.Button uninstallButton = CreateUninstallButton ();
-
-		Gtk.Switch enableSwitch = CreateEnableSwitch ();
-
-		BoxStyle spacedHorizontal = new (
-			orientation: Gtk.Orientation.Horizontal,
-			spacing: 6,
-			cssClass: AdwaitaStyles.Toolbar);
-		Gtk.Box hbox = GtkExtensions.Box (
-			spacedHorizontal,
-			[
-				enableSwitch,
-				installButton,
-				updateButton,
-				infoButton,
-				uninstallButton
-			]
-		);
-
-		BoxStyle spacedVertical = new (
-			orientation: Gtk.Orientation.Vertical,
-			spacing: 10);
-		Gtk.Box contentBox = GtkExtensions.Box (
-			spacedVertical,
-			[
-				titleLabel,
-				versionLabel,
-				sizeLabel,
-				repoLabel,
-				descriptionLabel,
-				hbox
-			]
-		);
-		contentBox.SetAllMargins (10);
-
-		Adw.ViewStack viewStack = Adw.ViewStack.New ();
-		viewStack.Add (emptyPage);
-		viewStack.Add (contentBox);
-		viewStack.SetVisibleChild (emptyPage);
-
-		// --- Gtk.Widget initialization
-
-		WidthRequest = 300;
-
-		// --- Adwaita.Bin initialization
-
-		Child = viewStack;
-
-		// --- References to keep
-
-		title_label = titleLabel;
-		version_label = versionLabel;
-		size_label = sizeLabel;
-		repo_label = repoLabel;
-		description_label = descriptionLabel;
-
-		info_button = infoButton;
-		install_button = installButton;
-		update_button = updateButton;
-		uninstall_button = uninstallButton;
-
-		enable_switch = enableSwitch;
-
-		content_box = contentBox;
-
-		empty_page = emptyPage;
-
-		view_stack = viewStack;
+		enable_switch.OnStateSet += (_, _) => {
+			HandleEnableSwitched ();
+			return false;
+		};
 	}
 
 	internal void Configure (SystemManager system, IChromeService chrome)
@@ -153,67 +71,6 @@ internal sealed partial class AddinInfoView
 	}
 
 	public static new AddinInfoView New () => NewWithProperties ([]);
-
-	private Gtk.Switch CreateEnableSwitch ()
-	{
-		Gtk.Switch result = Gtk.Switch.New ();
-		result.Visible = false;
-		result.OnStateSet += (_, _) => {
-			HandleEnableSwitched ();
-			return false;
-		};
-		return result;
-	}
-
-	private static Gtk.Label CreateDescriptionLabel ()
-	{
-		Gtk.Label result = Gtk.Label.New (null);
-		result.Halign = Gtk.Align.Start;
-		result.Hexpand = true;
-		result.Valign = Gtk.Align.Start;
-		result.Vexpand = true;
-		result.Xalign = 0;
-		result.Wrap = true;
-		result.AddCssClass (AdwaitaStyles.Body);
-		return result;
-	}
-
-	private Gtk.Button CreateInfoButton ()
-	{
-		Gtk.Button result = Gtk.Button.NewWithLabel (Translations.GetString ("More Information..."));
-		result.OnClicked += (_, _) => HandleInfoButtonClicked ();
-		result.Visible = false;
-		return result;
-	}
-
-	private Gtk.Button CreateInstallButton ()
-	{
-		Gtk.Button result = Gtk.Button.NewWithLabel (Translations.GetString ("Install..."));
-		result.AddCssClass (AdwaitaStyles.SuggestedAction);
-		result.OnClicked += (_, _) => HandleInstallButtonClicked ();
-		result.Visible = false;
-		return result;
-	}
-
-	private Gtk.Button CreateUpdateButton ()
-	{
-		Gtk.Button result = Gtk.Button.NewWithLabel (Translations.GetString ("Update..."));
-		result.AddCssClass (AdwaitaStyles.SuggestedAction);
-		result.OnClicked += (_, _) => HandleUpdateButtonClicked ();
-		result.Visible = false;
-		return result;
-	}
-
-	private Gtk.Button CreateUninstallButton ()
-	{
-		Gtk.Button result = Gtk.Button.NewWithLabel (Translations.GetString ("Uninstall..."));
-		result.AddCssClass (AdwaitaStyles.DestructiveAction);
-		result.OnClicked += (_, _) => HandleUninstallButtonClicked ();
-		result.Visible = false;
-		result.Hexpand = true;
-		result.Halign = Gtk.Align.End;
-		return result;
-	}
 
 	public void Update (AddinListViewItem? item)
 	{

--- a/Pinta.Gui.Addins/AddinInfoView.cs
+++ b/Pinta.Gui.Addins/AddinInfoView.cs
@@ -11,16 +11,16 @@ internal sealed partial class AddinInfoView
 {
 	[Gtk.Connect (nameof (title_label))]
 	private Gtk.Label title_label;
-	[Gtk.Connect (nameof (category_label))]
-	private Gtk.Label category_label;
-	[Gtk.Connect (nameof (author_label))]
-	private Gtk.Label author_label;
-	[Gtk.Connect (nameof (version_label))]
-	private Gtk.Label version_label;
-	[Gtk.Connect (nameof (size_label))]
-	private Gtk.Label size_label;
-	[Gtk.Connect (nameof (repo_label))]
-	private Gtk.Label repo_label;
+	[Gtk.Connect (nameof (category_row))]
+	private Adw.ActionRow category_row;
+	[Gtk.Connect (nameof (version_row))]
+	private Adw.ActionRow version_row;
+	[Gtk.Connect (nameof (author_row))]
+	private Adw.ActionRow author_row;
+	[Gtk.Connect (nameof (size_row))]
+	private Adw.ActionRow size_row;
+	[Gtk.Connect (nameof (repo_row))]
+	private Adw.ActionRow repo_row;
 	[Gtk.Connect (nameof (description_label))]
 	private Gtk.Label description_label;
 
@@ -96,22 +96,16 @@ internal sealed partial class AddinInfoView
 		view_stack.SetVisibleChild (content_box);
 
 		title_label.SetLabel (item.Name);
-		version_label.SetLabel (Translations.GetString ("Version: {0}", item.Version));
-		category_label.SetLabel (Translations.GetString ("Category: {0}", item.Category));
-		author_label.SetLabel (Translations.GetString ("Author: {0}", item.Author));
+		category_row.Subtitle = item.Category;
+		version_row.Subtitle = item.Version;
+		author_row.Subtitle = item.Author;
 		description_label.SetLabel (item.Description);
 
-		string? download_size = item.DownloadSize;
-		size_label.Visible = download_size != null;
+		size_row.Visible = item.DownloadSize != null;
+		size_row.Subtitle = item.DownloadSize ?? string.Empty;
 
-		if (download_size is not null)
-			size_label.SetLabel (Translations.GetString ("Download size: {0}", download_size));
-
-		string? repo_name = item.RepositoryName;
-		repo_label.Visible = repo_name != null;
-
-		if (repo_name is not null)
-			repo_label.SetLabel (Translations.GetString ("Available in repository: {0}", repo_name));
+		repo_row.Visible = item.RepositoryName != null;
+		repo_row.Subtitle = item.RepositoryName ?? string.Empty;
 
 		info_button.Visible = !string.IsNullOrEmpty (item.Url);
 		install_button.Visible = !item.Installed;

--- a/Pinta.Gui.Addins/AddinInfoView.ui
+++ b/Pinta.Gui.Addins/AddinInfoView.ui
@@ -39,6 +39,24 @@
             </child>
 
             <child>
+              <object class="GtkLabel" id="category_label">
+                <property name="halign">start</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="author_label">
+                <property name="halign">start</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </child>
+
+            <child>
               <object class="GtkLabel" id="size_label">
                 <property name="halign">start</property>
                 <style>
@@ -121,7 +139,7 @@
             </child>
           </object>
         </child>
-        
+
       </object>
     </child>
   </template>

--- a/Pinta.Gui.Addins/AddinInfoView.ui
+++ b/Pinta.Gui.Addins/AddinInfoView.ui
@@ -24,52 +24,7 @@
               <object class="GtkLabel" id="title_label">
                 <property name="halign">start</property>
                 <style>
-                  <class name="title-4"/>
-                </style>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkLabel" id="version_label">
-                <property name="halign">start</property>
-                <style>
-                  <class name="heading"/>
-                </style>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkLabel" id="category_label">
-                <property name="halign">start</property>
-                <style>
-                  <class name="heading"/>
-                </style>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkLabel" id="author_label">
-                <property name="halign">start</property>
-                <style>
-                  <class name="heading"/>
-                </style>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkLabel" id="size_label">
-                <property name="halign">start</property>
-                <style>
-                  <class name="heading"/>
-                </style>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkLabel" id="repo_label">
-                <property name="halign">start</property>
-                <style>
-                  <class name="heading"/>
+                  <class name="title-2"/>
                 </style>
               </object>
             </child>
@@ -78,13 +33,68 @@
               <object class="GtkLabel" id="description_label">
                 <property name="halign">start</property>
                 <property name="hexpand">true</property>
-                <property name="valign">start</property>
-                <property name="vexpand">true</property>
                 <property name="xalign">0</property>
                 <property name="wrap">true</property>
                 <style>
                   <class name="body"/>
                 </style>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkListBox">
+                <property name="selection-mode">none</property>
+                <property name="valign">start</property>
+                <property name="vexpand">true</property>
+                <style>
+                  <class name="boxed-list"/>
+                </style>
+
+                <child>
+                  <object class="AdwActionRow" id="category_row">
+                    <property name="title" translatable="yes">Category</property>
+                    <style>
+                      <class name="property"/>
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="AdwActionRow" id="version_row">
+                    <property name="title" translatable="yes">Version</property>
+                    <style>
+                      <class name="property"/>
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="AdwActionRow" id="author_row">
+                    <property name="title" translatable="yes">Author</property>
+                    <style>
+                      <class name="property"/>
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="AdwActionRow" id="size_row">
+                    <property name="title" translatable="yes">Download size</property>
+                    <style>
+                      <class name="property"/>
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="AdwActionRow" id="repo_row">
+                    <property name="title" translatable="yes">Repository</property>
+                    <style>
+                      <class name="property"/>
+                    </style>
+                  </object>
+                </child>
+
               </object>
             </child>
 

--- a/Pinta.Gui.Addins/AddinInfoView.ui
+++ b/Pinta.Gui.Addins/AddinInfoView.ui
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="AddinInfoView" parent="AdwBin">
+    <property name="width-request">300</property>
+    <child>
+      <object class="AdwViewStack" id="view_stack">
+
+        <!-- Empty page -->
+        <child>
+          <object class="AdwBin" id="empty_page"/>
+        </child>
+
+        <!-- Main content -->
+        <child>
+          <object class="GtkBox" id="content_box">
+            <property name="orientation">vertical</property>
+            <property name="spacing">10</property>
+            <property name="margin-top">10</property>
+            <property name="margin-bottom">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+
+            <child>
+              <object class="GtkLabel" id="title_label">
+                <property name="halign">start</property>
+                <style>
+                  <class name="title-4"/>
+                </style>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="version_label">
+                <property name="halign">start</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="size_label">
+                <property name="halign">start</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="repo_label">
+                <property name="halign">start</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="description_label">
+                <property name="halign">start</property>
+                <property name="hexpand">true</property>
+                <property name="valign">start</property>
+                <property name="vexpand">true</property>
+                <property name="xalign">0</property>
+                <property name="wrap">true</property>
+                <style>
+                  <class name="body"/>
+                </style>
+              </object>
+            </child>
+
+            <!-- Bottom button row -->
+            <child>
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">6</property>
+                <style>
+                  <class name="toolbar"/>
+                </style>
+
+                <child>
+                  <object class="GtkSwitch" id="enable_switch" />
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="install_button">
+                    <property name="label" translatable="yes">Install...</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="update_button">
+                    <property name="label" translatable="yes">Update...</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="info_button">
+                    <property name="label" translatable="yes">More Information...</property>
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="uninstall_button">
+                    <property name="label" translatable="yes">Uninstall...</property>
+                    <property name="hexpand">true</property>
+                    <property name="halign">end</property>
+                    <style>
+                      <class name="destructive-action"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        
+      </object>
+    </child>
+  </template>
+</interface>

--- a/Pinta.Gui.Addins/AddinListViewItem.cs
+++ b/Pinta.Gui.Addins/AddinListViewItem.cs
@@ -58,6 +58,8 @@ internal sealed partial class AddinListViewItem
 	public string Description => info.Description;
 	public string Version => info.Version;
 	public string Url => info.Url;
+	public string Author => info.Author;
+	public string Category => info.Category;
 
 	public bool Installed => installed_addin is not null;
 	public Addin? Addin => installed_addin;

--- a/Pinta.Gui.Addins/Pinta.Gui.Addins.csproj
+++ b/Pinta.Gui.Addins/Pinta.Gui.Addins.csproj
@@ -13,4 +13,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Pinta.Core\Pinta.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="*.ui">
+      <LogicalName>%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes

- Refactor to use a .ui file instead of building the layout in code
- Display the effect category and the author's name
- Switch to a boxed list for displaying the metadata, instead of many separate lines of text

Before:
<img width="720" height="434" alt="before" src="https://github.com/user-attachments/assets/3c9347b2-ae1d-4531-bf2c-2af54bf58b59" />


After:
<img width="857" height="502" alt="after" src="https://github.com/user-attachments/assets/96f77eee-9c65-4ae6-9fa1-d2d43119abed" />


### Checklist

- [x] This pull request follows the project's [contribution guidelines](https://github.com/PintaProject/Pinta/blob/master/patch-guidelines.md)
